### PR TITLE
Fix 3.2.0

### DIFF
--- a/mapflow/dialogs/dialogs.py
+++ b/mapflow/dialogs/dialogs.py
@@ -91,7 +91,8 @@ class ConfirmProcessingStart(*uic.loadUiType(ui_path / 'processing_start_confirm
     def setup(self, name, price, provider, zoom, area, model, blocks) -> None:
         self.nameLabel.setText(name)
         self.priceLabel.setText(price)
-        self.dataSourceLabel.setText(provider)
+        elided_provider = self.dataSourceLabel.fontMetrics().elidedText(provider, Qt.ElideRight, self.modelLabel.width() + 200)
+        self.dataSourceLabel.setText(elided_provider)
         if not zoom:
             zoom = "No zoom selected"
         self.zoomLabel.setText(zoom)
@@ -99,5 +100,7 @@ class ConfirmProcessingStart(*uic.loadUiType(ui_path / 'processing_start_confirm
         self.modelLabel.setText(model)
         if len(blocks) == 0:
             blocks = ["No options selected"]
+        else:
+            blocks = [block.text() for block in blocks if block.isChecked()]
         self.modelOptionsLabel.setText(', \n'.join(blocks))
         self.exec() 

--- a/mapflow/functional/service/project.py
+++ b/mapflow/functional/service/project.py
@@ -49,6 +49,7 @@ class ProjectService(QObject):
         self.api.delete_project(project_id, self.delete_project_callback)
     
     def delete_project_callback(self, response: QNetworkReply):
+        self.projects_data.total += -1
         self.get_projects()
     
     def update_project(self, project_id, project: UpdateProjectSchema):
@@ -71,6 +72,11 @@ class ProjectService(QObject):
 
         :param open_saved_page: A boolean that determines if we should get projects page from the settings or not.
         """
+        try: # if something changed and offset is now >= projects count
+            if self.projects_page_offset >= self.projects_data.total:
+                self.projects_page_offset = 0 # show first page
+        except AttributeError:
+            pass # if projects is an empty dict
         # Open the page containing current project
         if open_saved_page is True:
             # Get each page parameter from dict in settings (if no dict - create one with default values)
@@ -150,11 +156,6 @@ class ProjectService(QObject):
 
         :param open_saved_page: A boolean that determines if we should get projects page from the settings or not.
         """
-        try: # if something changed and offset is now bigger than projects count
-            if self.projects_page_offset > self.projects_data.total:
-                self.projects_page_offset = 0 # show first page
-        except AttributeError:
-            pass # if projects is an empty dict
         self.get_projects(open_saved_page)
         self.view.switch_to_projects()
 

--- a/mapflow/functional/service/project.py
+++ b/mapflow/functional/service/project.py
@@ -158,7 +158,9 @@ class ProjectService(QObject):
         self.get_projects(open_saved_page)
         self.view.switch_to_projects()
 
-    def switch_to_processings(self, save_page: Optional[bool] = False):
+    def switch_to_processings(self, 
+                              save_page: Optional[bool] = False,
+                              project_id: Optional[int]  = None):
         """Switch from projects to processings table in stacked widget.
 
         Allows to remember current projects page before switching (to later reopen it even after reload).
@@ -176,6 +178,7 @@ class ProjectService(QObject):
                              'filter': projects_filter}
             self.settings.setValue('projectsPage', projects_page)
         self.view.switch_to_processings()
+        self.project_id = project_id
 
     def get_filtered_projects(self):
         """Get projects, resetting filtered offset value.

--- a/mapflow/functional/service/project.py
+++ b/mapflow/functional/service/project.py
@@ -131,7 +131,11 @@ class ProjectService(QObject):
             projects_page_number = int(self.projects_page_offset/self.projects_page_limit) + 1
             self.view.show_projects_pages(True, projects_page_number, projects_total_pages)
         else:
-            self.view.show_projects_pages(False)
+            # When no projects found, but no filter specified (should be at lest 'Default')
+            if not self.projects_data.total and len(self.dlg.filterProjects.text()) <= 1:
+                self.get_projects() # request first page without any parameters
+            else: # when total is just less than the limit
+                self.view.show_projects_pages(False) # show first page and no controls
         self.projectsUpdated.emit()
         self.dlg.projectsTable.clearSelection()
         self.dlg.projectsTable.setSelectionMode(QAbstractItemView.SingleSelection)

--- a/mapflow/functional/service/project.py
+++ b/mapflow/functional/service/project.py
@@ -187,4 +187,5 @@ class ProjectService(QObject):
         So each time offset resets to 0 to show 1st page of newly filtered response.
         """
         self.projects_page_offset = 0
+        self.project_id = None
         self.get_projects()

--- a/mapflow/functional/service/project.py
+++ b/mapflow/functional/service/project.py
@@ -25,6 +25,7 @@ class ProjectService(QObject):
         self.view = ProjectView(self.dlg)
         self.projects_data = {}
         self.projects = []
+        self.project_id = None
         self.projects_page_limit = Config.PROJECTS_PAGE_LIMIT
         self.projects_page_offset = 0
         # Connections
@@ -37,6 +38,8 @@ class ProjectService(QObject):
         self.api.create_project(project, self.create_project_callback)
 
     def create_project_callback(self, response: QNetworkReply):
+        project = MapflowProject.from_dict(json.loads(response.readAll().data()))
+        self.project_id = project.id
         self.get_projects()
     
     def delete_project(self, project_id):
@@ -52,6 +55,8 @@ class ProjectService(QObject):
         self.api.update_project(project_id, project, self.update_project_callback)
     
     def update_project_callback(self, response: QNetworkReply):
+        project = MapflowProject.from_dict(json.loads(response.readAll().data()))
+        self.project_id = project.id
         self.get_projects()
     
     def get_project(self, project_id, callback: Callable, error_handler: Callable):
@@ -124,6 +129,7 @@ class ProjectService(QObject):
         self.projectsUpdated.emit()
         self.dlg.projectsTable.clearSelection()
         self.dlg.projectsTable.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.select_project(self.project_id)
     
     def select_project(self, project_id):
         self.view.select_project(project_id)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -690,10 +690,12 @@ class Mapflow(QObject):
                 if selected_id == pid:
                     self.current_project = project
                     self.dlg.currentProjectLabel.setText(self.tr("Project: <b>{}").format(self.current_project.name))
-            self.get_project_sharing(self.current_project)
+            if self.current_project:
+                self.get_project_sharing(self.current_project)
+                self.setup_workflow_defs(self.current_project.workflowDefs)
             self.setup_project_change_rights()
             self.settings.setValue("project_id", self.project_id)
-            self.setup_workflow_defs(self.current_project.workflowDefs)
+            
             # Manually toggle function to avoid race condition
             self.calculate_aoi_area_use_image_extent()
 
@@ -3209,6 +3211,7 @@ class Mapflow(QObject):
     def update_projects(self):
         self.projects = {pr.id: pr for pr in self.project_service.projects}
         if not self.projects:
+            self.dlg.projectsTable.clear()
             # Add a row with an error message to projects table
             table_item = QTableWidgetItem("No project that meets specified criteria was found")
             self.dlg.projectsTable.setRowCount(1)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -2061,15 +2061,14 @@ class Mapflow(QObject):
         # Show processing start confirmation dialog if checkbox is checked
         if self.dlg.cornfirmProcessingStart.isChecked():
             dialog = ConfirmProcessingStart(self.dlg)
-            # Define actions in case of dialog acceptance
-            def on_start_confirmation():
+            #! Define actions in case of dialog acceptance
+            def set_start_confirmation():
                 # Set "Confirm" checkbox opposite to "Don't show again" if they are not already the same
                 if not dialog.checkBox.isChecked() != self.dlg.cornfirmProcessingStart.isChecked():
                     self.dlg.cornfirmProcessingStart.setChecked(not dialog.checkBox.isChecked())
                     self.settings.setValue("confirmProcessingStart", str(not dialog.checkBox.isChecked()))
-                # And then post processing
-                start_processing()
-            dialog.accepted.connect(on_start_confirmation)
+            dialog.checkBox.toggled.connect(set_start_confirmation)
+            dialog.accepted.connect(start_processing)
             # Fill dialog with parameters
             dialog.setup(name=processing_params.name,
                          price=str(self.processing_cost)+self.tr(" credits"),

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -2814,7 +2814,7 @@ class Mapflow(QObject):
         if not self.project_id:
             return
         self.setup_processings_table()
-        self.project_service.switch_to_processings(save_page)
+        self.project_service.switch_to_processings(save_page, self.project_id)
     
     def show_projects(self, open_saved_page: Optional[bool] = False):
         """Get projects and switch from processings to projects table in stacked widget.

--- a/mapflow/schema/catalog.py
+++ b/mapflow/schema/catalog.py
@@ -57,7 +57,7 @@ class ImageSchema(Serializable, SkipDataClass):
         elif not isinstance(self.acquisitionDate, datetime):
             raise TypeError("Acquisition date must be either datetime or ISO-formatted str")
         # To percent
-        self.cloudCover = self.cloudCover*100
+        self.cloudCover = self.cloudCover
         self.source = self.sensor
         self.previewType = PreviewType(self.previewType)
 


### PR DESCRIPTION
Fix:
- don't send unnecessary cost requests
- select project when switching from processings to projects table
- forbid swithching to processings when no filterd projects found
- switch to first page when last page is deleted
- open first page if saved page doesn't exist