### PR TITLE
Draft for Image CRUD with conflicts

### DIFF
--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -113,6 +113,25 @@ class DataCatalogApi(QObject):
                             email_body=email_body).show()
 
     # Images CRUD
+    """ def upload_image(self,
+                     mosaic_id: UUID,
+                     image_path: Union[Path, str],
+                     callback: Callable = lambda *args: None,
+                     callback_kwargs: Optional[dict] = None,
+                     error_handler: Optional[Callable] = None,
+                     error_handler_kwargs: Optional[dict] = None):
+        body = self.create_upload_image_body(image_path = image_path)
+        url = f"{self.server}/rasters/mosaic/{mosaic_id}/image"
+        response = self.http.post(url=url,
+                       body=body,
+                       callback=callback,
+                       callback_kwargs=callback_kwargs,
+                       use_default_error_handler=error_handler is None,
+                       error_handler=error_handler,
+                       error_handler_kwargs=error_handler_kwargs or {}
+                       )
+        body.setParent(response) """
+    
     def upload_image(self,
                      mosaic_id: UUID,
                      image_path: Union[Path, str],
@@ -122,7 +141,7 @@ class DataCatalogApi(QObject):
                      error_handler_kwargs: Optional[dict] = None):
         body = self.create_upload_image_body(image_path = image_path)
         url = f"{self.server}/rasters/mosaic/{mosaic_id}/image"
-        self.http.post(url=url,
+        response = self.http.post(url=url,
                        body=body,
                        callback=callback,
                        callback_kwargs=callback_kwargs,
@@ -130,6 +149,21 @@ class DataCatalogApi(QObject):
                        error_handler=error_handler,
                        error_handler_kwargs=error_handler_kwargs or {}
                        )
+        body.setParent(response)
+
+    def upload_image_error_handler(self, response: QNetworkReply, image_path: str):
+        ErrorMessageWidget(parent=QApplication.activeWindow(),
+                           text=f'Could not upload "{image_path}" to mosaic',
+                           title=f'Error',
+                           email_body='').show()
+
+    def image_preview_l_error_handler(self, response: QNetworkReply):
+        error_summary, email_body = get_error_report_body(response=response,
+                                                          plugin_version=self.plugin_version)
+        ErrorMessageWidget(parent=QApplication.activeWindow(),
+                           text=error_summary,
+                           title="Error. Could not display preview",
+                           email_body=email_body).show()
 
     def get_mosaic_images(self, mosaic_id: UUID, callback: Callable):
         self.http.get(url=f"{self.server}/rasters/mosaic/{mosaic_id}/image",

--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -113,25 +113,6 @@ class DataCatalogApi(QObject):
                             email_body=email_body).show()
 
     # Images CRUD
-    """ def upload_image(self,
-                     mosaic_id: UUID,
-                     image_path: Union[Path, str],
-                     callback: Callable = lambda *args: None,
-                     callback_kwargs: Optional[dict] = None,
-                     error_handler: Optional[Callable] = None,
-                     error_handler_kwargs: Optional[dict] = None):
-        body = self.create_upload_image_body(image_path = image_path)
-        url = f"{self.server}/rasters/mosaic/{mosaic_id}/image"
-        response = self.http.post(url=url,
-                       body=body,
-                       callback=callback,
-                       callback_kwargs=callback_kwargs,
-                       use_default_error_handler=error_handler is None,
-                       error_handler=error_handler,
-                       error_handler_kwargs=error_handler_kwargs or {}
-                       )
-        body.setParent(response) """
-    
     def upload_image(self,
                      mosaic_id: UUID,
                      image_path: Union[Path, str],
@@ -151,9 +132,9 @@ class DataCatalogApi(QObject):
                        )
         body.setParent(response)
 
-    def upload_image_error_handler(self, response: QNetworkReply, image_path: str):
+    def upload_image_error_handler(self, image_paths: list):
         ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=f'Could not upload "{image_path}" to mosaic',
+                           text=f'Could not upload {str(image_paths)[1:-1]} to mosaic',
                            title=f'Error',
                            email_body='').show()
 
