### PR TITLE
Fix preview in case the image is non-collinear with mercator axes;

### DIFF
--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from PyQt5.QtCore import QObject, pyqtSignal, QFile, QIODevice
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest, QHttpMultiPart, QHttpPart
 from PyQt5.QtWidgets import QApplication, QProgressBar
-from qgis.core import QgsMapLayer, QgsRectangle
+from qgis.core import QgsMapLayer
 
 from ...schema.data_catalog import PreviewSize, MosaicCreateSchema, ImageReturnSchema, MosaicUpdateSchema
 from ...http import Http, get_error_report_body, data_catalog_message_parser
@@ -297,14 +297,14 @@ class DataCatalogApi(QObject):
     
     def get_image_preview_l(self,
                             image: ImageReturnSchema,
-                            extent: QgsRectangle,
+                            footprint,
                             callback: Callable,
                             image_name: str = ""):
         self.http.get(url=image.preview_url_l,
                       callback=callback,
                       use_default_error_handler=False,
                       error_handler=self.image_preview_l_error_handler,
-                      callback_kwargs={"extent": extent,
+                      callback_kwargs={"footprint": footprint,
                                        "image_name": image_name}
                      )
 

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -347,16 +347,103 @@ class ResultsLoader(QObject):
         self.add_layer(cloned_aoi, 0)
 
     def get_footprint_corners(self, footprint: QgsGeometry):
-        corners = []
-        footprint = footprint.asGeometryCollection()[0].asPolygon() # in case it's a MultiPolygon with only one polygon
-        if len(footprint[0]) != 5:
+        """Extract corners from footprint and order them as [NW, NE, SE, SW].
+        
+        Uses quadrant-based detection relative to the polygon center to determine
+        which corner is which, regardless of the original point order in the geometry.
+        
+        Note: This assumes rotation < 45° (each corner stays in its natural quadrant).
+        """
+        footprint_poly = footprint.asGeometryCollection()[0].asPolygon()  # in case it's a MultiPolygon
+        if len(footprint_poly[0]) != 5:
             self.message_bar.pushInfo(self.plugin_name, self.tr('Preview is unavailable'))
-            return
-        for point in range(4):
-            pt = footprint[0][point]
-            coords = (pt.x(), pt.y())
-            corners.append(coords)
-        return corners
+            return None
+        
+        # Get all 4 corners (ignore the 5th closing point)
+        points = [(footprint_poly[0][i].x(), footprint_poly[0][i].y()) for i in range(4)]
+        
+        # Find center of bounding box
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        cx = (min(xs) + max(xs)) / 2
+        cy = (min(ys) + max(ys)) / 2
+        
+        # Classify each point by quadrant relative to center
+        nw = ne = se = sw = None
+        for p in points:
+            if p[0] <= cx and p[1] >= cy:  # left and top
+                nw = p
+            elif p[0] >= cx and p[1] >= cy:  # right and top
+                ne = p
+            elif p[0] >= cx and p[1] <= cy:  # right and bottom
+                se = p
+            elif p[0] <= cx and p[1] <= cy:  # left and bottom
+                sw = p
+        
+        # Check all corners were found
+        if None in (nw, ne, se, sw):
+            self.message_bar.pushInfo(self.plugin_name, self.tr('Preview is unavailable'))
+            return None
+        
+        return [nw, ne, se, sw]
+
+    def display_preview_with_gcp(self,
+                                 response: QNetworkReply,
+                                 footprint: QgsGeometry,
+                                 crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:3857"),
+                                 image_name: str = "",
+                                 add_aoi: bool = False) -> Optional[QgsRasterLayer]:
+        """Display image preview using Ground Control Points from footprint corners.
+
+        Works correctly for rotated/skewed footprints (non axis-aligned).
+        Uses GCPs instead of GeoTransform to handle any footprint orientation.
+
+        :param response: HTTP response containing the image data
+        :param footprint: QgsGeometry of the image footprint (polygon)
+        :param crs: Coordinate reference system for the preview
+        :param image_name: Name to use for the layer
+        :param add_aoi: Whether to add AOI overlay on top of the preview
+        :return: The created raster layer, or None if failed
+        """
+        corners = self.get_footprint_corners(footprint)
+        if not corners:
+            return None
+
+        with open(self.temp_dir / os.urandom(32).hex(), mode='wb') as f:
+            f.write(response.readAll().data())
+
+        preview = gdal.Open(f.name)
+        preview.SetProjection(crs.toWkt())
+
+        # GCPs map image pixel coordinates to ground coordinates
+        # corners order: [0]=NW, [1]=NE, [2]=SE, [3]=SW (clockwise from NW)
+        # pixel coords: (0,0)=NW, (width,0)=NE, (width,height)=SE, (0,height)=SW
+        gcp_list = [
+            gdal.GCP(corners[0][0], corners[0][1], 0, 0, 0),
+            gdal.GCP(corners[1][0], corners[1][1], 0, preview.RasterXSize - 1, 0),
+            gdal.GCP(corners[3][0], corners[3][1], 0, 0, preview.RasterYSize - 1),
+            gdal.GCP(corners[2][0], corners[2][1], 0, preview.RasterXSize - 1, preview.RasterYSize - 1)
+        ]
+
+        preview.SetGCPs(gcp_list, crs.toWkt())
+        preview.FlushCache()
+
+        layer = QgsRasterLayer(f.name, f"{image_name} preview", 'gdal')
+
+        # Handle transparency
+        if layer.bandCount() == 4:
+            if layer.renderer().alphaBand() != 4:
+                layer.renderer().setAlphaBand(4)
+        else:
+            for band in range(layer.bandCount()):
+                layer.dataProvider().setNoDataValue(band, 0)
+
+        self.add_layer(layer)
+
+        if add_aoi:
+            self.add_aoi_to_preview()
+
+        return layer
   
     def georeference_preview_part(self,
                                   response: QNetworkReply,


### PR DESCRIPTION
 refactor to use GCP preview function for both myImagery and search; use some sketchy guess to determine the points order in the footprint, so need to test properly.

Actually, if we are SURE (from documentation?) that the imagery search will always return the footprint in the right point order, we may try to require the same from data-catalog, and skip the guess phase, should we?