### PR TITLE
feat(maxar): compose URL automatically

### DIFF
--- a/main_dialog.ui
+++ b/main_dialog.ui
@@ -128,11 +128,11 @@
      <attribute name="horizontalHeaderCascadingSectionResizes">
       <bool>false</bool>
      </attribute>
-     <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>116</number>
-     </attribute>
      <attribute name="horizontalHeaderMinimumSectionSize">
       <number>67</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>116</number>
      </attribute>
      <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
       <bool>true</bool>
@@ -384,7 +384,7 @@
            <height>0</height>
           </size>
          </property>
-         <property name="showCrs" stdset="0">
+         <property name="showCrs">
           <bool>true</bool>
          </property>
         </widget>
@@ -439,10 +439,10 @@
            <height>16777215</height>
           </size>
          </property>
-         <property name="allowEmptyLayer" stdset="0">
+         <property name="allowEmptyLayer">
           <bool>false</bool>
          </property>
-         <property name="showCrs" stdset="0">
+         <property name="showCrs">
           <bool>true</bool>
          </property>
         </widget>
@@ -1011,19 +1011,6 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="3">
-          <widget class="QPushButton" name="getMaxarURL">
-           <property name="font">
-            <font>
-             <pointsize>12</pointsize>
-             <kerning>true</kerning>
-            </font>
-           </property>
-           <property name="text">
-            <string>Get URL</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="labelMaxarAOI">
            <property name="minimumSize">
@@ -1058,10 +1045,10 @@
          </item>
          <item row="1" column="1" colspan="2">
           <widget class="QgsMapLayerComboBox" name="maxarAOICombo">
-           <property name="allowEmptyLayer" stdset="0">
+           <property name="allowEmptyLayer">
             <bool>false</bool>
            </property>
-           <property name="showCrs" stdset="0">
+           <property name="showCrs">
             <bool>true</bool>
            </property>
           </widget>
@@ -1188,7 +1175,7 @@
           <height>516</height>
          </rect>
         </property>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <property name="geometry">
           <rect>
            <x>20</x>

--- a/mapflow.py
+++ b/mapflow.py
@@ -134,7 +134,11 @@ class Mapflow:
         self.dlg.customProviderType.currentTextChanged.connect(lambda text: self.settings.setValue('customProviderType', text))
         self.dlg.preview.clicked.connect(self.preview)
         # Maxar
-        self.dlg.getMaxarURL.clicked.connect(self.get_maxar_url)
+        self.dlg.customProviderLogin.textChanged.connect(self.get_maxar_url)
+        self.dlg.customProviderPassword.textChanged.connect(self.get_maxar_url)
+        self.dlg.maxarConnectID.textChanged.connect(self.get_maxar_url)
+        self.dlg.checkMaxar.stateChanged.connect(self.get_maxar_url)
+        self.dlg.maxarMetadataTable.itemSelectionChanged.connect(self.get_maxar_url)
         self.dlg.getImageMetadata.clicked.connect(self.get_maxar_metadata)
 
     def monitor_polygon_layer_feature_selection(self, layers: List[QgsMapLayer]) -> None:
@@ -303,8 +307,11 @@ class Mapflow:
         The user only needs to put the Connect ID in the corresponding field and to select a row in the metadata table,
         if they would like to preview or process a single image. 
 
-        Is called by clicking the getMaxarURL ('Get URL') button.
+        Is called by editing any of customProviderLogin, customProviderPassword, maxarConnectID if the Maxar frame is 
+        enabled, or by enabling the frame itself. 
         """
+        if not self.dlg.checkMaxar.isChecked():
+            return
         connect_id = self.dlg.maxarConnectID.text()
         # Check if the user selected a specific image
         selected_row = self.dlg.maxarMetadataTable.currentRow()


### PR DESCRIPTION
The 'Get URL' button is removed. Now, the URL is compose anew on every text change in any of:
  - custom provider login
  - custom provider password
  - Connect ID
And also on maxar frame enabling.