### PR TITLE
Fix tables selection bug (when clicking on a cellWidget button)

### DIFF
--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -9,7 +9,7 @@ from osgeo import gdal
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtGui import QImage
 from PyQt5.QtNetwork import QNetworkReply
-from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog
+from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog, QAbstractItemView
 from qgis.core import QgsCoordinateReferenceSystem, QgsProject, QgsRasterLayer, QgsRectangle
 
 from ...dialogs.main_dialog import MainDialog
@@ -85,10 +85,14 @@ class DataCatalogService(QObject):
 
     def get_mosaic_callback(self, response: QNetworkReply):
         mosaic = MosaicReturnSchema.from_dict(json.loads(response.readAll().data()))
+        # Temporary forbit selection to prevent weird bug
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection)
         self.mosaics.update({mosaic.id: mosaic})
         self.mosaicsUpdated.emit()
-        self.view.display_mosaics(list(self.mosaics.values())) 
-        # Go to the right cell in case sorting changed items' order
+        self.view.display_mosaics(list(self.mosaics.values()))
+        # Allow selection back
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.SingleSelection) 
+        # Select the right cell
         if self.view.mosaic_table_visible:
             self.view.select_mosaic_cell(mosaic.id)
 

--- a/mapflow/functional/view/data_catalog_view.py
+++ b/mapflow/functional/view/data_catalog_view.py
@@ -273,9 +273,10 @@ class DataCatalogView(QObject):
     def show_images_table(self):
         row = self.dlg.selected_mosaic_cell.row()
         column = self.dlg.selected_mosaic_cell.column()
+        # Temporary forbit selection to prevent weird bug
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection)
         # Show images
         self.dlg.stackedLayout.setCurrentIndex(1)
-        self.dlg.mosaicTable.setCurrentCell(row, column)
         # En(dis)able buttons and change labels
         self.dlg.seeMosaicsButton.setEnabled(True)
         self.dlg.seeImagesButton.setEnabled(False)
@@ -283,6 +284,9 @@ class DataCatalogView(QObject):
         self.dlg.deleteCatalogButton.setText(self.tr("Delete image"))
         self.dlg.addCatalogButton.setText(self.tr("Add image"))
         self.dlg.addCatalogButton.setMenu(self.upload_image_menu)
+        # Allow selection back
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.dlg.mosaicTable.setCurrentCell(row, column)
         # Because we open images table always with empty selection
         self.clear_image_info()
 
@@ -309,8 +313,8 @@ class DataCatalogView(QObject):
         self.mosaic_cell_layout.setSpacing(0)
         self.mosaic_cell_layout.addWidget(self.dlg.addImageButton)
         self.mosaic_cell_layout.addWidget(self.dlg.mosaicSpacers[0])
-        #self.mosaic_cell_layout.addWidget(self.dlg.showImagesButton)
-        #self.mosaic_cell_layout.addWidget(self.dlg.mosaicSpacers[1])
+        self.mosaic_cell_layout.addWidget(self.dlg.showImagesButton)
+        self.mosaic_cell_layout.addWidget(self.dlg.mosaicSpacers[1])
         self.mosaic_cell_layout.addWidget(self.dlg.previewMosaicButton)
         self.mosaic_cell_layout.addWidget(self.dlg.mosaicSpacers[2])
         self.mosaic_cell_layout.addWidget(self.dlg.editMosaicButton)


### PR DESCRIPTION
Forbid selection at the start of 'get_mosaic_callback' and 'show_images_table' to avoid automatic selection change, and allow it in the end of these functions