### PR TITLE
Fix 'local_image_index' referenced before assignment in 'create_proce…

### DIFF
--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1927,6 +1927,8 @@ class Mapflow(QObject):
             except:
                 local_image_index = None
                 provider_name = None
+        else:
+            local_image_index = None
         wd_name = self.dlg.modelCombo.currentText()
         wd = self.workflow_defs.get(wd_name)
         try:


### PR DESCRIPTION
Error when clicking on mosaicTable cell:
File "mapflow.py", line 1954, in create_processing_request
local_image_index=local_image_index,
UnboundLocalError: local variable 'local_image_index' referenced before assignment

Is it right to fix it by assigning None to local_image_index if selected_image (for imagery search) is None?