### PR TITLE
Imagery search: multiple mosaics aoi

### DIFF
--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -47,6 +47,7 @@ class Config:
     # MAXAR
     METADATA_TABLE_ATTRIBUTES = {
         QCoreApplication.translate('Config', 'Product Type'): 'productType',
+        QCoreApplication.translate('Config', 'Provider Name'): 'providerName',
         QCoreApplication.translate('Config', 'Sensor'): 'source',
         QCoreApplication.translate('Config', 'Band Order'): 'colorBandOrder',
         QCoreApplication.translate('Config', 'Cloud %'): 'cloudCover',

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -51,6 +51,7 @@ class Config:
         QCoreApplication.translate('Config', 'Sensor'): 'source',
         QCoreApplication.translate('Config', 'Band Order'): 'colorBandOrder',
         QCoreApplication.translate('Config', 'Cloud %'): 'cloudCover',
+        QCoreApplication.translate('Config', 'Spatial Resolution, m'): 'pixelResolution',
         QCoreApplication.translate('Config', 'Off Nadir') + f' \N{DEGREE SIGN}': 'offNadirAngle',
         QCoreApplication.translate('Config', 'Date & Time') + ' ({t})'.format(t=TIMEZONE): 'acquisitionDate',
         QCoreApplication.translate('Config', 'Image ID'): 'id',

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -86,6 +86,8 @@ class Config:
 
     MAX_AOIS_PER_PROCESSING = int(QgsSettings().value("variables/mapflow_max_aois", "10"))
 
+    SEARCH_RESULTS_PAGE_LIMIT = 1000 # objects per page
+
     # OAuth2
     OAUTH2_URL = "https://auth-duty.mapflow.ai/auth/realms/mapflow-duty/protocol/openid-connect"
     AUTH_CONFIG_NAME = f"mapflow_{MAPFLOW_ENV}"

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -524,6 +524,17 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
             self.options_menu.removeAction(self.processing_update_action)
         else:
             self.options_menu.addAction(self.processing_update_action)
+
+    def enable_zoom_selector(self, enable: bool = True, zoom: str = None):
+        self.zoomCombo.setEnabled(enable)
+        if enable is False:
+            if zoom:
+                self.zoomCombo.setCurrentText(zoom)
+                self.zoomCombo.setToolTip(self.tr("Zoom is derived from found imagery resolution"))
+            else:
+                self.zoomCombo.setCurrentIndex(0)
+        else:
+            self.zoomCombo.setToolTip(self.tr("Zoom"))
     
     @property
     def project_controls(self):

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -5,7 +5,7 @@ from typing import Iterable, Optional, List
 from PyQt5 import uic
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QPalette
-from PyQt5.QtWidgets import QWidget, QPushButton, QCheckBox, QTableWidgetItem, QStackedLayout, QLabel, QToolButton, QAction, QMenu
+from PyQt5.QtWidgets import QWidget, QPushButton, QCheckBox, QTableWidgetItem, QStackedLayout, QLabel, QToolButton, QAction, QMenu, QAbstractItemView
 from qgis.core import QgsMapLayerProxyModel, QgsSettings
 
 from . import icons
@@ -127,7 +127,9 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.processing_update_action = QAction(self.tr("Rename"))
         self.setup_options_menu()
 
+        # Imagery Search
         self.imageId.setReadOnly(True)
+        self.metadataTable.setSelectionMode(QAbstractItemView.MultiSelection)
 
     # ===== Settings management ===== #
     def save_view_results_mode(self):

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -130,6 +130,7 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         # Imagery Search
         self.imageId.setReadOnly(True)
         self.metadataTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.enable_search_pages(False)
 
     # ===== Settings management ===== #
     def save_view_results_mode(self):
@@ -536,6 +537,19 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
                 self.zoomCombo.setToolTip(self.tr("Zoom"))
         else:
             self.zoomCombo.setToolTip(self.tr("Zoom"))
+
+    def enable_search_pages(self, enable: bool = False, page_number: int = 1, total_pages: int = 1):
+        self.searchLeftButton.setVisible(enable)
+        self.searchRightButton.setVisible(enable)
+        self.searchPageLabel.setVisible(enable)
+        if enable is False:
+            return
+        self.searchLeftButton.setIcon(icons.arrow_left_icon)
+        self.searchRightButton.setIcon(icons.arrow_right_icon)
+        self.searchLeftButton.setToolTip(self.tr("Previous page"))
+        self.searchRightButton.setToolTip(self.tr("Next page"))
+        self.searchPageLabel.setToolTip(self.tr("Page"))
+        self.searchPageLabel.setText(f"{page_number}/{total_pages}")
     
     @property
     def project_controls(self):

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -129,7 +129,7 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
 
         # Imagery Search
         self.imageId.setReadOnly(True)
-        self.metadataTable.setSelectionMode(QAbstractItemView.MultiSelection)
+        self.metadataTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
     # ===== Settings management ===== #
     def save_view_results_mode(self):

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -533,6 +533,7 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
                 self.zoomCombo.setToolTip(self.tr("Zoom is derived from found imagery resolution"))
             else:
                 self.zoomCombo.setCurrentIndex(0)
+                self.zoomCombo.setToolTip(self.tr("Zoom"))
         else:
             self.zoomCombo.setToolTip(self.tr("Zoom"))
     

--- a/mapflow/dialogs/static/ui/main_dialog.ui
+++ b/mapflow/dialogs/static/ui/main_dialog.ui
@@ -1120,50 +1120,6 @@
               <bool>false</bool>
              </property>
              <layout class="QGridLayout" name="gridLayout">
-              <item row="2" column="0">
-               <layout class="QVBoxLayout" name="layoutMetadataTable">
-                <property name="spacing">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QTableWidget" name="metadataTable">
-                  <property name="focusPolicy">
-                   <enum>Qt::NoFocus</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Double-click on a row to preview its image</string>
-                  </property>
-                  <property name="autoScroll">
-                   <bool>false</bool>
-                  </property>
-                  <property name="editTriggers">
-                   <set>QAbstractItemView::NoEditTriggers</set>
-                  </property>
-                  <property name="tabKeyNavigation">
-                   <bool>false</bool>
-                  </property>
-                  <property name="alternatingRowColors">
-                   <bool>true</bool>
-                  </property>
-                  <property name="selectionMode">
-                   <enum>QAbstractItemView::SingleSelection</enum>
-                  </property>
-                  <property name="selectionBehavior">
-                   <enum>QAbstractItemView::SelectRows</enum>
-                  </property>
-                  <property name="sortingEnabled">
-                   <bool>true</bool>
-                  </property>
-                  <property name="cornerButtonEnabled">
-                   <bool>false</bool>
-                  </property>
-                  <attribute name="horizontalHeaderStretchLastSection">
-                   <bool>true</bool>
-                  </attribute>
-                 </widget>
-                </item>
-               </layout>
-              </item>
               <item row="0" column="0">
                <layout class="QHBoxLayout" name="layoutMetadataDatetime" stretch="0,0,0,0,0,0">
                 <item>
@@ -1297,24 +1253,49 @@
                 </item>
                </layout>
               </item>
-              <item row="3" column="0" alignment="Qt::AlignRight">
-               <widget class="QPushButton" name="clearSearch">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+              <item row="2" column="0">
+               <layout class="QVBoxLayout" name="layoutMetadataTable">
+                <property name="spacing">
+                 <number>0</number>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>0</width>
-                  <height>0</height>
-                 </size>
-                </property>
-                <property name="text">
-                 <string>Clear </string>
-                </property>
-               </widget>
+                <item>
+                 <widget class="QTableWidget" name="metadataTable">
+                  <property name="focusPolicy">
+                   <enum>Qt::NoFocus</enum>
+                  </property>
+                  <property name="toolTip">
+                   <string>Double-click on a row to preview its image</string>
+                  </property>
+                  <property name="autoScroll">
+                   <bool>false</bool>
+                  </property>
+                  <property name="editTriggers">
+                   <set>QAbstractItemView::NoEditTriggers</set>
+                  </property>
+                  <property name="tabKeyNavigation">
+                   <bool>false</bool>
+                  </property>
+                  <property name="alternatingRowColors">
+                   <bool>true</bool>
+                  </property>
+                  <property name="selectionMode">
+                   <enum>QAbstractItemView::SingleSelection</enum>
+                  </property>
+                  <property name="selectionBehavior">
+                   <enum>QAbstractItemView::SelectRows</enum>
+                  </property>
+                  <property name="sortingEnabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="cornerButtonEnabled">
+                   <bool>false</bool>
+                  </property>
+                  <attribute name="horizontalHeaderStretchLastSection">
+                   <bool>true</bool>
+                  </attribute>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item row="1" column="0">
                <widget class="QgsCollapsibleGroupBox" name="metadataFilters">
@@ -1426,6 +1407,72 @@
                  </item>
                 </layout>
                </widget>
+              </item>
+              <item row="3" column="0">
+               <layout class="QHBoxLayout" name="horizontalLayout_16">
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QPushButton" name="searchLeftButton">
+                  <property name="toolTip">
+                   <string/>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="searchPageLabel">
+                  <property name="text">
+                   <string>1/1</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="searchRightButton">
+                  <property name="toolTip">
+                   <string/>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_6">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="clearSearch">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Clear </string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>

--- a/mapflow/entity/provider/basemap_provider.py
+++ b/mapflow/entity/provider/basemap_provider.py
@@ -16,7 +16,8 @@ class BasemapProvider(UsersProvider, ABC):
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
-                             zoom: Optional[str] = None):
+                             zoom: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
         params = {
             'url': self.url,
             'projection': self.crs.value.lower(),
@@ -122,7 +123,8 @@ class MaxarProvider(UsersProvider):
     def to_processing_params(self,
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
-                             url: Optional[str] = None):
+                             url: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
         params = PostSourceSchema(url=maxar_tile_url(self.url, image_id),
                                   source_type=self.source_type,
                                   projection=self.crs.value,

--- a/mapflow/entity/provider/default.py
+++ b/mapflow/entity/provider/default.py
@@ -25,8 +25,9 @@ class SentinelProvider(ProviderInterface):
     def to_processing_params(self,
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
-                             url: Optional[str] = None):
-        if not image_id:
+                             url: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
+        if not image_id and requires_id is True:
             raise ImageIdRequired("Sentinel provider must have image ID to launch the processing")
         return PostSourceSchema(url=image_id,
                                 source_type=SourceType.sentinel_l2a), {}
@@ -67,8 +68,9 @@ class ImagerySearchProvider(ProviderInterface):
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
-                             zoom: Optional[str] = None):
-        if not image_id:
+                             zoom: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
+        if not image_id and requires_id is True:
             raise ImageIdRequired("Search provider must have image ID to launch the processing")
         return PostProviderSchema(data_provider=provider_name,
                                   url=image_id,
@@ -109,7 +111,8 @@ class MyImageryProvider(ProviderInterface):
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
-                             zoom: Optional[str] = None):
+                             zoom: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
         return PostSourceSchema(url=url,
                                 source_type='local',
                                 zoom=zoom), {}
@@ -177,5 +180,6 @@ class DefaultProvider(ProviderInterface):
                              zoom: Optional[str] = None,
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
-                             url: Optional[str] = None):
+                             url: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
         return PostProviderSchema(data_provider=self.api_name, zoom=zoom), {}

