### PR TITLE
Fix result loading temp_dir error

### DIFF
--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -532,7 +532,7 @@ class ResultsLoader(QObject):
         # Layer creation options for QGIS 3.10.3+
         write_options = QgsVectorFileWriter.SaveVectorOptions()
         write_options.layerOptions = ['fid=id']
-        with open(os.path.join(self.temp_dir, os.urandom(32).hex()), mode='wb+') as f:
+        with open(os.path.join(str(self.temp_dir), os.urandom(32).hex()), mode='wb+') as f:
             f.write(response.readAll().data())
             f.seek(0)
             layer = QgsVectorLayer(f.name, '', 'ogr')

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -532,7 +532,7 @@ class ResultsLoader(QObject):
         # Layer creation options for QGIS 3.10.3+
         write_options = QgsVectorFileWriter.SaveVectorOptions()
         write_options.layerOptions = ['fid=id']
-        with open(os.path.join(str(self.temp_dir), os.urandom(32).hex()), mode='wb+') as f:
+        with open(os.path.join(self.temp_dir, os.urandom(32).hex()), mode='wb+') as f:
             f.write(response.readAll().data())
             f.seek(0)
             layer = QgsVectorLayer(f.name, '', 'ogr')

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -192,7 +192,7 @@ class Mapflow(QObject):
                                                        project=self.project,
                                                        settings=self.settings,
                                                        plugin_name=self.plugin_name,
-                                                       temp_dir=self.temp_dir
+                                                       temp_dir=self.temp_dir_name
                                                        )
 
         self.data_catalog_service = DataCatalogService(self.http, self.server, self.dlg, self.iface, self.result_loader, self.plugin_version)
@@ -339,17 +339,6 @@ class Mapflow(QObject):
         iface.addCustomActionForLayerType(self.remove_layer_action, None, QgsMapLayerType.VectorLayer, False)
         self.dlg.useAllVectorLayers.stateChanged.connect(self.toggle_all_layers)
         self.dlg.polygonCombo.setExceptedLayerList(self.filter_aoi_layers())
-
-        # Service init
-        self.result_loader = layer_utils.ResultsLoader(iface=self.iface,
-                                                       maindialog=self.dlg,
-                                                       http=self.http,
-                                                       server=self.server,
-                                                       project=self.project,
-                                                       settings=self.settings,
-                                                       plugin_name=self.plugin_name,
-                                                       temp_dir=self.temp_dir
-                                                       )
 
     def setup_layers_context_menu(self, layers: List[QgsMapLayer]):
         for layer in filter(layer_utils.is_polygon_layer, layers):


### PR DESCRIPTION
- self.result_loader was initialized two times for some reason
- the error would only appear if saving a temporary gpkg file is chosen in tne settings tab (that is why I could not reproduce it before - the default is loading temporary vector layer)
Hope this fixes an it