### PR TITLE
Reselect mosaic when uploading or deleteng images

### DIFF
--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -187,6 +187,7 @@ class DataCatalogService(QObject):
         if len(image_paths) == 0:
             if failed:
                 self.api.upload_image_error_handler(response=response, mosaic_name=mosaic_name, image_paths=failed)
+            self.dlg.mosaicTable.clearSelection()
             self.get_mosaic(mosaic_id)
             self.mosaicsUpdated.emit()
         else:
@@ -266,6 +267,7 @@ class DataCatalogService(QObject):
             if failed:
                 self.api.delete_image_error_handler(image_paths=failed)
             mosaic_id = self.selected_mosaic().id
+            self.dlg.mosaicTable.clearSelection()
             self.get_mosaic(mosaic_id)
             self.dlg.imageTable.clearSelection()
         else:

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -107,6 +107,7 @@ class DataCatalogService(QObject):
         dialog.deleteLater()
 
     def update_mosaic_callback(self, response: QNetworkReply, mosaic: MosaicReturnSchema):
+        self.dlg.mosaicTable.clearSelection()
         self.get_mosaic(mosaic.id)
 
     def delete_mosaic(self, mosaic):


### PR DESCRIPTION
For some reason, deselection of mosaic when uploading images stoped working automatically as it was (I checked before merging!!!)
Added it manualy in callbacks.
It still only sends get_mosaic and get_mosaic_images requests, but reloads coast and tables, as it should.