### PR TITLE
Processing: Start (post) with API v2

### DIFF
--- a/mapflow/entity/provider/basemap_provider.py
+++ b/mapflow/entity/provider/basemap_provider.py
@@ -2,32 +2,38 @@
 Basic, non-authentification XYZ provider
 """
 from abc import ABC
-from typing import Optional
+from typing import Optional,List
 from urllib.parse import urlparse, parse_qs
 
 from .provider import SourceType, CRS, UsersProvider, staticproperty
 from ...functional.layer_utils import maxar_tile_url, add_connect_id
 from ...requests.maxar_metadata_request import MAXAR_REQUEST_BODY, MAXAR_META_URL
-from ...schema.processing import PostSourceSchema
+from ...schema.processing import PostSourceSchema,UserDefinedParams, SourceParams, PostProcessingParams
 
 
 class BasemapProvider(UsersProvider, ABC):
     def to_processing_params(self,
-                             image_id: Optional[str] = None,
+                             image_ids: Optional[List[str]] = None,
+                             mosaic_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
                              zoom: Optional[str] = None,
                              requires_id: Optional[bool] = False):
         params = {
+            'sourceType': self.source_type.value.upper(),
             'url': self.url,
-            'projection': self.crs.value.lower(),
-            'source_type': self.source_type.value,
-            'zoom': zoom
+            'zoom': zoom,
+            'crs': self.crs.value.lower(),
+            'rasterLogin': None,
+            'rasterPassword': None
         }
         if self.credentials:
-            params.update(raster_login=self.credentials.login,
-                          raster_password=self.credentials.password)
-        return PostSourceSchema(**params), {}
+            params.update(rasterLogin=self.credentials.login,
+                          rasterPassword=self.credentials.password)
+        return PostProcessingParams(sourceParams=SourceParams(dataProvider=None,
+                                                              myImagery=None,
+                                                              imagerySearch=None,
+                                                              userDefined=UserDefinedParams(**params))), {}
 
     @property
     def requires_image_id(self):
@@ -122,11 +128,13 @@ class MaxarProvider(UsersProvider):
                                          geometry=geometry).encode()
 
     def to_processing_params(self,
-                             image_id: Optional[str] = None,
+                             image_ids: Optional[List[str]] = None,
+                             mosaic_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
+                             zoom: Optional[str] = None,
                              requires_id: Optional[bool] = False):
-        params = PostSourceSchema(url=maxar_tile_url(self.url, image_id),
+        params = PostSourceSchema(url=maxar_tile_url(self.url, image_ids[0]),
                                   source_type=self.source_type,
                                   projection=self.crs.value,
                                   raster_login=self.credentials.login,

--- a/mapflow/entity/provider/provider.py
+++ b/mapflow/entity/provider/provider.py
@@ -2,7 +2,7 @@ import json
 import os
 from abc import ABC
 from enum import Enum
-from typing import Iterable, Union, Optional
+from typing import Iterable, Union, Optional, List
 from pathlib import Path
 
 
@@ -20,6 +20,7 @@ class SourceType(StrEnum):
     tms = 'tms'
     quadkey = 'quadkey'
     sentinel_l2a = 'sentinel_l2a'
+    local = 'local'
 
     @property
     def requires_crs(self):
@@ -75,7 +76,8 @@ class ProviderInterface:
         raise NotImplementedError
 
     def to_processing_params(self,
-                             image_id: Optional[str] = None,
+                             image_ids: Optional[List[str]] = None,
+                             mosaic_id: Optional[str] = None,
                              provider_name: Optional[str] = None,
                              url: Optional[str] = None,
                              zoom: Optional[str] = None,

--- a/mapflow/metadata.txt
+++ b/mapflow/metadata.txt
@@ -21,8 +21,8 @@ changelog:
    	- Refreshing for My imagery tables
     	- Mosaics renamed to imagery collections
     - Imagery search:
-	- New preview column 
-	- Data provider filter (for available search providers)
+        - New preview column 
+        - Data provider filter (for available search providers)
     - Option in AOI-menu to create AOI layer from mosaic/image extent (instead of checkbox)
     - Confirmation of processing start (can be turned off/on)
     - Awaiting status added

--- a/mapflow/schema/__init__.py
+++ b/mapflow/schema/__init__.py
@@ -1,4 +1,13 @@
 from .base import SkipDataClass
 from .catalog import ImageCatalogRequestSchema, ImageCatalogResponseSchema
-from .processing import PostSourceSchema, PostProviderSchema, PostProcessingSchema
+from .processing import (PostSourceSchema, 
+                         PostProviderSchema, 
+                         PostProcessingSchema, 
+                         PostProcessingSchemaV2, 
+                         PostProcessingParams,
+                         DataProviderParams,
+                         MyImageryParams,
+                         ImagerySearchParams,
+                         UserDefinedParams,
+                         SourceParams)
 from .provider import ProviderReturnSchema

--- a/mapflow/schema/processing.py
+++ b/mapflow/schema/processing.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from typing import Optional, Mapping, Any, Union, Iterable
+from typing import Optional, Mapping, Any, Union, Iterable, List
 
 from .base import SkipDataClass, Serializable
-
+from ..entity.provider.provider import SourceType
 
 @dataclass
 class PostSourceSchema(Serializable, SkipDataClass):
@@ -58,3 +58,56 @@ class UpdateProcessingSchema(Serializable):
     name: str
     description: str
 
+
+@dataclass
+class MyImageryParams(Serializable, SkipDataClass):
+    imageIds: List[str]
+    mosaicId: str
+
+
+@dataclass
+class ImagerySearchParams(Serializable, SkipDataClass):
+    dataProvider: str
+    imageIds: List[str]
+    zoom: int
+
+
+@dataclass
+class DataProviderParams(Serializable, SkipDataClass):
+    providerName: str
+    zoom: str
+
+
+@dataclass
+class UserDefinedParams(Serializable, SkipDataClass):
+    sourceType: SourceType
+    url: str
+    zoom: Optional[int]
+    crs: str
+    rasterLogin: Optional[str]
+    rasterPassword: Optional[str]
+
+
+@dataclass
+class SourceParams(Serializable, SkipDataClass):
+    dataProvider: Optional[DataProviderParams]
+    myImagery: Optional[MyImageryParams]
+    imagerySearch: Optional[ImagerySearchParams]
+    userDefined: Optional[UserDefinedParams]
+
+
+@dataclass
+class PostProcessingParams(Serializable, SkipDataClass):
+    sourceParams: SourceParams
+
+
+@dataclass
+class PostProcessingSchemaV2(Serializable):
+    name: str
+    description: Optional[str]
+    projectId: str
+    wdId: Optional[str]
+    geometry: Mapping[str, Any]
+    params: PostProcessingParams
+    meta: Optional[Mapping[str, Any]]
+    blocks: Optional[Iterable[BlockOption]]


### PR DESCRIPTION
Added **PostProcessingSchemaV2** schema, which contains **PostProcessingParams**, that are formed by **sourceParams** of 1 of 4 types:
- dataProvider: Optional[**DataProviderParams**]
- myImagery: Optional[**MyImageryParams**]
- imagerySearch: Optional[**ImagerySearchParams**]
- userDefined: Optional[**UserDefinedParams**]
with corresponding attributes