--- a/mapflow/entity/provider/provider.py
+++ b/mapflow/entity/provider/provider.py
@@ -77,7 +77,8 @@ class ProviderInterface:
                              image_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
-                             zoom: Optional[str] = None):
+                             zoom: Optional[str] = None,
+                             requires_id: Optional[bool] = False):
         """ You cannot create a processing with generic provider without implementation"""
         raise NotImplementedError
 

--- a/mapflow/functional/geometry.py
+++ b/mapflow/functional/geometry.py
@@ -1,13 +1,14 @@
+from typing import List
+
 from qgis import processing as qgis_processing  # to avoid collisions
 from qgis.core import QgsVectorLayer, QgsFeature, QgsGeometry, QgsFeatureIterator
 
-
 def clip_aoi_to_image_extent(aoi_geometry: QgsGeometry,
-                             extent: QgsFeature) -> QgsFeatureIterator:
+                             extents: List[QgsFeature]) -> QgsFeatureIterator:
     """Clip user AOI to image extent if the image doesn't cover the entire AOI.
     args:
         aoi_geometry: AOI geometry - selected by user area of interest (input)
-        extent: image extent (overlay)
+        extents: list of QgsFeature objects from image extent(s) (overlay)
     """
     aoi_layer = QgsVectorLayer('Polygon?crs=epsg:4326', '', 'memory')
     aoi = QgsFeature()
