### PR TITLE
Don't clear providers combo on updating

### DIFF
--- a/mapflow/dialogs/static/ui/main_dialog.ui
+++ b/mapflow/dialogs/static/ui/main_dialog.ui
@@ -2235,7 +2235,7 @@
                <item>
                 <widget class="QRadioButton" name="viewAsTiles">
                  <property name="text">
-                  <string>view results as a vector layer</string>
+                  <string>view results as a vector tiles</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
@@ -2248,7 +2248,7 @@
                <item>
                 <widget class="QRadioButton" name="viewAsLocal">
                  <property name="text">
-                  <string>save local gpkg file to view results</string>
+                  <string>save results as a local vector file</string>
                  </property>
                  <attribute name="buttonGroup">
                   <string notr="true">buttonGroup</string>

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -630,11 +630,11 @@ class Mapflow(QObject):
             my_imagery_tab = self.dlg.tabWidget.findChild(QWidget, "catalogTab") 
             self.dlg.tabWidget.setCurrentWidget(my_imagery_tab)
             self.calculate_aoi_area_catalog()
+        else:
+            self.calculate_aoi_area_polygon_layer(polygon_layer)
         if provider.requires_image_id:
             imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
             self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
-        else:
-            self.calculate_aoi_area_polygon_layer(polygon_layer)
     
     def on_zoom_change(self):
         """ Set chosen zoom and update cost (if it depends on zoom for provider).
@@ -737,7 +737,7 @@ class Mapflow(QObject):
                 return
             else:
                 self.user_providers.append(new_provider)
-                provider_index = len(self.providers) - 1
+                provider_index = len(self.providers)
         else:
             # we replace old provider with a new one
             # if self.dlg_provider.property('mode') == 'edit':  #
@@ -776,7 +776,6 @@ class Mapflow(QObject):
         otherwise loads providers list from settings
         """
         self.user_providers.to_settings(self.settings)
-        self.dlg.providerCombo.clear()
         self.dlg.providerCombo.addItems(provider.name for provider in self.providers)
         self.set_available_imagery_sources(self.dlg.modelCombo.currentText())
 


### PR DESCRIPTION
Fix error that appers when adding a new provider. 
Plugin removes all providers from combo and adds them back (why, if it seems to work without it?), so each time it passes ImagerySearchProvider, it results in an error