### PR TITLE
Add test/build infra to master (Docker + agent-make watched files)

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,31 @@
+# Test runtime for the mapflow-qgis plugin.
+#
+# Pinned to qgis/qgis:release-3_28 — the LTR release, matches the
+# 3.20+ minimum in spec/004_stack.md. Bump only when the plugin's
+# minimum target changes.
+#
+# The repo is bind-mounted at /app at run time (see Makefile); we do
+# not COPY sources here so an iteration cycle is just `docker run`,
+# not rebuild.
+FROM qgis/qgis:release-3_28
+
+# xvfb-run is needed by the UI tier; the base image does not ship it.
+# Run apt without recommends to keep the image lean.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# QGIS images ship pytest-qgis hooks already; we only need pytest +
+# pytest-qt (the latter for the UI tier). The base image's pip is old
+# enough that PEP 668's externally-managed marker is not enforced.
+RUN python3 -m pip install --no-cache-dir \
+        pytest \
+        pytest-qt
+
+# Run Qt without an X display by default; the UI tier overrides this
+# by wrapping pytest in `xvfb-run` (provides a real X server).
+ENV QT_QPA_PLATFORM=offscreen \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,26 @@
+# Compose definition for the mapflow-qgis test image.
+#
+# The Makefile drives the test tiers via `docker build -f Dockerfile.tests`
+# and `docker run` directly; this file mirrors that same setup so the image
+# can also be built and run through Compose, e.g.:
+#
+#   docker compose build
+#   docker compose run --rm tests pytest tests/qgis
+#
+# The repo is bind-mounted at /app (sources are not COPYed into the image),
+# so an iteration cycle is just a re-run, not a rebuild. Keep this in sync
+# with Dockerfile.tests and the Makefile.
+services:
+  tests:
+    build:
+      context: .
+      dockerfile: Dockerfile.tests
+    image: mapflow-qgis-tests
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      QT_QPA_PLATFORM: offscreen
+      PYTHONDONTWRITEBYTECODE: "1"
+      PYTHONUNBUFFERED: "1"
+    command: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Repo root must be on sys.path so `import mapflow` resolves.
+# Per-tier conftests live in tests/{functional,qgis,ui}/.
+pythonpath = .
+testpaths = tests


### PR DESCRIPTION
Brings the test toolchain onto master so agent-make's watched-file integrity check passes and the Docker test image can build:

- docker-compose.yaml: the second agent-make watched file (with Makefile). Newly created (it did not exist on any branch); mirrors Dockerfile.tests and the Makefile's docker-run setup so the image can also build via Compose.
- Dockerfile.tests, pytest.ini: brought from dev unchanged.

Infra only: no application source and no test code. master's existing mapflow/ and tests/ are untouched.