@@ -15,9 +16,9 @@ def clip_aoi_to_image_extent(aoi_geometry: QgsGeometry,
     aoi_layer.dataProvider().addFeatures([aoi])
     aoi_layer.updateExtents()
     # Create a temp layer for the image extent
-    image_extent_layer = QgsVectorLayer('Polygon?crs=epsg:4326', '', 'memory')
-    image_extent_layer.dataProvider().addFeatures([extent])
-    aoi_layer.updateExtents()
+    image_extent_layer = QgsVectorLayer('MultiPolygon?crs=epsg:4326', '', 'memory')
+    image_extent_layer.dataProvider().addFeatures(extents)
+    image_extent_layer.updateExtents()
     # Find the intersection
     intersection = qgis_processing.run(
         'qgis:intersection',

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -156,7 +156,7 @@ class Mapflow(QObject):
         self.processings = []
         # Imagery search pagination
         self.search_page_offset = 0
-        self.search_page_limit = 1000
+        self.search_page_limit = self.config.SEARCH_RESULTS_PAGE_LIMIT
 
         # Clear previous temp dir, as it is not cleared automatically in exit from QGis
         previous_temp_dir = self.settings.value("temp_dir", None)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -291,8 +291,6 @@ class Mapflow(QObject):
 
         # Maxar
         self.dlg.imageId.textChanged.connect(self.sync_image_id_with_table_and_layer)
-        self.dlg.imageId.textChanged.connect(self.update_processing_cost)
-        self.dlg.metadataTable.itemSelectionChanged.connect(self.update_processing_cost)
         self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
             self.sync_table_selection_with_image_id_and_layer)
         self.meta_layer_table_connection = None

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1013,6 +1013,7 @@ class Mapflow(QObject):
                                                     minOffNadirAngle=min_off_nadir_angle,
                                                     maxOffNadirAngle=max_off_nadir_angle,
                                                     minAoiIntersectionPercent=min_intersection,
+                                                    limit=self.search_page_limit,
                                                     offset=offset)
         self.http.post(url=provider.meta_url,
                        body=request_payload.as_json().encode(),
@@ -3348,15 +3349,15 @@ class Mapflow(QObject):
                             for local_image_index in local_image_indices]
                 except KeyError:
                     zooms = []
