### PR TITLE
Patch/raster results layer

### DIFF
--- a/mapflow/entity/processing.py
+++ b/mapflow/entity/processing.py
@@ -18,7 +18,8 @@ class Processing:
                  created,
                  percent_completed,
                  raster_layer,
-                 vector_layer,
+                 vector_layer=None,
+                 result_raster_layer=None,
                  errors=None,
                  review_status=None,
                  in_review_until=None,
@@ -37,6 +38,7 @@ class Processing:
         self.errors = errors
         self.raster_layer = raster_layer
         self.vector_layer = vector_layer
+        self.result_raster_layer = result_raster_layer
         self.review_status = ProcessingReviewStatus(review_status)
         self.in_review_until = in_review_until
         self.params = params
@@ -61,7 +63,8 @@ class Processing:
         messages = processing.get('messages', [])
         errors = [ErrorMessage.from_response(message) for message in messages]
         raster_layer = processing['rasterLayer']
-        vector_layer = processing['vectorLayer']
+        vector_layer = processing.get('vectorLayer', None)
+        result_raster_layer = processing.get('resultRasterLayer', None)
         if processing.get('reviewStatus'):
             review_status = processing.get('reviewStatus', {}).get('reviewStatus')
             in_review_until_str = processing.get('reviewStatus', {}).get('inReviewUntil')
@@ -84,6 +87,7 @@ class Processing:
                    percent_completed,
                    raster_layer,
                    vector_layer,
+                   result_raster_layer,
                    errors,
                    review_status,
                    in_review_until,

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -326,8 +326,28 @@ class ResultsLoader(QObject):
         preview_dict[url] = preview_layer.id()
 
     # ======= Load as tile layers ====== #
-
     def load_result_tiles(self, processing):
+        if processing.result_raster_layer:
+            self.load_result_raster_tiles(processing)
+        else:
+            self.load_result_vector_tiles(processing)
+    
+    def load_result_raster_tiles(self, processing):
+        raster_tilejson = processing.raster_layer.get("tileJsonUrl", None)
+        result_tilejson = processing.result_raster_layer.get("tileJsonUrl", None)
+        raster_layer = generate_raster_layer(processing.raster_layer.get("tileUrl", None),
+                                             name=f"{processing.name} raster")
+        result_layer = generate_raster_layer(processing.result_raster_layer.get("tileUrl", None),
+                                             name=processing.name)
+        self.request_layer_extent(tilejson_uri=raster_tilejson,
+                                  layer=raster_layer,
+                                  next_layers = [result_layer],
+                                  next_tilejson_uris = [result_tilejson],
+                                  processing_id = processing.id_
+                                  )
+
+
+    def load_result_vector_tiles(self, processing):
         raster_tilejson = processing.raster_layer.get("tileJsonUrl", None)
         vector_tilejson = processing.vector_layer.get("tileJsonUrl", None)
         raster_layer = generate_raster_layer(processing.raster_layer.get("tileUrl", None),


### PR DESCRIPTION
We want to allow new API feature - raster tiles streaming.
In case "show as tiles" this will be a new and preferrable type of result preview, to disallow free usage of vector results.
Older processings will have only vector tiles, so we do not remove this possibility, but newer ones will lack vector tiles (after release of thiss feature at frontend)

In case "download as file" nothing will change, but the api will be hidden behind the paywall (later)