### PR TITLE
Add ruff + pyright linting setup (Makefile + configs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,56 @@
+# Test runner for mapflow-qgis.
+#
+# All targets run inside the qgis/qgis:release-3_28 Docker image so
+# host setup is irrelevant. See spec/004_stack.md and tests/README.md
+# for tier definitions.
+
+IMAGE ?= mapflow-qgis-tests
+DOCKERFILE ?= Dockerfile.tests
+DOCKER_RUN = docker run --rm -v "$(CURDIR)":/app -w /app $(IMAGE)
+
+# Linting runs on the HOST (not in the Docker image): ruff is AST-only and
+# pyright runs in lenient/basic mode, so neither needs the QGIS runtime. Both
+# are installed in the project venv; override RUFF/PYRIGHT to point elsewhere.
+RUFF ?= venv/bin/ruff
+PYRIGHT ?= venv/bin/pyright
+
+.PHONY: help docker-build test test-functional test-qgis test-ui lint clean
+
+help:
+	@echo "Targets:"
+	@echo "  docker-build      Build the test image ($(IMAGE))"
+	@echo "  test-functional   Run pure-logic tests under tests/functional/"
+	@echo "  test-qgis         Run QGIS-runtime tests under tests/qgis/"
+	@echo "  test-ui           Run UI tests under tests/ui/ (xvfb-run)"
+	@echo "  test              Run all three tiers"
+	@echo "  lint              Run ruff + pyright on the host (uses project venv)"
+	@echo "  clean             Remove pytest cache + bytecode"
+
+docker-build:
+	docker build -f $(DOCKERFILE) -t $(IMAGE) .
+
+test-functional: docker-build
+	$(DOCKER_RUN) pytest tests/functional
+
+test-qgis: docker-build
+	$(DOCKER_RUN) pytest tests/qgis
+
+test-ui: docker-build
+	# pytest exits 5 when no tests are collected; the UI tier is an
+	# empty harness today, so treat that as a pass. Remove this guard
+	# once the first UI test lands.
+	$(DOCKER_RUN) bash -c 'xvfb-run -a pytest tests/ui; rc=$$?; [ $$rc -eq 0 ] || [ $$rc -eq 5 ]'
+
+test: test-functional test-qgis test-ui
+
+# Static analysis. Ruff catches unused code / real-bug patterns; pyright adds
+# flow analysis (possibly-unbound, undefined names) that ruff can't do.
+# Config lives in pyproject.toml (ruff) and pyrightconfig.json (pyright).
+lint:
+	$(RUFF) check mapflow tests
+	$(PYRIGHT)
+
+clean:
+	find . -type d -name __pycache__ -exec rm -rf {} +
+	find . -type f -name '*.pyc' -delete
+	rm -rf .pytest_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.ruff]
+target-version = "py39"   # QGIS 3.28 ships Python 3.9
+line-length = 120
+
+[tool.ruff.lint]
+# Start with the real-bug rules; add "E","W","I","UP" once the baseline is clean.
+select = ["F", "B"]   # pyflakes + flake8-bugbear
+
+[tool.ruff.lint.per-file-ignores]
+# __init__.py files re-export symbols for the package's public API; the imports
+# look "unused" locally but are intentional. Standard ruff idiom.
+"__init__.py" = ["F401"]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,27 @@
+{
+  "include": ["mapflow", "tests"],
+  "typeCheckingMode": "basic",
+  "reportMissingImports": false,
+  "reportMissingModuleSource": false,
+
+  "// note": "Correctness/flow checks Ruff can't do are kept as errors. Type-completeness reports are muted until a dedicated typing pass; this codebase is largely untyped.",
+
+  "reportPossiblyUnbound": "error",
+  "reportUndefinedVariable": "error",
+  "reportSelfClsParameterName": "error",
+
+  "reportOptionalMemberAccess": "none",
+  "reportOptionalSubscript": "none",
+  "reportOptionalIterable": "none",
+  "reportOptionalOperand": "none",
+  "reportOptionalCall": "none",
+  "reportArgumentType": "none",
+  "reportAttributeAccessIssue": "none",
+  "reportCallIssue": "none",
+  "reportReturnType": "none",
+  "reportAssignmentType": "none",
+  "reportOperatorIssue": "none",
+  "reportGeneralTypeIssues": "none",
+  "reportInvalidTypeForm": "none",
+  "reportRedeclaration": "none"
+}


### PR DESCRIPTION
Brings the Makefile and linter configs (pyproject.toml, pyrightconfig.json) onto master so agent-make's Makefile guard is satisfied and 'make lint' works from the protected branch.

Setup only: no code fixes and no doc edits. The AGENTS.md/README linting docs and the lint-driven fixes remain on the dev-based feature branch.