@@ -177,11 +158,25 @@ class DataCatalogApi(QObject):
                       use_default_error_handler=True
                       )
 
-    def delete_image(self, image_id: UUID, callback: Callable = lambda *args: None):
+    def delete_image(self,
+                     image_id: UUID,
+                     callback: Callable = lambda *args: None,
+                     callback_kwargs: Optional[dict] = None,
+                     error_handler: Optional[Callable] = None,
+                     error_handler_kwargs: Optional[dict] = None):
         self.http.delete(url=f"{self.server}/rasters/image/{image_id}",
-                      callback=callback,
-                      use_default_error_handler=True
-                      )
+                       callback=callback,
+                       callback_kwargs=callback_kwargs,
+                       use_default_error_handler=error_handler is None,
+                       error_handler=error_handler,
+                       error_handler_kwargs=error_handler_kwargs or {}
+                       )
+        
+    def delete_image_error_handler(self, image_paths: list):
+        ErrorMessageWidget(parent=QApplication.activeWindow(),
+                           text=f'Could not delete {str(image_paths)[1:-1]} from mosaic',
+                           title=f'Error',
+                           email_body='').show()
 
     def get_image_preview(self,
                           image: ImageReturnSchema,

--- a/mapflow/functional/controller/data_catalog_controller.py
+++ b/mapflow/functional/controller/data_catalog_controller.py
@@ -15,3 +15,5 @@ class DataCatalogController(QObject):
         self.dlg.imageInfoButton.clicked.connect(self.service.image_info)
         self.dlg.tabWidget.tabBarClicked.connect(self.service.get_user_limit)
         self.dlg.imageTable.selectionModel().selectionChanged.connect(self.service.check_image_selection)
+        self.dlg.addImageButton.clicked.connect(self.service.upload_images_to_mosaic)
+        self.dlg.deleteImageButton.clicked.connect(self.service.delete_image)

--- a/mapflow/functional/view/data_catalog_view.py
+++ b/mapflow/functional/view/data_catalog_view.py
@@ -80,11 +80,15 @@ class DataCatalogView(QObject):
 
     def display_images(self, images: list[ImageReturnSchema]):
         self.dlg.imageTable.setRowCount(len(images))
-        self.dlg.imageTable.setColumnCount(1)
+        self.dlg.imageTable.setColumnCount(2)
+        self.dlg.imageTable.setColumnHidden(0, True)
         for row, image in enumerate(images):
             table_item = QTableWidgetItem()
             table_item.setData(Qt.DisplayRole, image.id)
             self.dlg.imageTable.setItem(row, 0, table_item)
+            name_item = QTableWidgetItem()
+            name_item.setData(Qt.DisplayRole, image.filename)
+            self.dlg.imageTable.setItem(row, 1, name_item)
 
     def show_preview_s(self, preview_image):
         self.dlg.imagePreview.setPixmap(QPixmap.fromImage(preview_image))


### PR DESCRIPTION
Since mosaic CRUD is not merged, I decided to start parallel work on image CRUD (so it will probably be with conflicts again, but i'll fix it).
There are 2 major issues:

1) Your initial script for 'update_images' is quite hard for me to understand. 
Callback and error handler are the same as function, so:
- I am not able to update image table with callback
- We call this function, probably, to much (?), so It gives an error, saying that 'mosaic_id' argument got multiple values.

  So I tried to implement it differently.

2) When first adding image(s) to mosaic and then clicking on mosaic preview, we get right results. 
But when I add or delete image in the next iteration, preview stays the same even after plugin or QGIS reloading. 
Is this the issue with plugin or something else. 
I suppose tileUrl is not being updated (?), because the list of images is right and their previews work fine.