-                if set(product_types) == set(["Mosaic"]): # allow zooms only for mosaics
-                    unique_zooms = set(filter(lambda x: x is not None, zooms))
-                    if len(unique_zooms) > 1: # forbid multiselection for results with different zooms
+                # Allow zooms only for mosaics
+                if set(product_types) == set(["Mosaic"]):
+                    # No specified zoom if NULL is returned or it's None
+                    unique_zooms = set(filter(lambda x: (x is not None and x != QVariant()), zooms))
+                    # Forbid multiselection for results with different zooms
+                    if len(unique_zooms) > 1:
                         zoom_error = self.tr("Selected search results must have the same spatial resolution")
                     elif len(unique_zooms) == 1: # get unique zoom as a parameter
-                        if list(unique_zooms)[0] == QVariant():
-                            zoom = None # no specified zoom if NULL is returned
-                        else:
-                            zoom = str(int(list(unique_zooms)[0]))
+                        zoom = str(int(list(unique_zooms)[0]))
             self.dlg.enable_zoom_selector(False, zoom)
         else:
             if self.zoom_selector:

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional, Union, Callable, Tuple
 
 from PyQt5.QtCore import (
-    QDate, QObject, QCoreApplication, QTimer, QTranslator, Qt, QFile, QIODevice, QTextStream, QByteArray, QTemporaryDir
+    QDate, QObject, QCoreApplication, QTimer, QTranslator, Qt, QFile, QIODevice, QTextStream, QByteArray, QTemporaryDir, QVariant
 )
 from PyQt5.QtGui import QColor
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest, QHttpMultiPart, QHttpPart
@@ -3355,7 +3355,10 @@ class Mapflow(QObject):
                     if len(unique_zooms) > 1: # forbid multiselection for results with different zooms
                         zoom_error = self.tr("Selected search results must have the same spatial resolution")
                     elif len(unique_zooms) == 1: # get unique zoom as a parameter
