### PR TITLE
Create layout before containing

### DIFF
--- a/mapflow/functional/view/data_catalog_view.py
+++ b/mapflow/functional/view/data_catalog_view.py
@@ -345,6 +345,8 @@ class DataCatalogView(QObject):
                                           cellWidget)
         
     def contain_mosaic_cell_buttons(self):
+        self.mosaic_cell_layout = QHBoxLayout()
+        self.create_mosaic_cell_buttons_layout()
         self.mosaicContainerWidget.setLayout(self.mosaic_cell_layout)
 
     def contain_image_cell_buttons(self):


### PR DESCRIPTION
After refactoring when updating mosaic, edit button dissapears. 
Creating layout each time before containing it somehow fixes the problem...