### PR TITLE
send default mapbox pattern to get token replaced on the server

### DIFF
--- a/mapflow/entity/provider/default.py
+++ b/mapflow/entity/provider/default.py
@@ -55,15 +55,11 @@ class MaxarSecureWatchProxyProvider(MaxarProxyProvider):
 class MapboxProvider(XYZProvider):
     def __init__(self):
         super().__init__(name="Mapbox",
-                         url=None, #  'https://api.tiles.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token={token}',
+                         url="https://api.tiles.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token={token}",
                          crs=CRS.web_mercator)
     @property
     def preview_url(self, image_id=None):
         return None
-
-    def to_processing_params(self, image_id=None):
-        # This is a default provider which is supplied on server
-        return {}, {}
 
     @property
     def is_default(self):


### PR DESCRIPTION
It now uses Provider from WM database, not from WD. 