-                        zoom = str(int(list(unique_zooms)[0]))
+                        if list(unique_zooms)[0] == QVariant():
+                            zoom = None # no specified zoom if NULL is returned
+                        else:
+                            zoom = str(int(list(unique_zooms)[0]))
             self.dlg.enable_zoom_selector(False, zoom)
         else:
             if self.zoom_selector:

--- a/mapflow/schema/catalog.py
+++ b/mapflow/schema/catalog.py
@@ -40,6 +40,7 @@ class ImageSchema(Serializable, SkipDataClass):
     previewType: Optional[PreviewType] = None
     previewUrl: Optional[str] = None
     providerName: Optional[str] = None
+    zoom: Optional[str] = None
 
     def __post_init__(self):
         if isinstance(self.acquisitionDate, str):

--- a/mapflow/schema/catalog.py
+++ b/mapflow/schema/catalog.py
@@ -24,6 +24,8 @@ class ImageCatalogRequestSchema(Serializable):
     minOffNadirAngle: Optional[float] = None
     maxOffNadirAngle: Optional[float] = None
     minAoiIntersectionPercent: Optional[float] = None
+    limit: Optional[int] = 1000
+    offset: Optional[int] = 0
 
 @dataclass
 class ImageSchema(Serializable, SkipDataClass):
@@ -61,6 +63,9 @@ class ImageSchema(Serializable, SkipDataClass):
 @dataclass
 class ImageCatalogResponseSchema(Serializable):
     images: List[ImageSchema]
+    total: int
+    limit: int = 1000
+    offset: int = 0
 
     def __post_init__(self):
         self.images = [ImageSchema.from_dict(image) for image in self.images]

--- a/mapflow/schema/catalog.py
+++ b/mapflow/schema/catalog.py
@@ -5,7 +5,7 @@ from typing import Optional, Mapping, Any, Union, List
 
 from .base import Serializable, SkipDataClass
 
-from config import Config
+from ..config import Config
 
 class PreviewType(str, Enum):
     png = "png"

--- a/mapflow/schema/catalog.py
+++ b/mapflow/schema/catalog.py
@@ -5,6 +5,7 @@ from typing import Optional, Mapping, Any, Union, List
 
 from .base import Serializable, SkipDataClass
 
+from config import Config
 
 class PreviewType(str, Enum):
     png = "png"
@@ -24,7 +25,7 @@ class ImageCatalogRequestSchema(Serializable):
     minOffNadirAngle: Optional[float] = None
     maxOffNadirAngle: Optional[float] = None
     minAoiIntersectionPercent: Optional[float] = None
-    limit: Optional[int] = 1000
+    limit: Optional[int] = Config.SEARCH_RESULTS_PAGE_LIMIT
     offset: Optional[int] = 0
 
 @dataclass
@@ -64,7 +65,7 @@ class ImageSchema(Serializable, SkipDataClass):
 class ImageCatalogResponseSchema(Serializable):
     images: List[ImageSchema]
     total: int
-    limit: int = 1000
+    limit: int = Config.SEARCH_RESULTS_PAGE_LIMIT
     offset: int = 0
 
     def __post_init__(self):


### PR DESCRIPTION
- Allow multiselect in imagery search table and connect multiselection to layer
- Allow processing with multiple search results if they have the same provider name and product type (which is "Mosaic")
In that case: 
-- in processing paramets don't show url, only provide"_name. 
-- intersect AOI with all selected footprints
Otherwise (with multiselect) show: "You can launch multiple image processing only if it has the same mosaic provider"