### PR TITLE
See & edit template AOIs: in-template navigation, AOI grouping, names

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -9,6 +9,24 @@
   - navigate from template to processings launched from it
   - create, launch, delete, and update template parameters
 
+### 1a. See & edit template AOIs (feature/see-template-aois) [ready-for-review]
+- Added a 3rd navigation level (Projects -> Processings -> Template). Reused the
+  existing left/right "fake" nav buttons rather than new widgets; the right
+  (placeholder) button becomes "enter selected template", the left button is
+  context-aware (template -> processings -> projects). Decoupled map side-effects
+  via ProcessingService.templateOpened/templateClosed signals so the service stays
+  UI-agnostic and selection-independent (inside a template there is no template row).
+- AOI names: backend parses names from searchParams.aoiDetails InputAoiProperties
+  (max 64 chars); create now sends a per-feature aoiDetails FeatureCollection built
+  from the source layer's `name` attribute, falling back to combined `aoi`.
+- DELETE-with-body needed for bulk AOI delete: QNetworkAccessManager.deleteResource
+  has no body, so http.py routes DELETE+body through sendCustomRequest with a QBuffer
+  parented to the reply.
+- Runtime ids are strings (dataclasses don't coerce UUID), so table_id/selection
+  keys are strings throughout. ProcessingService gained class-level in_template_mode
+  default so partially-constructed (test) instances don't trip PyQt's QObject guard.
+- See WAL_1.md for the full step list and remaining notes.
+
 - UI requirements:
   - show processings from template in related map layers
   - support mark image/all as seen flows

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -50,6 +50,9 @@ class Config:
 
     # PROCESSINGS
     PROCESSING_TABLE_REFRESH_INTERVAL = 6  # in seconds
+    # In-template view polls a single (lighter) endpoint and its data changes slowly,
+    # so it refreshes less often than the project processings list.
+    TEMPLATE_TABLE_REFRESH_INTERVAL = 15  # in seconds
     PROCESSING_TABLE_COLUMNS = ('name',
                                 'workflowDef',
                                 'status',

--- a/mapflow/dialogs/colors.py
+++ b/mapflow/dialogs/colors.py
@@ -1,0 +1,22 @@
+"""Named UI colors, shared so the same palette can be reused across widgets.
+
+Import the names rather than hard-coding ``QColor(...)`` literals at call sites, e.g.::
+
+    from ...dialogs.colors import LightBlue
+    item.setBackground(LightBlue)
+"""
+from PyQt5.QtGui import QColor
+
+# Base palette (by appearance).
+LightBlue = QColor(207, 242, 249)
+BlueTint = QColor(207, 226, 243)
+GreenTint = QColor(223, 240, 223)
+Grey = QColor(230, 230, 230)
+Peach = QColor(255, 220, 200)
+
+# Semantic aliases for the processings/templates table rows.
+TemplateRow = LightBlue
+AoiRow = BlueTint
+AoiProcessingRow = GreenTint
+SeparatorRow = Grey
+ReviewExpiringRow = Peach

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -57,6 +57,13 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.createProject.setIcon(icons.plus_icon)
         self.deleteProject.setIcon(icons.minus_icon)
         self.updateProject.setIcon(icons.edit_icon)
+        # Navigation arrows: left = back one level, right = into the selected template.
+        self.switchProjectsButton.setIcon(icons.arrow_left_icon)
+        self.switchProjectsButton.setToolTip(self.tr("Back"))
+        self.switchProcessingsButton.setIcon(icons.arrow_right_icon)
+        self.switchProcessingsButton.setToolTip(self.tr("Open processings"))
+        self.switchProcessingsFakeButton.setIcon(icons.arrow_right_icon)
+        self.switchProcessingsFakeButton.setToolTip(self.tr("Open selected template"))
 
         coin_pixmap = icons.coins_icon.pixmap(16, 16)
         self.labelCoins_1.setPixmap(coin_pixmap)
@@ -132,6 +139,10 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.template_rename_action = QAction(self.tr("Rename"))
         self.template_pause_action = QAction(self.tr("Pause"))
         self.template_resume_action = QAction(self.tr("Resume"))
+        # AOI-specific actions (in-template view)
+        self.aoi_rename_action = QAction(self.tr("Rename AOI"))
+        self.aoi_delete_action = QAction(self.tr("Delete AOI"))
+        self.aoi_add_action = QAction(self.tr("Add AOI from current layer"))
         self.setup_options_menu()
 
         # Imagery Search

--- a/mapflow/dialogs/static/ui/main_dialog.ui
+++ b/mapflow/dialogs/static/ui/main_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1060</width>
+    <width>1083</width>
     <height>550</height>
    </rect>
   </property>
@@ -148,10 +148,10 @@
            <property name="maxVisibleItems">
             <number>30</number>
            </property>
-           <property name="allowEmptyLayer">
+           <property name="allowEmptyLayer" stdset="0">
             <bool>false</bool>
            </property>
-           <property name="showCrs">
+           <property name="showCrs" stdset="0">
             <bool>true</bool>
            </property>
           </widget>
@@ -1080,7 +1080,6 @@
                     <widget class="QLabel" name="projectsPageLabel">
                      <property name="font">
                       <font>
-                       <weight>50</weight>
                        <bold>false</bold>
                       </font>
                      </property>
@@ -1318,7 +1317,6 @@
                   <widget class="QLabel" name="processingsPageLabel">
                    <property name="font">
                     <font>
-                     <weight>50</weight>
                      <bold>false</bold>
                     </font>
                    </property>
@@ -1429,7 +1427,6 @@
                    </property>
                    <property name="font">
                     <font>
-                     <weight>50</weight>
                      <bold>false</bold>
                     </font>
                    </property>
@@ -1670,11 +1667,11 @@
                   <property name="toolTip">
                    <string>Click and wait for a few seconds until the table below is filled out</string>
                   </property>
-                  <property name="popupMode">
-                   <enum>QToolButton::MenuButtonPopup</enum>
-                  </property>
                   <property name="text">
                    <string>Search </string>
+                  </property>
+                  <property name="popupMode">
+                   <enum>QToolButton::MenuButtonPopup</enum>
                   </property>
                  </widget>
                 </item>
@@ -1777,11 +1774,11 @@
                     <verstretch>0</verstretch>
                    </sizepolicy>
                   </property>
-                  <property name="popupMode">
-                   <enum>QToolButton::MenuButtonPopup</enum>
-                  </property>
                   <property name="text">
                    <string>Seen</string>
+                  </property>
+                  <property name="popupMode">
+                   <enum>QToolButton::MenuButtonPopup</enum>
                   </property>
                  </widget>
                 </item>
@@ -1841,13 +1838,13 @@
                 <property name="checked">
                  <bool>false</bool>
                 </property>
-                <property name="collapsed">
+                <property name="collapsed" stdset="0">
                  <bool>false</bool>
                 </property>
-                <property name="saveCollapsedState">
+                <property name="saveCollapsedState" stdset="0">
                  <bool>true</bool>
                 </property>
-                <property name="saveCheckedState">
+                <property name="saveCheckedState" stdset="0">
                  <bool>false</bool>
                 </property>
                 <layout class="QGridLayout" name="layoutMetadataFilters" columnstretch="0,0,0">
@@ -1997,7 +1994,7 @@
                    <item>
                     <widget class="QCheckBox" name="hideUnavailableResults">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -3053,7 +3050,7 @@
                  <rect>
                   <x>0</x>
                   <y>0</y>
-                  <width>207</width>
+                  <width>213</width>
                   <height>240</height>
                  </rect>
                 </property>

--- a/mapflow/errors/api_errors.py
+++ b/mapflow/errors/api_errors.py
@@ -18,4 +18,8 @@ class ApiErrors(ErrorMessageList):
             "You don't have enough limit, please contact admin!":
                 self.tr("You don't have enough limit to create this planned processing. "
                         "Please contact your administrator to increase the limit."),
+            # Backend rejects activating/resuming a template past the active-templates cap.
+            "You have reached the maximum number of active templates":
+                self.tr("You have reached the maximum number of active planned processings. "
+                        "Pause or delete another one before activating this template."),
         }

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -9,6 +9,8 @@ from ...schema.processing import (
     PostProcessingSchema,
     UpdateProcessingSchema,
     ProcessingsRequest,
+)
+from ...schema.template import (
     CreateProcessingTemplateSchema,
     UpdateProcessingTemplateSchema,
     RunTemplateProcessingSchema,

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -12,6 +12,9 @@ from ...schema.processing import (
     CreateProcessingTemplateSchema,
     UpdateProcessingTemplateSchema,
     RunTemplateProcessingSchema,
+    UpdateAoiSchema,
+    AddAoisSchema,
+    DeleteAoisSchema,
 )
 
 class ProcessingApi(QObject):
@@ -247,6 +250,53 @@ class ProcessingApi(QObject):
             path=f"processings/template/{template_id}/processings",
             callback=callback,
             use_default_error_handler=True,
+            timeout=5,
+        )
+
+    # ---- Template AOI management ----
+    def update_aoi(self,
+                   template_id: Union[UUID, str],
+                   aoi_id: Union[UUID, str],
+                   data: UpdateAoiSchema,
+                   callback: Callable,
+                   error_handler: Optional[Callable] = None):
+        # NB: the backend serves AOI update over POST (not PUT) — see
+        # ProcessingResource.updateAoiEndpoint (`.post`). PUT returns 404.
+        self.http.post(
+            path=f"processings/template/{template_id}/aoi/{aoi_id}",
+            body=data.as_json().encode(),
+            headers={},
+            callback=callback,
+            error_handler=error_handler,
+            use_default_error_handler=error_handler is None,
+            timeout=5,
+        )
+
+    def add_aois(self,
+                 template_id: Union[UUID, str],
+                 data: AddAoisSchema,
+                 callback: Callable,
+                 error_handler: Optional[Callable] = None):
+        self.http.post(
+            path=f"processings/template/{template_id}/aoi",
+            body=data.as_json().encode(),
+            callback=callback,
+            error_handler=error_handler,
+            use_default_error_handler=error_handler is None,
+            timeout=5,
+        )
+
+    def delete_aois(self,
+                    template_id: Union[UUID, str],
+                    data: DeleteAoisSchema,
+                    callback: Callable,
+                    error_handler: Optional[Callable] = None):
+        self.http.delete(
+            path=f"processings/template/{template_id}/aoi",
+            body=data.as_json().encode(),
+            callback=callback,
+            error_handler=error_handler,
+            use_default_error_handler=error_handler is None,
             timeout=5,
         )
 

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -1,5 +1,5 @@
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtWidgets import QMessageBox, QWidget
 
 from ..app_context import AppContext
 from ..service.alert_service import alert
@@ -54,17 +54,71 @@ class ProjectProcessingController(QObject):
         self.project_service.projectsFiltered.connect(self.connect_projects)
 
     def _setup_navigation(self):
-        """Navigation between projects and processings views."""
-        # Connect UI navigation buttons
-        self.dlg.switchProjectsButton.clicked.connect(lambda: self.show_projects(open_saved_page=True))
+        """Navigation between projects, processings and in-template views."""
+        # Left arrow: back one level (template -> processings -> projects).
+        self.dlg.switchProjectsButton.clicked.connect(self.navigate_back)
         self.dlg.switchProcessingsButton.clicked.connect(lambda: self.show_processings(save_page=True))
+        # Right arrow (the former placeholder): enter the selected template ("one step right").
+        self.dlg.switchProcessingsFakeButton.clicked.connect(self.navigate_into_template)
         self.dlg.projectsTable.doubleClicked.connect(self._on_project_double_clicked)
-    
+        # Keep the "enter template" arrow enabled only when a single template is selected.
+        self.dlg.processingsTable.itemSelectionChanged.connect(self._update_nav_buttons)
+        self._update_nav_buttons()
+
     def _on_project_double_clicked(self, index):
         """Handle double-click on project row to navigate to processings."""
         project_id = self.dlg.projectsTable.item(index.row(), 0).text()
         self.app_context.current_project = self.project_service.projects.get(project_id)
         self.show_processings(save_page=True)
+
+    # ==== IN-TEMPLATE NAVIGATION ==== #
+    def navigate_back(self):
+        """Left arrow: leave a template (back to processings) or go back to projects."""
+        if self.processing_service.in_template_mode:
+            self.exit_template()
+        else:
+            self.show_projects(open_saved_page=True)
+
+    def navigate_into_template(self):
+        """Right arrow: enter the currently selected template."""
+        if self.processing_service.in_template_mode:
+            return
+        template = self.processing_service.selected_template()
+        if not template or not self.processing_service.is_only_templates_selected():
+            return
+        self.enter_template(template)
+
+    def enter_template(self, template):
+        """Enter the in-template view for the given template."""
+        self.processing_service.enter_template_view(template)
+        self._set_processings_tab_text(str(template.name))
+        self._update_nav_buttons()
+
+    def exit_template(self):
+        """Return from the in-template view to the project's processings list."""
+        self.processing_service.exit_template_view()
+        self.processing_service.setup_processings_table()
+        self._set_processings_tab_text(self.tr("Processing"))
+        self._update_nav_buttons()
+
+    def _set_processings_tab_text(self, text: str):
+        """Set the processings tab label (used as a breadcrumb for the template name)."""
+        processings_tab = self.dlg.tabWidget.findChild(QWidget, "processingsTab")
+        if processings_tab is None:
+            return
+        tab_index = self.dlg.tabWidget.indexOf(processings_tab)
+        if tab_index >= 0:
+            self.dlg.tabWidget.setTabText(tab_index, text)
+
+    def _update_nav_buttons(self):
+        """Enable the 'enter template' arrow only for a single-template selection."""
+        in_template = self.processing_service.in_template_mode
+        can_enter = (
+            not in_template
+            and self.processing_service.is_only_templates_selected()
+            and self.processing_service.selected_template() is not None
+        )
+        self.dlg.switchProcessingsFakeButton.setEnabled(bool(can_enter))
 
     def show_processings(self, save_page: bool = False):
         """

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 from typing import Dict, Optional, List
-from PyQt5.QtCore import QObject, QTimer
+from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import QMessageBox, QApplication, QInputDialog
 from .provider_service import (get_provider_params, 
@@ -24,12 +24,18 @@ from ..view.processing_view import ProcessingView
 from ..api.processing_api import ProcessingApi
 from ...schema import ProcessingDTO, UpdateProcessingSchema, ProcessingStatus, BillingType, ProcessingHistory, PostProcessingSchemaV2
 from ...schema.processing import (
+    AOI_NAME_MAX_LENGTH,
+    DeleteAoisSchema,
+    NoAoiProcessingsRow,
     ProcessingsRequest,
     ProcessingsResult,
     RunTemplateProcessingSchema,
+    TemplateAoiDTO,
+    TemplateProcessingSchema,
+    UpdateAoiSchema,
     UpdateProcessingTemplateSchema,
 )
-from ...schema.processing import ProcessingTemplateDTO
+from ...schema.processing import ProcessingTemplateDTO, ProcessingTemplateDetails
 from ..service.alert_service import alert
 from ..app_context import AppContext
 from ...entity.provider import ImagerySearchProvider
@@ -42,6 +48,16 @@ class ProcessingService(QObject):
     """
     A service to store & query the mapflow processings.
     """
+
+    # Emitted when entering/leaving the in-template view, so map side-effects
+    # (search results, AOI layers) can be handled outside the service.
+    templateOpened = pyqtSignal(object)
+    templateClosed = pyqtSignal(object)
+
+    # Class-level defaults so the mode check is safe even when callers (and tests)
+    # construct the service without running __init__.
+    in_template_mode = False
+    active_template = None
 
     def __init__(self,
                  http: Http,
@@ -63,6 +79,11 @@ class ProcessingService(QObject):
                                  result_loader=self.result_loader)
         self.processings = {}
         self.templates = {}
+        # In-template navigation state (level 3: Projects -> Processings -> Template).
+        self.in_template_mode = False
+        self.active_template = None  # ProcessingTemplateDTO currently opened
+        self.template_processings = {}  # processings launched from the active template
+        self.template_aois = {}  # TemplateAoiDTO keyed by table_id
         self.processings_data = None  # ProcessingsResult
         self.processings_page_limit = Config.PROCESSINGS_PAGE_LIMIT
         self.processings_page_offset = 0
@@ -199,13 +220,19 @@ class ProcessingService(QObject):
     def template_to_run(self) -> Optional[ProcessingTemplateDTO]:
         """The template a 'Start' click would run, or None for a regular processing.
 
-        Planned (template) processing applies only when ALL hold: a template is selected
-        (not a processing), the source is imagery search, and that template's results are
-        open in the search table. This is the single source of truth shared by the start
-        button text and the start action, so they never disagree.
+        Planned (template) processing applies when the source is imagery search and the
+        open search results belong to a template — either the template currently opened in
+        the in-template view, or (in the processings list) a selected template row. This is
+        the single source of truth shared by the start button text and the start action,
+        so they never disagree.
         """
-        template = self.selected_template()
-        if not template or self.selected_processing():
+        if self.in_template_mode:
+            template = self.active_template
+        else:
+            template = self.selected_template()
+            if not template or self.selected_processing():
+                return None
+        if not template:
             return None
         if not isinstance(self.app_context.data_provider, ImagerySearchProvider):
             return None
@@ -465,6 +492,11 @@ class ProcessingService(QObject):
     def get_processings(self):
         if not self.app_context.current_project:
             return
+        # While inside a template, the table shows that template's AOIs + processings.
+        # The poll timer calls this method, so redirect it to the template refresh.
+        if self.in_template_mode:
+            self.refresh_template_view()
+            return
         # Clamp offset if it exceeds total
         try:
             if self.processings_data and self.processings_page_offset >= self.processings_data.total:
@@ -553,6 +585,8 @@ class ProcessingService(QObject):
         self.view.update_processing_table(self.combined_processing_rows())
 
     def _sort_key(self, item, sort_by: str):
+        if isinstance(item, TemplateAoiDTO):
+            return self._aoi_sort_key(item, sort_by)
         is_processing = isinstance(item, ProcessingDTO)
         if sort_by == "NAME":
             return (item.name or "").lower()
@@ -577,12 +611,175 @@ class ProcessingService(QObject):
         # CREATED (default)
         return item.created if is_processing else item.createdAt
 
+    def _aoi_sort_key(self, aoi: TemplateAoiDTO, sort_by: str):
+        """Sort key for AOI rows. AOIs are sorted only among themselves (see
+        ``combined_template_rows``), so keys never compare across row types."""
+        if sort_by == "AREA":
+            return aoi.aoi_area or 0
+        if sort_by == "STATUS":
+            return aoi.table_status.lower()
+        # NAME and everything else (AOIs have no creation time): order by name.
+        return (aoi.display_name or "").lower()
+
     def combined_processing_rows(self):
+        if self.in_template_mode:
+            return self.combined_template_rows()
         sort_by, sort_order = self.view.sort_processings()
         reverse = sort_order == "DESC"
         templates = sorted(self.templates.values(), key=lambda t: self._sort_key(t, sort_by), reverse=reverse)
         processings = sorted(self.processings.values(), key=lambda p: self._sort_key(p, sort_by), reverse=reverse)
         return list(templates) + list(processings)
+
+    # ============ IN-TEMPLATE VIEW ============ #
+
+    @staticmethod
+    def _template_has_aoi(template: ProcessingTemplateDTO) -> bool:
+        try:
+            return bool(template.aoi_dtos())
+        except Exception:
+            return False
+
+    @staticmethod
+    def _parse_template_response(response: QNetworkReply):
+        """Parse a ``GET /processings/template/{id}`` response into a ProcessingTemplateDTO."""
+        try:
+            data = json.loads(response.readAll().data())
+            if isinstance(data, dict) and "template" in data:
+                return ProcessingTemplateDetails.from_dict(data).template
+            if isinstance(data, dict):
+                return ProcessingTemplateDTO.from_dict(data)
+        except Exception:
+            return None
+        return None
+
+    def hydrate_template(self, template: ProcessingTemplateDTO, callback):
+        """Ensure the template carries its ``aoiDetails`` (the project poll omits them),
+        then invoke ``callback(hydrated_template)``."""
+        if self._template_has_aoi(template):
+            callback(template)
+            return
+        self.api.get_template(
+            template_id=template.id,
+            callback=lambda response: callback(self._parse_template_response(response) or template),
+        )
+
+    def enter_template_view(self, template: ProcessingTemplateDTO):
+        """Open a template ('one step right'): show its AOIs + launched processings.
+
+        The project-scoped poll omits ``searchParams``; hydrate the template by id first
+        when its AOIs are missing, then enter.
+        """
+        self.hydrate_template(template, self._hydrate_and_enter)
+
+    def _hydrate_and_enter(self, template: ProcessingTemplateDTO):
+        if template is not None:
+            self.templates[template.id] = template
+        self._do_enter_template(template)
+
+    def _do_enter_template(self, template: ProcessingTemplateDTO):
+        self.in_template_mode = True
+        self.active_template = template
+        self.template_aois = {aoi.table_id: aoi for aoi in template.aoi_dtos()}
+        self.template_processings = {}
+        self._rebuild_template_rows()
+        # Fetch the full processings (with result layers) for double-click loading.
+        self._fetch_template_processings()
+        self.processing_fetch_timer.start()
+        # Map side-effects (search results + AOI layers) are handled by listeners.
+        self.templateOpened.emit(template)
+
+    def exit_template_view(self):
+        """Leave the template ('one step left'): return to the project's processings."""
+        closed = self.active_template
+        self.in_template_mode = False
+        self.active_template = None
+        self.template_processings = {}
+        self.template_aois = {}
+        # Let listeners clean up the template's map layers / search table.
+        self.templateClosed.emit(closed)
+
+    def refresh_template_view(self):
+        """Re-hydrate the active template (its ``aoiDetails`` carry the per-AOI processings
+        and statuses) and re-render the grouped rows. Driven by the poll timer."""
+        if not self.active_template:
+            return
+        self.api.get_template(
+            template_id=self.active_template.id,
+            callback=self._refresh_template_callback,
+        )
+
+    def _refresh_template_callback(self, response: QNetworkReply):
+        hydrated = self._parse_template_response(response)
+        if hydrated is not None:
+            self.active_template = hydrated
+            self.templates[hydrated.id] = hydrated
+        # Re-fetch the processings too (statuses/progress change); the rows re-render once
+        # that arrives (the processings callback rebuilds).
+        self._fetch_template_processings()
+
+    def _rebuild_template_rows(self):
+        if not self.active_template:
+            return
+        self.template_aois = {aoi.table_id: aoi for aoi in self.active_template.aoi_dtos()}
+        self.view.update_processing_table(self.combined_template_rows())
+
+    def _fetch_template_processings(self):
+        """Fetch the template's processings (v1 ``ProcessingJson``) for the full row data
+        (model, progress, status, result layers) and the unbound ('No AOI') section."""
+        if not self.active_template:
+            return
+        self.api.get_template_processings(
+            template_id=self.active_template.id,
+            callback=self.get_template_processings_callback,
+        )
+
+    def get_template_processings_callback(self, response: QNetworkReply):
+        """Store the template's full processings (keyed by id) and re-render the rows."""
+        try:
+            data = json.loads(response.readAll().data())
+        except Exception:
+            data = []
+        items = data.get("results") if isinstance(data, dict) else data
+        processings = {}
+        for item in items or []:
+            if not isinstance(item, dict):
+                continue
+            try:
+                processing = TemplateProcessingSchema.from_dict(item)
+            except (TypeError, ValueError, KeyError):
+                continue
+            processings[str(processing.id)] = processing
+        self.template_processings = processings
+        if self.in_template_mode:
+            self._rebuild_template_rows()
+
+    def template_processing(self, processing_id: str):
+        """Full processing (with layers) for a grouped AOI-processing row, by id."""
+        return self.template_processings.get(str(processing_id))
+
+    def combined_template_rows(self):
+        """Grouped layout: each AOI row (color-coded) followed by its processings, then the
+        next AOI; finally a 'No AOI' separator and any processings attached to the template
+        but not intersecting an AOI (absent from aoiDetails).
+
+        Processing rows use the full ``TemplateProcessingSchema`` (model/progress/status)
+        when loaded, falling back to the lighter aoiDetails link until then.
+        """
+        rows = []
+        bound_ids = set()
+        for aoi in self.template_aois.values():
+            rows.append(aoi)
+            for link in aoi.processings:
+                pid = str(link.processingId) if link.processingId else ""
+                if pid:
+                    bound_ids.add(pid)
+                full = self.template_processings.get(pid)
+                rows.append(full if full is not None else link)
+        unbound = [p for pid, p in self.template_processings.items() if pid not in bound_ids]
+        if unbound:
+            rows.append(NoAoiProcessingsRow())
+            rows.extend(unbound)
+        return rows
 
     def show_processings_next_page(self):
         self.processings_page_offset += self.processings_page_limit
@@ -1004,7 +1201,93 @@ class ProcessingService(QObject):
     def delete_template_error_handler(self, error: str):
         """Handle delete template error."""
         alert(self.tr("Error deleting template: {}").format(error), QMessageBox.Critical)
-    
+
+    # ============ AOI ACTIONS (in-template view) ============ #
+
+    def rename_aoi(self):
+        """Rename the selected AOI via the per-AOI update endpoint."""
+        aoi = self.selected_aoi()
+        template = self.active_template
+        if not aoi or not template:
+            return
+        if not aoi.can_rename:
+            alert(self.tr("This AOI has no id yet and cannot be renamed. "
+                          "Reopen the template and try again."), QMessageBox.Information)
+            return
+
+        new_name, ok = QInputDialog.getText(
+            self.dlg,
+            self.tr("Rename AOI"),
+            self.tr("AOI name:"),
+            text=str(aoi.name or ""),
+        )
+        if not ok:
+            return
+        new_name = (new_name or "").strip()
+        if not new_name:
+            alert(self.tr("Please, specify AOI name"), QMessageBox.Warning)
+            return
+        if len(new_name) > AOI_NAME_MAX_LENGTH:
+            alert(self.tr("AOI name must not exceed {limit} characters").format(
+                limit=AOI_NAME_MAX_LENGTH), QMessageBox.Warning)
+            return
+        if new_name == (aoi.name or ""):
+            return
+
+        self.api.update_aoi(
+            template_id=template.id,
+            aoi_id=aoi.id,
+            data=UpdateAoiSchema(name=new_name),
+            callback=self.aoi_changed_callback,
+            error_handler=self.aoi_change_error_handler,
+        )
+
+    def delete_aoi(self):
+        """Delete the selected AOI(s) from the active template."""
+        template = self.active_template
+        if not template:
+            return
+        deletable = [a for a in self.selected_aois() if a.can_rename]
+        if not deletable:
+            return
+        if not alert(self.tr("Delete selected AOI(s)?"), QMessageBox.Question):
+            return
+        self.api.delete_aois(
+            template_id=template.id,
+            data=DeleteAoisSchema(aoiIds=[a.id for a in deletable]),
+            callback=self.aoi_changed_callback,
+            error_handler=self.aoi_change_error_handler,
+        )
+
+    def aoi_changed_callback(self, response: QNetworkReply):
+        """After an AOI add/rename/delete, re-hydrate the template (so names/ids are fresh)."""
+        if self.active_template:
+            self.api.get_template(
+                template_id=self.active_template.id,
+                callback=self._reopen_template_callback,
+            )
+
+    def _reopen_template_callback(self, response: QNetworkReply):
+        try:
+            data = json.loads(response.readAll().data())
+            if isinstance(data, dict) and "template" in data:
+                hydrated = ProcessingTemplateDetails.from_dict(data).template
+            elif isinstance(data, dict):
+                hydrated = ProcessingTemplateDTO.from_dict(data)
+            else:
+                hydrated = None
+            if hydrated is not None:
+                self.active_template = hydrated
+                self.templates[hydrated.id] = hydrated
+        except Exception:
+            pass
+        if self.in_template_mode and self.active_template:
+            self.template_aois = {aoi.table_id: aoi for aoi in self.active_template.aoi_dtos()}
+            self.view.update_processing_table(self.combined_template_rows())
+
+    def aoi_change_error_handler(self, error):
+        alert(self.tr("AOI update failed: {}").format(error), QMessageBox.Critical)
+
     def open_template_details(self):
         """Open a dialog showing template details."""
         template = self.selected_template()
@@ -1035,9 +1318,22 @@ class ProcessingService(QObject):
 
     def selected_processings(self, limit=None) -> List[ProcessingDTO]:
         pids = self.view.selected_processing_ids(limit=limit)
+        # In template view the table holds the template's processings, not the project's.
+        pool = self.template_processings if self.in_template_mode else self.processings
         # limit None will give full selection
-        selected_processings = [self.processings[pid] for pid in filter(lambda pid: pid in pids, self.processings)]
+        selected_processings = [pool[pid] for pid in filter(lambda pid: pid in pids, pool)]
         return selected_processings
+
+    def selected_aois(self, limit=None) -> List[TemplateAoiDTO]:
+        """Selected AOI rows (only meaningful inside the in-template view)."""
+        pids = self.view.selected_processing_ids(limit=limit)
+        return [self.template_aois[pid] for pid in filter(lambda pid: pid in pids, self.template_aois)]
+
+    def selected_aoi(self) -> Optional[TemplateAoiDTO]:
+        first = self.selected_aois(limit=1)
+        if not first:
+            return None
+        return first[0]
 
     def selected_processing(self) -> Optional[ProcessingDTO]:
         first = self.selected_processings(limit=1)

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -947,9 +947,10 @@ class ProcessingService(QObject):
             pass
         self.get_processings()
 
-    def update_template_error_handler(self, error: str):
+    def update_template_error_handler(self, response):
         """Handle template update error."""
-        alert(self.tr("Error renaming template: {}" ).format(error), QMessageBox.Critical)
+        alert(self.tr("Error renaming template: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
 
     # Processing cost
     def update_processing_cost(self):
@@ -1102,9 +1103,24 @@ class ProcessingService(QObject):
         except Exception as e:
             alert(self.tr("Failed to pause template: {}").format(str(e)), QMessageBox.Critical)
     
-    def pause_template_error_handler(self, error: str):
+    def _template_error_text(self, response) -> str:
+        """Resolve a template/AOI action error response to a meaningful, translatable message.
+
+        The error handlers receive a ``QNetworkReply``; parse its body through the central
+        error registry (e.g. a generic ``BAD_REQUEST`` with "You have reached the maximum
+        number of active templates" maps to a translated description) rather than formatting
+        the raw reply object (which produced an empty/garbled message box)."""
+        try:
+            body = response.readAll().data().decode()
+            message = api_message_parser(body)
+        except Exception:
+            message = None
+        return message or self.tr("Unknown server error")
+
+    def pause_template_error_handler(self, response):
         """Handle pause template error."""
-        alert(self.tr("Error pausing template: {}").format(error), QMessageBox.Critical)
+        alert(self.tr("Error pausing template: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
     
     def resume_template(self):
         """Resume the selected template."""
@@ -1156,10 +1172,11 @@ class ProcessingService(QObject):
         except Exception as e:
             alert(self.tr("Failed to resume template: {}").format(str(e)), QMessageBox.Critical)
     
-    def resume_template_error_handler(self, error: str):
-        """Handle resume template error."""
+    def resume_template_error_handler(self, response):
+        """Handle resume template error (e.g. "maximum number of active templates")."""
         self._resume_template_state = {}
-        alert(self.tr("Error resuming template: {}").format(error), QMessageBox.Critical)
+        alert(self.tr("Error resuming template: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
 
     def restart_template(self):
         """Restart the selected failed template."""
@@ -1183,9 +1200,10 @@ class ProcessingService(QObject):
         except Exception as e:
             alert(self.tr("Failed to restart template: {}").format(str(e)), QMessageBox.Critical)
 
-    def restart_template_error_handler(self, error: str):
+    def restart_template_error_handler(self, response):
         """Handle restart template error."""
-        alert(self.tr("Error restarting template: {}").format(error), QMessageBox.Critical)
+        alert(self.tr("Error restarting template: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
     
     def delete_template(self):
         """Delete the selected template after confirmation."""
@@ -1215,9 +1233,10 @@ class ProcessingService(QObject):
         except Exception as e:
             alert(self.tr("Failed to delete template: {}").format(str(e)), QMessageBox.Critical)
     
-    def delete_template_error_handler(self, error: str):
+    def delete_template_error_handler(self, response):
         """Handle delete template error."""
-        alert(self.tr("Error deleting template: {}").format(error), QMessageBox.Critical)
+        alert(self.tr("Error deleting template: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
 
     # ============ AOI ACTIONS (in-template view) ============ #
 
@@ -1302,8 +1321,9 @@ class ProcessingService(QObject):
             self.template_aois = {aoi.table_id: aoi for aoi in self.active_template.aoi_dtos()}
             self.view.update_processing_table(self.combined_template_rows())
 
-    def aoi_change_error_handler(self, error):
-        alert(self.tr("AOI update failed: {}").format(error), QMessageBox.Critical)
+    def aoi_change_error_handler(self, response):
+        alert(self.tr("AOI update failed: {}").format(self._template_error_text(response)),
+              QMessageBox.Critical)
 
     def open_template_details(self):
         """Open a dialog showing template details."""

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -24,18 +24,21 @@ from ..view.processing_view import ProcessingView
 from ..api.processing_api import ProcessingApi
 from ...schema import ProcessingDTO, UpdateProcessingSchema, ProcessingStatus, BillingType, ProcessingHistory, PostProcessingSchemaV2
 from ...schema.processing import (
+    ProcessingsRequest,
+    ProcessingsResult,
+)
+from ...schema.template import (
     AOI_NAME_MAX_LENGTH,
     DeleteAoisSchema,
     NoAoiProcessingsRow,
-    ProcessingsRequest,
-    ProcessingsResult,
     RunTemplateProcessingSchema,
     TemplateAoiDTO,
     TemplateProcessingSchema,
     UpdateAoiSchema,
     UpdateProcessingTemplateSchema,
+    ProcessingTemplateDTO,
+    ProcessingTemplateDetails,
 )
-from ...schema.processing import ProcessingTemplateDTO, ProcessingTemplateDetails
 from ..service.alert_service import alert
 from ..app_context import AppContext
 from ...entity.provider import ImagerySearchProvider
@@ -58,6 +61,8 @@ class ProcessingService(QObject):
     # construct the service without running __init__.
     in_template_mode = False
     active_template = None
+    _default_poll_interval = Config.PROCESSING_TABLE_REFRESH_INTERVAL * 1000
+    _template_poll_interval = Config.TEMPLATE_TABLE_REFRESH_INTERVAL * 1000
 
     def __init__(self,
                  http: Http,
@@ -90,6 +95,9 @@ class ProcessingService(QObject):
         self.processings_history = None # ProcessingHistory() - local storage for active processings list
         self.processing_fetch_timer = QTimer(dlg)
         self.processing_fetch_timer.setInterval(timer_interval)
+        # Project-list poll interval vs the slower in-template poll (set on enter/exit).
+        self._default_poll_interval = timer_interval
+        self._template_poll_interval = Config.TEMPLATE_TABLE_REFRESH_INTERVAL * 1000
         self.processing_cost = 0
         self._delete_state = {}  # Store state for template deletion callback
         self._resume_template_state = {}
@@ -684,6 +692,8 @@ class ProcessingService(QObject):
         self._rebuild_template_rows()
         # Fetch the full processings (with result layers) for double-click loading.
         self._fetch_template_processings()
+        # Poll the in-template view less aggressively than the project list.
+        self.processing_fetch_timer.setInterval(self._template_poll_interval)
         self.processing_fetch_timer.start()
         # Map side-effects (search results + AOI layers) are handled by listeners.
         self.templateOpened.emit(template)
@@ -695,33 +705,40 @@ class ProcessingService(QObject):
         self.active_template = None
         self.template_processings = {}
         self.template_aois = {}
+        # Restore the regular (faster) project-list poll cadence.
+        self.processing_fetch_timer.setInterval(self._default_poll_interval)
         # Let listeners clean up the template's map layers / search table.
         self.templateClosed.emit(closed)
 
     def refresh_template_view(self):
-        """Re-hydrate the active template (its ``aoiDetails`` carry the per-AOI processings
-        and statuses) and re-render the grouped rows. Driven by the poll timer."""
-        if not self.active_template:
-            return
-        self.api.get_template(
-            template_id=self.active_template.id,
-            callback=self._refresh_template_callback,
-        )
+        """Poll tick: refresh only the processings (status/progress + the unbound section).
 
-    def _refresh_template_callback(self, response: QNetworkReply):
-        hydrated = self._parse_template_response(response)
-        if hydrated is not None:
-            self.active_template = hydrated
-            self.templates[hydrated.id] = hydrated
-        # Re-fetch the processings too (statuses/progress change); the rows re-render once
-        # that arrives (the processings callback rebuilds).
-        self._fetch_template_processings()
+        The AOI grouping (``aoiDetails`` from the full template) changes slowly and is
+        re-hydrated on enter and after AOI edits — NOT every tick — so a poll is a single
+        ``/processings`` request rather than three. AOI statuses are kept current by syncing
+        them from the polled processings (see ``_sync_aoi_statuses_from_processings``).
+        """
+        if self.active_template:
+            self._fetch_template_processings()
 
     def _rebuild_template_rows(self):
         if not self.active_template:
             return
         self.template_aois = {aoi.table_id: aoi for aoi in self.active_template.aoi_dtos()}
+        self._sync_aoi_statuses_from_processings()
         self.view.update_processing_table(self.combined_template_rows())
+
+    def _sync_aoi_statuses_from_processings(self):
+        """Refresh each AOI's processing-link statuses from the latest polled processings, so
+        the AOI aggregate status is current without re-fetching the full template each tick."""
+        for aoi in self.template_aois.values():
+            for link in aoi.processings:
+                full = self.template_processings.get(str(link.processingId))
+                if full is not None:
+                    try:
+                        link.processingStatus = full.status.value
+                    except AttributeError:
+                        pass
 
     def _fetch_template_processings(self):
         """Fetch the template's processings (v1 ``ProcessingJson``) for the full row data

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -1,13 +1,14 @@
 from typing import List, Union
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtWidgets import QAbstractItemView, QTableWidgetItem, QMessageBox, QCheckBox, QMenu
-from PyQt5.QtGui import QColor
 from ...dialogs.main_dialog import MainDialog
 from ...dialogs import icons
-from ...schema.processing import (ProcessingDTO, ProcessingTemplateDTO, TemplateAoiDTO,
-                                  AoiProcessingLink, TemplateProcessingSchema,
-                                  NoAoiProcessingsRow,
+from ...dialogs import colors
+from ...schema.processing import (ProcessingDTO,
                                   ProcessingUIParams, ProcessingSortBy, ProcessingSortOrder)
+from ...schema.template import (ProcessingTemplateDTO, TemplateAoiDTO,
+                                AoiProcessingLink, TemplateProcessingSchema,
+                                NoAoiProcessingsRow)
 from ...config import config
 from ..service.alert_service import alert
 
@@ -190,20 +191,20 @@ class ProcessingView:
         is_template_processing = isinstance(processing, (AoiProcessingLink, TemplateProcessingSchema))
         if is_template:
             set_color = True
-            color = QColor(207, 242, 249)  # light blue for templates    #! Dark theme?
+            color = colors.TemplateRow  #! Dark theme?
         elif is_aoi:
             set_color = True
-            color = QColor(207, 226, 243)  # blue tint for AOI rows (matches the AOI map layer)
+            color = colors.AoiRow  # matches the AOI map layer
         elif is_template_processing:
             set_color = True
-            color = QColor(223, 240, 223)  # green tint for an AOI's processings (matches the map)
+            color = colors.AoiProcessingRow  # matches the processing map layer
         elif is_separator:
             set_color = True
-            color = QColor(230, 230, 230)  # neutral grey for the 'No AOI' separator
+            color = colors.SeparatorRow  # the 'No AOI' separator
         elif processing.status.is_ok and processing.review_expires:
             # setting color for close review
             set_color = True
-            color = QColor(255, 220, 200)
+            color = colors.ReviewExpiringRow
         for _col, attr in enumerate(config.PROCESSING_TABLE_COLUMNS):
             table_item = QTableWidgetItem()
             table_item.setData(Qt.DisplayRole, processing_dict[attr])
@@ -242,30 +243,38 @@ class ProcessingView:
         # UPDATE THE TABLE
         # Memorize the selection to restore it after table update
         selected_processings = self.selected_processing_ids()
-        # Explicitly clear selection since resetting row count won't do it
-        self.dlg.processingsTable.clearSelection()
-        # Temporarily enable multi selection so that selectRow won't clear previous selection
-        self.dlg.processingsTable.setSelectionMode(QAbstractItemView.MultiSelection)
-        # Row insertion triggers sorting -> row indexes shift -> duplicate rows, so turn sorting off
-        self.dlg.processingsTable.setSortingEnabled(False)
-        self.dlg.processingsTable.setRowCount(len(processings))
-        # Fill out the table
-        for row, proc in enumerate(processings):
-            table_items = self.create_table_items(processing=proc)
-            for col, item in enumerate(table_items):
-                self.dlg.processingsTable.setItem(row, col, item)
-            if proc.id in selected_processings:
-                self.dlg.processingsTable.selectRow(row)
-        # Keep Qt sorting disabled — row order is set by combined_processing_rows (templates first).
-        # Re-show sort indicator if a header sort is active (setSortingEnabled(False) hides it)
-        if self._header_sort_by is not None:
-            col = next(c for c, s in self._COLUMN_SORT_MAP.items() if s == self._header_sort_by)
-            order = Qt.DescendingOrder if self._header_sort_desc else Qt.AscendingOrder
-            header = self.dlg.processingsTable.horizontalHeader()
-            header.setSortIndicatorShown(True)
-            header.setSortIndicator(col, order)
-        # Restore extended selection and filtering
-        self.dlg.processingsTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        table = self.dlg.processingsTable
+        # Block selection signals during the programmatic rebuild: clearing and re-selecting
+        # rows would otherwise fire itemSelectionChanged on every poll, which (in the
+        # in-template view) re-runs the AOI search-results filter and rebuilds map layers.
+        table.blockSignals(True)
+        try:
+            # Explicitly clear selection since resetting row count won't do it
+            table.clearSelection()
+            # Temporarily enable multi selection so that selectRow won't clear previous selection
+            table.setSelectionMode(QAbstractItemView.MultiSelection)
+            # Row insertion triggers sorting -> row indexes shift -> duplicate rows, so turn sorting off
+            table.setSortingEnabled(False)
+            table.setRowCount(len(processings))
+            # Fill out the table
+            for row, proc in enumerate(processings):
+                table_items = self.create_table_items(processing=proc)
+                for col, item in enumerate(table_items):
+                    table.setItem(row, col, item)
+                if proc.id in selected_processings:
+                    table.selectRow(row)
+            # Keep Qt sorting disabled — row order is set by combined_processing_rows (templates first).
+            # Re-show sort indicator if a header sort is active (setSortingEnabled(False) hides it)
+            if self._header_sort_by is not None:
+                col = next(c for c, s in self._COLUMN_SORT_MAP.items() if s == self._header_sort_by)
+                order = Qt.DescendingOrder if self._header_sort_desc else Qt.AscendingOrder
+                header = table.horizontalHeader()
+                header.setSortIndicatorShown(True)
+                header.setSortIndicator(col, order)
+            # Restore extended selection and filtering
+            table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        finally:
+            table.blockSignals(False)
 
     def add_new_processing(self, processing: ProcessingDTO):
         self.dlg.processingsTable.insertRow(0)

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -4,7 +4,10 @@ from PyQt5.QtWidgets import QAbstractItemView, QTableWidgetItem, QMessageBox, QC
 from PyQt5.QtGui import QColor
 from ...dialogs.main_dialog import MainDialog
 from ...dialogs import icons
-from ...schema.processing import ProcessingDTO, ProcessingTemplateDTO, ProcessingUIParams, ProcessingSortBy, ProcessingSortOrder
+from ...schema.processing import (ProcessingDTO, ProcessingTemplateDTO, TemplateAoiDTO,
+                                  AoiProcessingLink, TemplateProcessingSchema,
+                                  NoAoiProcessingsRow,
+                                  ProcessingUIParams, ProcessingSortBy, ProcessingSortOrder)
 from ...config import config
 from ..service.alert_service import alert
 
@@ -181,10 +184,23 @@ class ProcessingView:
         set_color = False
         processing_dict = processing.as_processing_table_dict()
         is_template = isinstance(processing, ProcessingTemplateDTO)
+        is_aoi = isinstance(processing, TemplateAoiDTO)
+        is_separator = isinstance(processing, NoAoiProcessingsRow)
+        # An AOI's processing, whether the lighter aoiDetails link or the full schema.
+        is_template_processing = isinstance(processing, (AoiProcessingLink, TemplateProcessingSchema))
         if is_template:
             set_color = True
             color = QColor(207, 242, 249)  # light blue for templates    #! Dark theme?
-        elif not is_template and processing.status.is_ok and processing.review_expires:
+        elif is_aoi:
+            set_color = True
+            color = QColor(207, 226, 243)  # blue tint for AOI rows (matches the AOI map layer)
+        elif is_template_processing:
+            set_color = True
+            color = QColor(223, 240, 223)  # green tint for an AOI's processings (matches the map)
+        elif is_separator:
+            set_color = True
+            color = QColor(230, 230, 230)  # neutral grey for the 'No AOI' separator
+        elif processing.status.is_ok and processing.review_expires:
             # setting color for close review
             set_color = True
             color = QColor(255, 220, 200)
@@ -198,6 +214,15 @@ class ProcessingView:
                         count=processing.newImagesCount
                     )
                 table_item.setToolTip(template_tip)
+            elif is_aoi:
+                aoi_tip = self.tr("Template AOI")
+                if processing.hasNewImages:
+                    aoi_tip = self.tr("Template AOI with new images")
+                table_item.setToolTip(aoi_tip)
+            elif is_template_processing:
+                table_item.setToolTip(self.tr("Processing from this AOI. Double-click to load results."))
+            elif is_separator:
+                table_item.setToolTip(self.tr("Processings not intersecting any AOI"))
             elif processing.status.is_failed:
                 table_item.setToolTip(processing.error_message(raw=config.SHOW_RAW_ERROR))
             elif processing.reviewUntil:

--- a/mapflow/http.py
+++ b/mapflow/http.py
@@ -2,7 +2,7 @@ import html
 import json
 from typing import Callable, Union, Optional
 
-from PyQt5.QtCore import QObject, QTimer, QUrl, qVersion
+from PyQt5.QtCore import QBuffer, QByteArray, QObject, QTimer, QUrl, qVersion
 from PyQt5.QtNetwork import QHttpMultiPart, QNetworkReply, QNetworkRequest
 from qgis.core import QgsNetworkAccessManager, Qgis, QgsApplication, QgsAuthMethodConfig
 
@@ -156,7 +156,19 @@ class Http(QObject):
             # We skip the exception handling, then the request goes out unauthorized and the error response is handled
             pass
 
-        response = method(request, body) if (method == self.nam.post or method == self.nam.put) else method(request)
+        if method == self.nam.post or method == self.nam.put:
+            response = method(request, body)
+        elif method == self.nam.deleteResource and body is not None:
+            # QNetworkAccessManager.deleteResource() takes no body; a DELETE with a JSON
+            # payload (e.g. bulk AOI delete) must go through sendCustomRequest with a
+            # QIODevice. Parent the buffer to the reply so it outlives the async request.
+            buffer = QBuffer()
+            buffer.setData(QByteArray(body))
+            buffer.open(QBuffer.ReadOnly)
+            response = self.nam.sendCustomRequest(request, b"DELETE", buffer)
+            buffer.setParent(response)
+        else:
+            response = method(request)
 
         response.finished.connect(lambda response=response,
                                          callback=callback,

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -58,14 +58,14 @@ from .schema import (BillingType,
                      MyImageryParams,
                      ProviderReturnSchema,
                      UserDefinedParams)
-from .schema.catalog import (AoiResponseSchema,
-                             MultiPreviewList,
+from .schema.catalog import (MultiPreviewList,
                              PreviewType,
                              ProductType)
 from .schema.project import MapflowProject
-from .schema.processing import (CreateProcessingTemplateSchema,
-                                ProcessingTemplateDetails,
-                                ProcessingTemplateDTO,
+from .schema.processing import (AOI_NAME_MAX_LENGTH,
+                                AddAoisSchema,
+                                AddSingleAoiSchema,
+                                CreateProcessingTemplateSchema,
                                 SearchParams)
 from .schema.workflow_def import WorkflowDef
 # Dialogs
@@ -90,6 +90,10 @@ from .entity.provider import (create_provider,
 
 class Mapflow(QObject):
     """This class represents the plugin. It is instantiated by QGIS."""
+
+    # The AOI id the in-template search results are currently filtered by (None = all).
+    # Class-level default so the check is safe before on_template_opened sets it.
+    _template_search_aoi_filter = None
 
     def __init__(self, iface) -> None:
         """Initialize the plugin.
@@ -305,6 +309,10 @@ class Mapflow(QObject):
         self.dlg.processingsTable.cellDoubleClicked.connect(self.load_results)
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
         self.processing_service.connect_processings_pagination()
+        # In-template navigation: map side-effects on enter/leave a template.
+        self.processing_service.templateOpened.connect(self.on_template_opened)
+        self.processing_service.templateClosed.connect(self.on_template_closed)
+        self.dlg.processingsTable.itemSelectionChanged.connect(self.filter_search_by_selected_aoi)
         # Processings ratings
         self.dlg.processingsTable.itemSelectionChanged.connect(self.enable_feedback)
         self.dlg.processingsTable.itemSelectionChanged.connect(self.on_processings_selection_changed)
@@ -433,6 +441,10 @@ class Mapflow(QObject):
         self.dlg.template_rename_action.triggered.connect(self.processing_service.update_template)
         self.dlg.template_pause_action.triggered.connect(self.processing_service.pause_template)
         self.dlg.template_resume_action.triggered.connect(self.processing_service.resume_template)
+        # AOI actions (in-template view)
+        self.dlg.aoi_rename_action.triggered.connect(self.processing_service.rename_aoi)
+        self.dlg.aoi_delete_action.triggered.connect(self.processing_service.delete_aoi)
+        self.dlg.aoi_add_action.triggered.connect(self.add_template_aoi)
         self.dlg.options_menu.aboutToShow.connect(self.update_processing_options_menu)
         self.dlg.saveOptionsButton.setMenu(self.dlg.options_menu)
 
@@ -443,6 +455,30 @@ class Mapflow(QObject):
 
         selected_template = self.processing_service.selected_template()
         selected_processing = self.processing_service.selected_processing()
+
+        # In-template view: AOI add/rename/delete (only for AOI rows / empty selection;
+        # a selected processing row falls through to the normal processing actions below).
+        if self.processing_service.in_template_mode and not selected_processing:
+            can_edit = self.app_context.user_role.can_delete_rename_review_processing
+            selected_aoi = self.processing_service.selected_aoi()
+            if selected_aoi:
+                self.dlg.aoi_rename_action.setEnabled(can_edit and selected_aoi.can_rename)
+                menu.addAction(self.dlg.aoi_rename_action)
+                self.dlg.aoi_delete_action.setEnabled(can_edit and selected_aoi.can_rename)
+                menu.addAction(self.dlg.aoi_delete_action)
+            self.dlg.aoi_add_action.setEnabled(
+                can_edit and self.dlg.polygonCombo.currentLayer() is not None
+            )
+            menu.addAction(self.dlg.aoi_add_action)
+            return
+
+        # In-template view, a processing row is backed by the v1 TemplateProcessingSchema
+        # (flat params, no ProcessingParams) — offer only the read-only result actions, not
+        # restart/duplicate which need v2 source params.
+        if self.processing_service.in_template_mode and selected_processing:
+            menu.addAction(self.dlg.save_result_action)
+            menu.addAction(self.dlg.see_details_action)
+            return
 
         # Template selection: only template details action.
         if selected_template and not selected_processing:
@@ -520,8 +556,12 @@ class Mapflow(QObject):
         if self.dlg.processingProblemsLabel.text() == planned_reason:
             self.dlg.processingProblemsLabel.clear()
 
-    def get_selected_template_callback(self, response: QNetworkReply):
-        """Render selected template search results in the search table."""
+    def get_selected_template_callback(self, response: QNetworkReply, template=None):
+        """Render a template's search results in the search table.
+
+        ``template`` is passed explicitly because inside the in-template view the table
+        selection points at AOIs/processings, not the template row.
+        """
         response_json = json.loads(response.readAll().data())
         if not response_json.get("images"):
             self.dlg.metadataTable.clearContents()
@@ -529,7 +569,8 @@ class Mapflow(QObject):
             self.app_context.open_template_results_id = None
             self.alert(self.tr("No images was found"), QMessageBox.Information)
             return
-        template = self.processing_service.selected_template()
+        if template is None:
+            template = self.processing_service.selected_template()
         template_group_name = str(template.name) if template else None
         # Mark these results as belonging to this template, so a "Start" runs a planned processing.
         self.app_context.open_template_results_id = str(template.id) if template else None
@@ -584,7 +625,9 @@ class Mapflow(QObject):
         if template_group_name:
             target_group = self._template_group_target(template_group_name)
             self.app_context.project.addMapLayer(layer, addToLegend=False)
-            target_group.insertLayer(0, layer)
+            # Append (bottom) so the search-results footprints sit below the AOI/processing
+            # subgroups rather than on top of them.
+            target_group.addLayer(layer)
         else:
             self.result_loader.add_layer(layer=layer)
         # Selecting a footprint on the map selects the matching table row (and triggers preview).
@@ -612,27 +655,21 @@ class Mapflow(QObject):
                 ids.append(str(aoi_id))
         return ids
 
-    def _linked_processings_from_template(self, template) -> List[dict]:
-        """Extract processing links from template AOI details."""
-        links = []
-        search_params = template.searchParams or {}
-        if isinstance(search_params, dict):
-            aoi_details = search_params.get("aoiDetails", {})
-        else:
-            aoi_details = search_params.aoiDetails
-
-        if not aoi_details:
-            return links
-
-        for feature in aoi_details.get("features", []):
-            feature_processings = feature.get("properties", {}).get("processings", [])
-            links.extend(feature_processings)
-        return links
-
     def show_template_details_and_navigation(self, template):
-        """Show template summary."""
-        linked_processings = self._linked_processings_from_template(template)
-        linked_count = len(linked_processings)
+        """Show template summary. The processings count is fetched from the
+        ``/processings`` endpoint (aoiDetails links are not always populated)."""
+        self.processing_service.api.get_template_processings(
+            template_id=template.id,
+            callback=lambda response: self._show_template_details_callback(template, response),
+        )
+
+    def _show_template_details_callback(self, template, response: QNetworkReply):
+        try:
+            data = json.loads(response.readAll().data())
+            items = data.get("results") if isinstance(data, dict) else data
+            linked_count = len([i for i in (items or []) if isinstance(i, dict)])
+        except Exception:
+            linked_count = 0
         new_images = template.newImagesCount or 0
         local_created_at = template.createdAt.astimezone()
         local_active_until = template.activeUntil.astimezone()
@@ -649,64 +686,40 @@ class Mapflow(QObject):
         alert(details, QMessageBox.Information)
 
     def select_template_processings(self):
-        """Select all processings in the table that were launched from selected template."""
+        """Menu action: load AOI/processing layers for the selected template."""
         template = self.processing_service.selected_template()
         if not template or self.processing_service.selected_processing():
             return
+        # Hydrate first (the list view's template omits aoiDetails), then draw layers.
+        self.processing_service.hydrate_template(template, self._load_template_layers)
 
-        template_group_name = str(template.name)
-        processings_subgroup_name = self.tr("Processings AOI")
-
-        template_aoi_layer = None
-        try:
-            template_aoi_layer = self._add_geojson_aoi_layer(
-                features=template._aoi_features(),
-                layer_name=self.tr("Planned AOI: {name}").format(name=template.name),
-                style_name='aoi.qml',
-                template_group_name=template_group_name,
-            )
-        except Exception:
-            template_aoi_layer = None
-
-        links = self._linked_processings_from_template(template)
-        linked_items = []
-        seen_ids = set()
-        for item in links:
-            processing_id = item.get("processingId")
-            if not processing_id:
-                continue
-            processing_id = str(processing_id)
-            if processing_id in seen_ids:
-                continue
-            seen_ids.add(processing_id)
-            processing_name = item.get("processingName") or item.get("name") or self.tr("Unknown")
-            linked_items.append((processing_name, processing_id))
-
-        if not linked_items:
+    def _load_template_layers(self, template):
+        """Draw, per AOI, a subgroup named after the AOI containing the AOI polygon (blue)
+        and each of its processings' footprints (green), all from the template's
+        ``aoiDetails`` (no extra requests)."""
+        if not template:
             return
-
-        # Add linked processings AOIs to the same group as template AOI
-        for _, processing_id in linked_items:
-            self.http.get(
-                url=f'{self.server}/processings/{processing_id}/aois',
-                callback=self._add_template_processing_aoi_callback,
-                callback_kwargs={
-                    'processing_id': processing_id,
-                    'template_group_name': template_group_name,
-                    'processings_subgroup_name': processings_subgroup_name,
-                    'reference_layer_id': template_aoi_layer.id() if template_aoi_layer else None,
-                },
-                use_default_error_handler=True,
-                timeout=30,
-            )
-        
-        linked_details = "<br/>".join(
-            f"- <b>{name}</b> ({pid})" for name, pid in linked_items
-        )
-        alert(
-            self.tr("Linked processings:<br/>{details}").format(details=linked_details),
-            QMessageBox.Information,
-        )
+        template_group_name = str(template.name)
+        for aoi in template.aoi_dtos():
+            subgroup_name = self.tr("AOI: {name}").format(name=aoi.display_name)
+            if aoi.geometry:
+                self._add_geojson_aoi_layer(
+                    features=[{"type": "Feature", "geometry": aoi.geometry, "properties": {}}],
+                    layer_name=aoi.display_name,
+                    style_name='aoi_template_blue.qml',
+                    template_group_name=template_group_name,
+                    subgroup_name=subgroup_name,
+                )
+            for link in aoi.processings:
+                if not link.geometry:
+                    continue
+                self._add_geojson_aoi_layer(
+                    features=[{"type": "Feature", "geometry": link.geometry, "properties": {}}],
+                    layer_name=link.processingName or str(link.processingId),
+                    style_name='aoi_template_processing_green.qml',
+                    template_group_name=template_group_name,
+                    subgroup_name=subgroup_name,
+                )
 
     def _add_geojson_aoi_layer(self,
                                features: list,
@@ -780,45 +793,80 @@ class Mapflow(QObject):
             return subgroup
         return template_group
 
-    def _add_template_processing_aoi_callback(self,
-                                              response: QNetworkReply,
-                                              processing_id: str,
-                                              template_group_name: Optional[str] = None,
-                                              processings_subgroup_name: Optional[str] = None,
-                                              reference_layer_id: Optional[str] = None):
-        try:
-            data = json.loads(response.readAll().data())
-            geojson = AoiResponseSchema(data).aoi_as_geojson()
-            features = geojson.get('features', [])
-            self._add_geojson_aoi_layer(
-                features=features,
-                layer_name=self.tr("AOI: {id}").format(id=processing_id),
-                style_name='aoi_templates_processing.qml',
-                template_group_name=template_group_name,
-                subgroup_name=processings_subgroup_name,
-                reference_layer_id=reference_layer_id,
-            )
-        except Exception:
-            return
-
     def show_template_search_results(self):
-        """Open imagery search tab and fill it with selected template search results."""
+        """Menu action: fill the imagery-search table with the selected template's results."""
         template = self.processing_service.selected_template()
         if not template or self.processing_service.selected_processing():
             return
+        # Explicit "See search results" action: bring the imagery-search tab to front.
+        self._load_template_search(template, switch_tab=True)
 
-        imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
-        if imagery_search_tab:
-            self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
+    def _load_template_search(self, template, aoi_ids=None, switch_tab=False):
+        """Fill the imagery-search table with the template's search results.
 
-        aoi_ids = self._aoi_ids_from_template(template)
+        ``aoi_ids`` restricts the results to specific AOIs (S7: filter by selected AOI);
+        when ``None`` all of the template's AOIs are used. ``switch_tab`` brings the
+        imagery-search tab to front — only the explicit menu action does so; entering a
+        template or filtering by AOI must not steal focus from the processings tab.
+        """
+        if not template:
+            return
+        if switch_tab:
+            imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
+            if imagery_search_tab:
+                self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
+
+        if aoi_ids is None:
+            aoi_ids = self._aoi_ids_from_template(template)
         self.processing_service.api.get_template_images(
             template_id=template.id,
-            callback=self.get_selected_template_callback,
+            callback=lambda response: self.get_selected_template_callback(response, template),
             limit=self.search_page_limit,
             offset=self.search_page_offset,
             aoi_ids=aoi_ids or None,
         )
+
+    def add_template_aoi(self):
+        """Add the current polygon layer's features as named AOIs to the active template."""
+        template = self.processing_service.active_template
+        if not template:
+            return
+        try:
+            feature_collection = self._build_template_aoi_details()
+        except ValueError as e:
+            self.alert(str(e), QMessageBox.Warning)
+            return
+        if not feature_collection or not feature_collection.get("features"):
+            self.alert(self.tr("Select a polygon layer with at least one feature to add as AOI"),
+                       QMessageBox.Warning)
+            return
+        aois = [
+            AddSingleAoiSchema(geometry=f["geometry"], name=f["properties"].get("name"))
+            for f in feature_collection["features"]
+        ]
+        self.processing_service.api.add_aois(
+            template_id=template.id,
+            data=AddAoisSchema(aois=aois),
+            callback=self.processing_service.aoi_changed_callback,
+            error_handler=self.processing_service.aoi_change_error_handler,
+        )
+
+    def filter_search_by_selected_aoi(self):
+        """S7: inside a template, selecting an AOI filters the imagery-search results
+        (table and footprint layer) to images intersecting that AOI; de-selecting the AOI
+        (or selecting a processing) restores all of the template's results."""
+        if not self.processing_service.in_template_mode:
+            return
+        template = self.processing_service.active_template
+        if not template:
+            return
+        aoi = self.processing_service.selected_aoi()
+        desired = aoi.id if (aoi and aoi.id) else None
+        # Only reload when the effective filter actually changes (selection fires often).
+        if desired == self._template_search_aoi_filter:
+            return
+        self._template_search_aoi_filter = desired
+        self._load_template_search(template, aoi_ids=[desired] if desired else None)
 
     def select_processing_in_table(self, processing_id: str):
         """Select processing row by ID and open processing details."""
@@ -1331,6 +1379,48 @@ class Mapflow(QObject):
             return
         self.get_metadata()
 
+    def _build_template_aoi_details(self) -> Optional[dict]:
+        """Build a GeoJSON FeatureCollection of the AOI layer's features for template creation.
+
+        Each feature carries ``properties.name`` from the layer's ``name`` attribute (when
+        present), so the backend persists named AOIs (parsed as ``InputAoiProperties``).
+        Returns ``None`` when there is no usable polygon layer, so the caller falls back to
+        the combined ``aoi`` geometry. Raises ``ValueError`` if a name exceeds the limit.
+        """
+        layer = self.dlg.polygonCombo.currentLayer()
+        if not layer or layer.featureCount() == 0:
+            return None
+        source_features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
+        if not source_features:
+            return None
+        has_name_field = layer.fields().indexFromName("name") != -1
+        features = []
+        for feature in source_features:
+            geom = feature.geometry()
+            if geom is None or geom.isEmpty():
+                continue
+            wgs_geom = helpers.to_wgs84(QgsGeometry(geom), layer.crs())
+            name = None
+            if has_name_field:
+                raw = feature.attribute("name")
+                # QGIS NULL attributes are not None; normalize to a real None.
+                if raw not in (None, "") and str(raw).upper() != "NULL":
+                    name = str(raw).strip()
+            if name and len(name) > AOI_NAME_MAX_LENGTH:
+                raise ValueError(
+                    self.tr("AOI name '{name}' exceeds {limit} characters").format(
+                        name=name, limit=AOI_NAME_MAX_LENGTH
+                    )
+                )
+            features.append({
+                "type": "Feature",
+                "geometry": json.loads(wgs_geom.asJson()),
+                "properties": {"name": name},
+            })
+        if not features:
+            return None
+        return {"type": "FeatureCollection", "features": features}
+
     def create_search_template(self):
         """Create planned search template using current AOI and imagery-search filters."""
         self.replace_search_provider_index()
@@ -1363,8 +1453,15 @@ class Mapflow(QObject):
         product_types = self.selected_search_product_types() or []
         search_providers = self.selected_search_providers()
 
+        try:
+            aoi_details = self._build_template_aoi_details()
+        except ValueError as e:
+            self.alert(str(e), QMessageBox.Warning)
+            return
+
         search_params = SearchParams(
             aoi=json.loads(self.app_context.aoi.asJson()),
+            aoiDetails=aoi_details,
             acquisitionDateFrom=from_time,
             acquisitionDateTo=to_time,
             maxCloudCover=max_cloud_cover,
@@ -2897,45 +2994,48 @@ class Mapflow(QObject):
 
     # =================== Results management ==================== #
     def _open_template(self, template):
-        """Open a template's results, fetching its ``searchParams`` on demand.
+        """Navigate into a template ('one step right').
 
-        The poll uses the project-scoped template list, which omits ``searchParams``.
-        They are needed to render the template AOI and filter its search results, so
-        when they are missing we fetch the full template by id first, then open.
+        The actual hydration (the poll omits ``searchParams``) and state switch happen in
+        the service; map side-effects are handled by ``on_template_opened`` via signal.
         """
-        if self._template_has_aoi(template):
-            self.show_template_search_results()
-            self.select_template_processings()
+        self.project_processing_controller.enter_template(template)
+
+    def on_template_opened(self, template):
+        """React to entering a template: fill search results and load AOI/processing layers."""
+        # Initial results are the whole template (no AOI filter applied yet).
+        self._template_search_aoi_filter = None
+        self._load_template_search(template)
+        self._load_template_layers(template)
+
+    def on_template_closed(self, template):
+        """React to leaving a template: drop its map group and clear the search table."""
+        if template is not None:
+            self._remove_template_group(str(template.name))
+        self.app_context.open_template_results_id = None
+        self._template_search_aoi_filter = None
+        self.dlg.metadataTable.clearContents()
+        self.dlg.metadataTable.setRowCount(0)
+
+    def _remove_template_group(self, template_group_name: str):
+        """Remove the template's layer-tree group (and its layers) from the map."""
+        if not template_group_name:
             return
-        self.processing_service.api.get_template(
-            template_id=template.id,
-            callback=self._template_hydrated_callback,
-        )
-
-    @staticmethod
-    def _template_has_aoi(template) -> bool:
-        try:
-            return bool(template._aoi_features())
-        except Exception:
-            return False
-
-    def _template_hydrated_callback(self, response: QNetworkReply):
-        """Replace the stored template with its full (searchParams-bearing) version,
-        then open its results and linked-processing AOIs."""
-        try:
-            data = json.loads(response.readAll().data())
-            if isinstance(data, dict) and "template" in data:
-                hydrated = ProcessingTemplateDetails.from_dict(data).template
-            elif isinstance(data, dict):
-                hydrated = ProcessingTemplateDTO.from_dict(data)
-            else:
-                hydrated = None
-            if hydrated is not None:
-                self.processing_service.templates[hydrated.id] = hydrated
-        except Exception:
-            pass
-        self.show_template_search_results()
-        self.select_template_processings()
+        root = self.app_context.project.layerTreeRoot()
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        mapflow_group = root.findGroup(mapflow_group_name)
+        parent_group = mapflow_group if mapflow_group else root
+        template_group = parent_group.findGroup(template_group_name)
+        if template_group is None:
+            return
+        for layer in template_group.findLayers():
+            layer_id = layer.layerId()
+            if layer_id:
+                try:
+                    self.app_context.project.removeMapLayer(layer_id)
+                except (RuntimeError, KeyError):
+                    pass
+        parent_group.removeChildNode(template_group)
 
     def load_results(self):
         # Check if it's a template first

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -847,6 +847,9 @@ class Mapflow(QObject):
             if imagery_search_tab:
                 self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
 
+        # A template's search results always load from the first page — pagination is per-load
+        # context (template / selected AOI) and must not carry over from a previous one.
+        self.search_page_offset = 0
         if aoi_ids is None:
             aoi_ids = self._aoi_ids_from_template(template)
         self.processing_service.api.get_template_images(
@@ -3090,6 +3093,9 @@ class Mapflow(QObject):
         self._template_search_aoi_filter = None
         self.dlg.metadataTable.clearContents()
         self.dlg.metadataTable.setRowCount(0)
+        # Clear the template search-results pagination so it is not preserved on re-open.
+        self.search_page_offset = 0
+        self.dlg.enable_search_pages(False)
 
     def _remove_template_group(self, template_group_name: str):
         """Remove the template's layer-tree group (and its layers) from the map."""

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -20,8 +20,8 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtXml import QDomDocument
 from qgis.core import (
-    Qgis, QgsCoordinateReferenceSystem, QgsDistanceArea, QgsFeature, QgsGeometry, 
-    QgsMapLayer, QgsMapLayerType, QgsPoint, QgsProject, QgsRasterLayer, 
+    Qgis, QgsCoordinateReferenceSystem, QgsDistanceArea, QgsFeature, QgsGeometry,
+    QgsLayerTreeLayer, QgsMapLayer, QgsMapLayerType, QgsPoint, QgsProject, QgsRasterLayer,
     QgsRectangle, QgsVectorLayer, QgsWkbTypes
 )
 
@@ -62,11 +62,11 @@ from .schema.catalog import (MultiPreviewList,
                              PreviewType,
                              ProductType)
 from .schema.project import MapflowProject
-from .schema.processing import (AOI_NAME_MAX_LENGTH,
-                                AddAoisSchema,
-                                AddSingleAoiSchema,
-                                CreateProcessingTemplateSchema,
-                                SearchParams)
+from .schema.template import (AOI_NAME_MAX_LENGTH,
+                              AddAoisSchema,
+                              AddSingleAoiSchema,
+                              CreateProcessingTemplateSchema,
+                              SearchParams)
 from .schema.workflow_def import WorkflowDef
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
@@ -94,6 +94,9 @@ class Mapflow(QObject):
     # The AOI id the in-template search results are currently filtered by (None = all).
     # Class-level default so the check is safe before on_template_opened sets it.
     _template_search_aoi_filter = None
+    # Id of the currently shown mosaic-preview boundary layer, so it can be removed when the
+    # next preview is shown (its name varies by acquisition date, so name-match alone misses it).
+    _mosaic_preview_footprint_id = None
 
     def __init__(self, iface) -> None:
         """Initialize the plugin.
@@ -720,6 +723,34 @@ class Mapflow(QObject):
                     template_group_name=template_group_name,
                     subgroup_name=subgroup_name,
                 )
+
+    def _relocate_preview_to_template_group(self, layer) -> None:
+        """In the in-template view, move a freshly added preview layer into the template's
+        map group, above the search-results footprints and below the AOI subgroups, so the
+        precedence is AOIs (top) > previews > search results (bottom)."""
+        service = self.processing_service
+        if not layer or not service.in_template_mode or not service.active_template:
+            return
+        try:
+            template_group = self._template_group_target(str(service.active_template.name))
+            root = self.app_context.project.layerTreeRoot()
+            node = root.findLayer(layer.id())
+            if node is None or template_group is None:
+                return
+            footprints_layer = getattr(self.app_context, 'metadata_layer', None)
+            footprints_id = footprints_layer.id() if footprints_layer else None
+            children = template_group.children()
+            # Default to the bottom; otherwise insert directly above the footprints layer
+            # (which itself sits below the AOI/processing subgroups).
+            insert_index = len(children)
+            for i, child in enumerate(children):
+                if isinstance(child, QgsLayerTreeLayer) and child.layerId() == footprints_id:
+                    insert_index = i
+                    break
+            template_group.insertChildNode(insert_index, node.clone())
+            (node.parent() or root).removeChildNode(node)
+        except (AttributeError, RuntimeError):
+            return
 
     def _add_geojson_aoi_layer(self,
                                features: list,
@@ -1380,42 +1411,53 @@ class Mapflow(QObject):
         self.get_metadata()
 
     def _build_template_aoi_details(self) -> Optional[dict]:
-        """Build a GeoJSON FeatureCollection of the AOI layer's features for template creation.
+        """Build the ``searchParams.aoiDetails`` FeatureCollection for template creation.
 
         Each feature carries ``properties.name`` from the layer's ``name`` attribute (when
-        present), so the backend persists named AOIs (parsed as ``InputAoiProperties``).
-        Returns ``None`` when there is no usable polygon layer, so the caller falls back to
-        the combined ``aoi`` geometry. Raises ``ValueError`` if a name exceeds the limit.
+        present), so the backend persists named AOIs (parsed as ``InputAoiProperties``; the
+        name is optional). When the AOI does not come from a polygon layer (e.g. an
+        image/mosaic extent), a single unnamed feature is built from ``app_context.aoi``.
+
+        ``aoiDetails`` is always used — the legacy plain ``aoi`` field is deprecated because
+        names cannot be attached to it. Returns ``None`` only when there is no AOI at all.
+        Raises ``ValueError`` if a name exceeds the limit.
         """
         layer = self.dlg.polygonCombo.currentLayer()
-        if not layer or layer.featureCount() == 0:
-            return None
-        source_features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
-        if not source_features:
-            return None
-        has_name_field = layer.fields().indexFromName("name") != -1
+        source_features = []
+        if layer is not None and layer.featureCount():
+            source_features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
         features = []
-        for feature in source_features:
-            geom = feature.geometry()
-            if geom is None or geom.isEmpty():
-                continue
-            wgs_geom = helpers.to_wgs84(QgsGeometry(geom), layer.crs())
-            name = None
-            if has_name_field:
-                raw = feature.attribute("name")
-                # QGIS NULL attributes are not None; normalize to a real None.
-                if raw not in (None, "") and str(raw).upper() != "NULL":
-                    name = str(raw).strip()
-            if name and len(name) > AOI_NAME_MAX_LENGTH:
-                raise ValueError(
-                    self.tr("AOI name '{name}' exceeds {limit} characters").format(
-                        name=name, limit=AOI_NAME_MAX_LENGTH
+        if source_features:
+            has_name_field = layer.fields().indexFromName("name") != -1
+            for feature in source_features:
+                geom = feature.geometry()
+                if geom is None or geom.isEmpty():
+                    continue
+                wgs_geom = helpers.to_wgs84(QgsGeometry(geom), layer.crs())
+                name = None
+                if has_name_field:
+                    raw = feature.attribute("name")
+                    # QGIS NULL attributes are not None; normalize to a real None.
+                    if raw not in (None, "") and str(raw).upper() != "NULL":
+                        name = str(raw).strip()
+                if name and len(name) > AOI_NAME_MAX_LENGTH:
+                    raise ValueError(
+                        self.tr("AOI name '{name}' exceeds {limit} characters").format(
+                            name=name, limit=AOI_NAME_MAX_LENGTH
+                        )
                     )
-                )
+                features.append({
+                    "type": "Feature",
+                    "geometry": json.loads(wgs_geom.asJson()),
+                    "properties": {"name": name},
+                })
+        # Fall back to the combined AOI (e.g. image/mosaic extent) as one unnamed feature,
+        # so we still send aoiDetails rather than the deprecated plain `aoi`.
+        if not features and self.app_context.aoi:
             features.append({
                 "type": "Feature",
-                "geometry": json.loads(wgs_geom.asJson()),
-                "properties": {"name": name},
+                "geometry": json.loads(self.app_context.aoi.asJson()),
+                "properties": {"name": None},
             })
         if not features:
             return None
@@ -1458,9 +1500,13 @@ class Mapflow(QObject):
         except ValueError as e:
             self.alert(str(e), QMessageBox.Warning)
             return
+        if not aoi_details:
+            self.alert(self.tr('Please, select a valid area of interest'))
+            return
 
+        # Always send aoiDetails (FeatureCollection); the plain `aoi` field is deprecated
+        # because per-AOI names cannot be attached to it.
         search_params = SearchParams(
-            aoi=json.loads(self.app_context.aoi.asJson()),
             aoiDetails=aoi_details,
             acquisitionDateFrom=from_time,
             acquisitionDateTo=to_time,
@@ -2374,10 +2420,29 @@ class Mapflow(QObject):
         self.alert(self.tr("Sorry, we couldn't load the image"))
         self.report_http_error(response, self.tr('Error previewing Sentinel imagery'))
 
+    def _move_layer_to_top(self, layer_id: str) -> bool:
+        """Move an existing layer's tree node to the top of its parent group."""
+        root = self.app_context.project.layerTreeRoot()
+        node = root.findLayer(layer_id)
+        if not node:
+            return False
+        parent = node.parent() or root
+        parent.insertChildNode(0, node.clone())
+        parent.removeChildNode(node)
+        return True
+
     def preview_catalog(self, image_id):
         feature = self.metadata_feature(image_id)
         if not feature:
             self.alert(self.tr("Preview is unavailable when metadata layer is removed"))
+            return
+        # If this image's preview is already on the map (layers are named "<image_id> preview"),
+        # just bring it to the top instead of downloading and adding a duplicate.
+        existing_preview = self.app_context.project.mapLayersByName(f"{image_id} preview")
+        if existing_preview:
+            self._move_layer_to_top(existing_preview[0].id())
+            self.iface.setActiveLayer(existing_preview[0])
+            self.iface.mapCanvas().refresh()
             return
         footprint = self.metadata_footprint(feature=feature)
         url = feature.attribute('previewUrl')
@@ -2478,13 +2543,14 @@ class Mapflow(QObject):
         Display image preview using Ground Control Points from footprint corners.
         Delegates to ResultsLoader.display_preview_with_gcp().
         """
-        self.result_loader.display_preview_with_gcp(
+        layer = self.result_loader.display_preview_with_gcp(
             response=response,
             footprint=footprint,
             crs=crs,
             image_name=image_id,
             add_aoi=True
         )
+        self._relocate_preview_to_template_group(layer)
 
     def preview_multiple_png(self,
                              response: QNetworkReply,
@@ -2508,6 +2574,7 @@ class Mapflow(QObject):
             vrt_layer = QgsRasterLayer(vrt_path, "{image_id} preview".format(image_id=image_id), 'gdal')
             self.result_loader.add_layer(vrt_layer)
             self.result_loader.add_aoi_to_preview()
+            self._relocate_preview_to_template_group(vrt_layer)
             return
         # Requset part: remove first image from the list and get its preview
         image_to_preview = previews.pop(0)
@@ -2537,6 +2604,7 @@ class Mapflow(QObject):
                             if layer.dataProvider().dataSourceUri() == tile_layer.dataProvider().dataSourceUri()]
         self.app_context.project.removeMapLayers(tiles_to_delete)
         self.result_loader.add_layer(layer=tile_layer, order=0)
+        self._relocate_preview_to_template_group(tile_layer)
         # Add footprint layer
         if feature:
             footprint_layer = QgsVectorLayer("Polygon?crs=EPSG:4326",
@@ -2545,10 +2613,16 @@ class Mapflow(QObject):
             footprint_layer.dataProvider().addFeatures([feature])
             footprint_layer.updateExtents()
             footprint_layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata_footprint.qml'))
+            # Remove same-named boundaries AND the previously shown one (its name varies by
+            # acquisition date, so a name match alone leaves the old boundary on the map).
             footprints_to_delete = [layer.id() for layer in self.app_context.project.mapLayers().values()
                                     if layer.name() == footprint_layer.name()]
+            if self._mosaic_preview_footprint_id:
+                footprints_to_delete.append(self._mosaic_preview_footprint_id)
             self.app_context.project.removeMapLayers(footprints_to_delete)
             self.result_loader.add_layer(layer=footprint_layer, order=0)
+            self._mosaic_preview_footprint_id = footprint_layer.id()
+            self._relocate_preview_to_template_group(footprint_layer)
         self.result_loader.add_aoi_to_preview()
 
     def preview_sentinel(self, image_id):

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -559,6 +559,22 @@ class Mapflow(QObject):
         if self.dlg.processingProblemsLabel.text() == planned_reason:
             self.dlg.processingProblemsLabel.clear()
 
+    def _template_single_data_provider(self, template) -> Optional[str]:
+        """The template's sole search data provider, used to backfill an image's providerName
+        when the backend returns it null. ``None`` when the template searches zero or several
+        providers (then we cannot attribute an image to one)."""
+        if not template:
+            return None
+        search_params = getattr(template, "searchParams", None)
+        if isinstance(search_params, SearchParams):
+            providers = search_params.dataProviders
+        elif isinstance(search_params, dict):
+            providers = search_params.get("dataProviders")
+        else:
+            providers = None
+        providers = [p for p in (providers or []) if p]
+        return providers[0] if len(providers) == 1 else None
+
     def get_selected_template_callback(self, response: QNetworkReply, template=None):
         """Render a template's search results in the search table.
 
@@ -580,8 +596,16 @@ class Mapflow(QObject):
         response_data = ImageCatalogResponseSchema(**response_json)
         images = response_data.images
         geoms = response_data.as_geojson()
+        # Template search images may omit per-image providerName; without it a planned
+        # processing (and its cost) cannot resolve `dataProvider` and the backend rejects the
+        # request. Backfill from the template's own searchParams.dataProviders when it searches
+        # a single provider (multi-provider templates rely on the backend providing it).
+        template_provider = self._template_single_data_provider(template)
         for position, feature in enumerate(geoms.get("features", ())):
-            feature["properties"]["local_index"] = position
+            props = feature.setdefault("properties", {})
+            props["local_index"] = position
+            if not props.get("providerName") and template_provider:
+                props["providerName"] = template_provider
         # Footprints must keep the real providerName/productType so that a planned
         # processing started from these results can resolve its source params (dataProvider).
         self._store_template_search_footprints(geoms, template_group_name=template_group_name)

--- a/mapflow/schema/__init__.py
+++ b/mapflow/schema/__init__.py
@@ -18,6 +18,21 @@ from .processing import (PostSourceSchema,
                          ProcessingSortOrder,
                          ProcessingsRequest,
                          ProcessingsResult)
+from .template import (AOI_NAME_MAX_LENGTH,
+                       SearchParams,
+                       ProcessingTemplateDTO,
+                       ProcessingTemplateDetails,
+                       TemplateAoiDTO,
+                       AoiProcessingLink,
+                       NoAoiProcessingsRow,
+                       TemplateProcessingSchema,
+                       CreateProcessingTemplateSchema,
+                       UpdateProcessingTemplateSchema,
+                       RunTemplateProcessingSchema,
+                       UpdateAoiSchema,
+                       AddSingleAoiSchema,
+                       AddAoisSchema,
+                       DeleteAoisSchema)
 from .provider import ProviderReturnSchema
 from .workflow_def import WorkflowDef, BlockConfig
 from .status import ProcessingStatus, ProcessingReviewStatus

--- a/mapflow/schema/processing.py
+++ b/mapflow/schema/processing.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Mapping, Any, Union, Iterable, List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from .base import SkipDataClass, Serializable, parse_api_datetime_utc
 from .status import ProcessingStatus, ProcessingReviewStatus
@@ -122,9 +122,13 @@ class ProcessingParams(Serializable, SkipDataClass):
     def from_dict(cls, params_dict: Optional[dict]):
         if not params_dict:
             return None
-        clsf = [f.name for f in fields(cls)]
-        processing_params = cls(**{k: v for k, v in params_dict.items() if k in clsf})
-        source_params = processing_params.sourceParams
+        # The template `/processings` endpoint returns legacy flat params
+        # (e.g. {"url", "zoom", "data_provider"}) instead of the v2 {"sourceParams": {...}}
+        # shape. Without sourceParams there is nothing to resolve — return None rather
+        # than raise (a raise here would drop the whole processing from the list).
+        source_params = params_dict.get("sourceParams")
+        if not isinstance(source_params, dict):
+            return None
 
         if source_params.get("dataProvider"):
             source_params = DataProviderParams(DataProviderSchema(**source_params.get("dataProvider")))
@@ -261,17 +265,25 @@ class ProcessingTemplateDTO(Serializable, SkipDataClass):
 
     @property
     def table_status(self) -> str:
-        if (self.status or "").upper() == "FAILED":
+        """Template status for the processings/templates list:
+        - ``Searching`` while the initial (or a re-run) search is in progress;
+        - ``Failed`` on error;
+        - ``Created`` once ready but not yet checked (``lastCheckedAt`` is null);
+        - ``Updated`` after the first daily check, with a ``(newImagesCount)`` tag when there
+          are unseen images.
+        """
+        status = (self.status or "").upper()
+        if status == "FAILED":
             return "Failed"
+        if status == "SEARCHING":
+            return "Searching"
         if not self.isActive:
             return "Inactive"
-        if self.lastCheckedAt:
-            status = "Updated"
-        else:
-            status = "Created"
+        if not self.lastCheckedAt:
+            return "Created"
         if self.newImagesCount and self.newImagesCount > 0:
-            return f"{status} ({self.newImagesCount})"
-        return status
+            return f"Updated ({self.newImagesCount})"
+        return "Updated"
 
     def as_processing_table_dict(self):
         return {
@@ -285,6 +297,215 @@ class ProcessingTemplateDTO(Serializable, SkipDataClass):
             "reviewUntil": None,
             "id": self.id,
         }
+
+    def aoi_dtos(self) -> "List[TemplateAoiDTO]":
+        """Parse the template's AOIs (with names and linked processings) from aoiDetails."""
+        return [TemplateAoiDTO.from_feature(f) for f in self._aoi_features()]
+
+
+# Backend rejects AOI names longer than this; mirror the check client-side.
+AOI_NAME_MAX_LENGTH = 64
+
+
+@dataclass
+class AoiProcessingLink(Serializable, SkipDataClass):
+    """A processing launched for a template AOI (from aoiDetails feature properties).
+
+    Carries enough to display the processing as a grouped row under its AOI and to draw
+    its footprint on the map. For actions that need layers (load results), look the full
+    processing up by ``processingId`` in the ``/processings`` list (``TemplateProcessingSchema``).
+    """
+    processingId: Optional[str] = None
+    processingName: Optional[str] = None
+    processingStatus: Optional[str] = None
+    area: Optional[float] = None  # square metres, as reported by the backend
+    projectId: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+
+    @property
+    def is_aoi_processing(self) -> bool:
+        return True
+
+    @property
+    def id(self) -> str:
+        """Row id (matches ``as_processing_table_dict``); used for table selection restore."""
+        return str(self.processingId) if self.processingId else ""
+
+    @property
+    def aoi_area(self) -> Optional[float]:
+        if self.area is None:
+            return None
+        try:
+            return round(float(self.area) / 1e6, 4)
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def display_status(self) -> str:
+        raw = self.processingStatus or ""
+        try:
+            return ProcessingStatus(raw).display_value
+        except (ValueError, KeyError):
+            return raw
+
+    def as_processing_table_dict(self):
+        return {
+            "name": self.processingName,
+            "workflowDef": "",  # not provided by aoiDetails; grouped under its AOI
+            "status": self.display_status,
+            "percentCompleted": "N/A",
+            "aoiArea": self.aoi_area,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": str(self.processingId) if self.processingId else "",
+        }
+
+
+@dataclass
+class TemplateAoiDTO(Serializable, SkipDataClass):
+    """One AOI of a template, parsed from an aoiDetails GeoJSON feature.
+
+    Mirrors the backend ``TemplateAoiProperties`` (id, name, processings, hasNewImages).
+    ``table_id`` is a stable-per-render key for the processings table: the real AOI id
+    when present, otherwise a synthetic one (AOIs without ids cannot be renamed/deleted).
+    """
+    id: Optional[str] = None
+    name: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+    processings: List[AoiProcessingLink] = field(default_factory=list)
+    hasNewImages: bool = False
+    table_id: str = ""
+
+    def __post_init__(self):
+        if not self.table_id:
+            self.table_id = str(self.id) if self.id else f"aoi-{uuid4().hex}"
+
+    @classmethod
+    def from_feature(cls, feature: Mapping[str, Any]) -> "TemplateAoiDTO":
+        feature = feature or {}
+        props = feature.get("properties") or {}
+        aoi_id = feature.get("id") or props.get("id")
+        processings = [
+            AoiProcessingLink.from_dict(p)
+            for p in (props.get("processings") or [])
+            if isinstance(p, dict)
+        ]
+        return cls(
+            id=str(aoi_id) if aoi_id else None,
+            name=props.get("name"),
+            geometry=feature.get("geometry"),
+            processings=processings,
+            hasNewImages=bool(props.get("hasNewImages", False)),
+        )
+
+    @property
+    def is_aoi(self) -> bool:
+        return True
+
+    @property
+    def can_rename(self) -> bool:
+        """Only AOIs with a persisted id can be renamed/deleted via the per-AOI endpoint."""
+        return self.id is not None
+
+    @property
+    def display_name(self) -> str:
+        return self.name if self.name else "(unnamed)"  #! Translate
+
+    @property
+    def aoi_area(self) -> Optional[float]:
+        if not self.geometry:
+            return None
+        try:
+            calculator = make_distance_calculator()
+            total = geojson_feature_area_sqkm(
+                {"type": "Feature", "geometry": self.geometry, "properties": {}},
+                calculator,
+            )
+            return round(total, 4) if total else None
+        except Exception:
+            return None
+
+    @property
+    def table_status(self) -> str:
+        """Aggregate status of the AOI's processings:
+        - any in progress / awaiting → ``In progress (ok/total)``;
+        - else any failed → ``Failed (ok/total)``;
+        - else all ok → ``OK (total)``.
+        """
+        statuses = [(p.processingStatus or "").upper() for p in self.processings]
+        total = len(statuses)
+        if total == 0:
+            return "—"
+        ok = sum(1 for s in statuses if s == "OK")
+        in_progress = sum(1 for s in statuses if s in ("IN_PROGRESS", "AWAITING"))
+        failed = sum(1 for s in statuses if s == "FAILED")
+        if in_progress:
+            return f"In progress ({ok}/{total})"  #! Translate
+        if failed:
+            return f"Failed ({ok}/{total})"  #! Translate
+        if ok == total:
+            return f"OK ({total})"  #! Translate
+        return f"OK ({ok}/{total})"  #! Translate
+
+    def as_processing_table_dict(self):
+        return {
+            "name": self.display_name,
+            "workflowDef": "AOI",  #! Translate
+            "status": self.table_status,
+            "percentCompleted": "N/A",
+            "aoiArea": self.aoi_area,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": self.table_id,
+        }
+
+
+@dataclass
+class NoAoiProcessingsRow(Serializable, SkipDataClass):
+    """Separator row introducing processings attached to the template but not intersecting
+    any of its AOIs (the backend omits them from ``aoiDetails``)."""
+    id: str = ""
+
+    @property
+    def is_separator(self) -> bool:
+        return True
+
+    def as_processing_table_dict(self):
+        return {
+            "name": "No AOI",  #! Translate
+            "workflowDef": "",
+            "status": "",
+            "percentCompleted": "",
+            "aoiArea": None,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": "",
+        }
+
+
+@dataclass
+class UpdateAoiSchema(Serializable, SkipDataClass):
+    name: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+
+
+@dataclass
+class AddSingleAoiSchema(Serializable, SkipDataClass):
+    geometry: Mapping[str, Any]
+    name: Optional[str] = None
+
+
+@dataclass
+class AddAoisSchema(Serializable, SkipDataClass):
+    aois: List[AddSingleAoiSchema]
+
+
+@dataclass
+class DeleteAoisSchema(Serializable, SkipDataClass):
+    aoiIds: List[str]
 
 
 @dataclass
@@ -401,8 +622,8 @@ class ProcessingDTO(Serializable, SkipDataClass):
         return {
             "name": self.name,
             "workflowDef": self.workflowDef.name,
-            "status": self.reviewStatus.reviewStatus.display_value 
-                      if (self.reviewStatus and not self.reviewStatus.is_none) 
+            "status": self.reviewStatus.reviewStatus.display_value
+                      if (self.reviewStatus and not self.reviewStatus.is_none)
                       else self.status.display_value,
             "percentCompleted": self.percentCompleted,
             "aoiArea": self.aoiArea/1000000,
@@ -410,6 +631,68 @@ class ProcessingDTO(Serializable, SkipDataClass):
             "created": self.created.astimezone().strftime('%Y-%m-%d %H:%M'),
             "reviewUntil": self.reviewUntil,
             "id": self.id
+        }
+
+
+@dataclass
+class TemplateProcessingSchema(Serializable, SkipDataClass):
+    """A processing as returned by ``GET /processings/template/{id}/processings``.
+
+    This endpoint serves the v1 ``ProcessingJson`` shape, whose ``params`` is a flat
+    ``Map[String,String]`` (e.g. ``{url, zoom, data_provider}``) — NOT the v2
+    ``{sourceParams: {...}}`` used elsewhere. There is no v2 variant of this endpoint, so
+    a dedicated schema keeps the flat params instead of forcing it through ``ProcessingDTO``
+    (whose ``ProcessingParams`` parsing would discard or choke on the flat shape).
+
+    It still carries the result layers, so a processing listed here can be loaded.
+    """
+    id: UUID
+    name: str
+    projectId: UUID
+    status: ProcessingStatus
+    workflowDef: WorkflowDef
+    created: datetime
+    rasterLayer: RasterLayer
+    vectorLayer: VectorLayer
+    params: Optional[Mapping[str, str]] = None  # v1 flat params, kept as-is
+    description: Optional[str] = None
+    aoiArea: Optional[int] = None
+    area: Optional[int] = None
+    cost: Optional[int] = None
+    percentCompleted: Optional[int] = None
+    blocks: Optional[List[BlockOption]] = None
+    messages: Optional[List[ErrorMessage]] = None
+    reviewStatus: Optional[ProcessingReviewStatus] = None
+
+    def __post_init__(self):
+        self.status = ProcessingStatus(self.status)
+        self.created = _parse_iso_datetime(self.created)
+        self.rasterLayer = RasterLayer.from_dict(self.rasterLayer)
+        self.vectorLayer = VectorLayer.from_dict(self.vectorLayer)
+        self.workflowDef = WorkflowDef.from_dict(self.workflowDef)
+        self.blocks = [BlockOption.from_dict(b) for b in (self.blocks or [])]
+        self.messages = [ErrorMessage.from_response(m) for m in (self.messages or [])]
+        if self.reviewStatus is None:
+            self.reviewStatus = ProcessingReviewStatus()
+        else:
+            self.reviewStatus = ProcessingReviewStatus.from_dict(self.reviewStatus)
+
+    @property
+    def is_final_state(self) -> bool:
+        return self.status.is_terminal and not self.reviewStatus.is_not_accepted
+
+    def as_processing_table_dict(self):
+        area = (self.aoiArea if self.aoiArea is not None else self.area) or 0
+        return {
+            "name": self.name,
+            "workflowDef": self.workflowDef.name if self.workflowDef else "",
+            "status": self.status.display_value,
+            "percentCompleted": self.percentCompleted,
+            "aoiArea": area / 1e6,
+            "cost": self.cost,
+            "created": self.created.astimezone().strftime('%Y-%m-%d %H:%M'),
+            "reviewUntil": None,
+            "id": self.id,
         }
 
 

--- a/mapflow/schema/processing.py
+++ b/mapflow/schema/processing.py
@@ -1,9 +1,9 @@
 from enum import Enum
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Mapping, Any, Union, Iterable, List
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from .base import SkipDataClass, Serializable, parse_api_datetime_utc
 from .status import ProcessingStatus, ProcessingReviewStatus
@@ -11,7 +11,12 @@ from .layer import RasterLayer, VectorLayer
 from .workflow_def import WorkflowDef
 from ..entity.provider.provider import SourceType
 from ..errors import ErrorMessage
-from ..functional.geometry import geojson_feature_area_sqkm, make_distance_calculator
+
+
+def _parse_iso_datetime(dt_str: str) -> datetime:
+    """Parse ISO 8601 datetime strings with or without microseconds."""
+    return parse_api_datetime_utc(dt_str)
+
 
 @dataclass
 class PostSourceSchema(Serializable, SkipDataClass):
@@ -20,7 +25,7 @@ class PostSourceSchema(Serializable, SkipDataClass):
     projection: Optional[str] = None
     raster_login: Optional[str] = None
     raster_password: Optional[str] = None
-    zoom: Optional[str] = None    
+    zoom: Optional[str] = None
 
 
 @dataclass
@@ -117,7 +122,7 @@ class ProcessingParams(Serializable, SkipDataClass):
                         MyImageryParams,
                         ImagerySearchParams,
                         UserDefinedParams]
-    
+
     @classmethod
     def from_dict(cls, params_dict: Optional[dict]):
         if not params_dict:
@@ -154,397 +159,6 @@ class PostProcessingSchemaV2(Serializable):
     params: ProcessingParams
     meta: Optional[Mapping[str, Any]]
     blocks: Optional[Iterable[BlockOption]]
-
-
-def _parse_iso_datetime(dt_str: str) -> datetime:
-    """Parse ISO 8601 datetime strings with or without microseconds."""
-    return parse_api_datetime_utc(dt_str)
-
-
-@dataclass
-class SearchParams(Serializable, SkipDataClass):
-    aoiDetails: Optional[Mapping[str, Any]] = None
-    aoi: Optional[Mapping[str, Any]] = None
-    acquisitionDateFrom: Optional[str] = None
-    acquisitionDateTo: Optional[str] = None
-    minResolution: Optional[float] = None
-    maxResolution: Optional[float] = None
-    maxCloudCover: Optional[float] = None
-    minOffNadirAngle: Optional[float] = None
-    maxOffNadirAngle: Optional[float] = None
-    minAoiIntersectionPercent: Optional[float] = None
-    maxAoiIntersectionPercent: Optional[float] = None
-    returnErrors: Optional[bool] = None
-    limit: Optional[int] = None
-    offset: Optional[int] = None
-    hideUnavailable: Optional[bool] = None
-    dataProviders: Optional[List[str]] = None
-    productTypes: Optional[List[str]] = None
-
-
-@dataclass
-class ProcessingTemplateDTO(Serializable, SkipDataClass):
-    id: UUID
-    name: str
-    status: str
-    createdAt: datetime
-    userId: UUID
-    searchParams: SearchParams
-    projectId: UUID
-    activeUntil: datetime
-    processingParams: Optional[Mapping[str, Any]] = None
-    lastCheckedAt: Optional[datetime] = None
-    newImagesCount: Optional[int] = None
-    isActive: bool = False
-    isArchived: bool = False
-    maxAoiIntersectionPercent: Optional[float] = None
-    area: Optional[float] = None  # AOI area in square metres, as reported by the backend
-
-    def __post_init__(self):
-        self.createdAt = _parse_iso_datetime(self.createdAt)
-        if self.lastCheckedAt:
-            self.lastCheckedAt = _parse_iso_datetime(self.lastCheckedAt)
-        self.activeUntil = _parse_iso_datetime(self.activeUntil)
-        if isinstance(self.searchParams, dict):
-            self.searchParams = SearchParams.from_dict(self.searchParams)
-
-    @property
-    def is_template(self) -> bool:
-        return True
-
-    def _aoi_features(self):
-        """Return template AOI features from either aoiDetails or aoi shape."""
-        if isinstance(self.searchParams, SearchParams):
-            aoi_details = self.searchParams.aoiDetails
-            if aoi_details:
-                return (aoi_details or {}).get("features", [])
-            if self.searchParams.aoi:
-                return [{
-                    "type": "Feature",
-                    "geometry": self.searchParams.aoi,
-                    "properties": {},
-                }]
-            return []
-
-        search_params = self.searchParams or {}
-        aoi_details = search_params.get("aoiDetails", {})
-        if aoi_details:
-            return (aoi_details or {}).get("features", [])
-
-        aoi = search_params.get("aoi")
-        if aoi:
-            return [{
-                "type": "Feature",
-                "geometry": aoi,
-                "properties": {},
-            }]
-        return []
-
-    @property
-    def aoi_area(self) -> Optional[float]:
-        """Total AOI area in sq km.
-
-        Prefers the backend-provided ``area`` (square metres), which the project
-        template list returns even though it omits ``searchParams``. Falls back to
-        computing from ``searchParams.aoiDetails`` when ``area`` is absent.
-        """
-        if self.area is not None:
-            try:
-                return round(float(self.area) / 1e6, 4)
-            except (TypeError, ValueError):
-                pass
-        try:
-            features = self._aoi_features()
-            if not features:
-                return None
-            calculator = make_distance_calculator()
-            total = sum(geojson_feature_area_sqkm(f, calculator) for f in features)
-            return round(total, 4) if total else None
-        except Exception:
-            return None
-
-    @property
-    def table_status(self) -> str:
-        """Template status for the processings/templates list:
-        - ``Searching`` while the initial (or a re-run) search is in progress;
-        - ``Failed`` on error;
-        - ``Created`` once ready but not yet checked (``lastCheckedAt`` is null);
-        - ``Updated`` after the first daily check, with a ``(newImagesCount)`` tag when there
-          are unseen images.
-        """
-        status = (self.status or "").upper()
-        if status == "FAILED":
-            return "Failed"
-        if status == "SEARCHING":
-            return "Searching"
-        if not self.isActive:
-            return "Inactive"
-        if not self.lastCheckedAt:
-            return "Created"
-        if self.newImagesCount and self.newImagesCount > 0:
-            return f"Updated ({self.newImagesCount})"
-        return "Updated"
-
-    def as_processing_table_dict(self):
-        return {
-            "name": self.name,
-            "workflowDef": "Planned", #! Translate
-            "status": self.table_status,
-            "percentCompleted": "N/A",
-            "aoiArea": self.aoi_area,
-            "cost": None,
-            "created": self.createdAt.astimezone().strftime('%Y-%m-%d %H:%M'),
-            "reviewUntil": None,
-            "id": self.id,
-        }
-
-    def aoi_dtos(self) -> "List[TemplateAoiDTO]":
-        """Parse the template's AOIs (with names and linked processings) from aoiDetails."""
-        return [TemplateAoiDTO.from_feature(f) for f in self._aoi_features()]
-
-
-# Backend rejects AOI names longer than this; mirror the check client-side.
-AOI_NAME_MAX_LENGTH = 64
-
-
-@dataclass
-class AoiProcessingLink(Serializable, SkipDataClass):
-    """A processing launched for a template AOI (from aoiDetails feature properties).
-
-    Carries enough to display the processing as a grouped row under its AOI and to draw
-    its footprint on the map. For actions that need layers (load results), look the full
-    processing up by ``processingId`` in the ``/processings`` list (``TemplateProcessingSchema``).
-    """
-    processingId: Optional[str] = None
-    processingName: Optional[str] = None
-    processingStatus: Optional[str] = None
-    area: Optional[float] = None  # square metres, as reported by the backend
-    projectId: Optional[str] = None
-    geometry: Optional[Mapping[str, Any]] = None
-
-    @property
-    def is_aoi_processing(self) -> bool:
-        return True
-
-    @property
-    def id(self) -> str:
-        """Row id (matches ``as_processing_table_dict``); used for table selection restore."""
-        return str(self.processingId) if self.processingId else ""
-
-    @property
-    def aoi_area(self) -> Optional[float]:
-        if self.area is None:
-            return None
-        try:
-            return round(float(self.area) / 1e6, 4)
-        except (TypeError, ValueError):
-            return None
-
-    @property
-    def display_status(self) -> str:
-        raw = self.processingStatus or ""
-        try:
-            return ProcessingStatus(raw).display_value
-        except (ValueError, KeyError):
-            return raw
-
-    def as_processing_table_dict(self):
-        return {
-            "name": self.processingName,
-            "workflowDef": "",  # not provided by aoiDetails; grouped under its AOI
-            "status": self.display_status,
-            "percentCompleted": "N/A",
-            "aoiArea": self.aoi_area,
-            "cost": None,
-            "created": "",
-            "reviewUntil": None,
-            "id": str(self.processingId) if self.processingId else "",
-        }
-
-
-@dataclass
-class TemplateAoiDTO(Serializable, SkipDataClass):
-    """One AOI of a template, parsed from an aoiDetails GeoJSON feature.
-
-    Mirrors the backend ``TemplateAoiProperties`` (id, name, processings, hasNewImages).
-    ``table_id`` is a stable-per-render key for the processings table: the real AOI id
-    when present, otherwise a synthetic one (AOIs without ids cannot be renamed/deleted).
-    """
-    id: Optional[str] = None
-    name: Optional[str] = None
-    geometry: Optional[Mapping[str, Any]] = None
-    processings: List[AoiProcessingLink] = field(default_factory=list)
-    hasNewImages: bool = False
-    table_id: str = ""
-
-    def __post_init__(self):
-        if not self.table_id:
-            self.table_id = str(self.id) if self.id else f"aoi-{uuid4().hex}"
-
-    @classmethod
-    def from_feature(cls, feature: Mapping[str, Any]) -> "TemplateAoiDTO":
-        feature = feature or {}
-        props = feature.get("properties") or {}
-        aoi_id = feature.get("id") or props.get("id")
-        processings = [
-            AoiProcessingLink.from_dict(p)
-            for p in (props.get("processings") or [])
-            if isinstance(p, dict)
-        ]
-        return cls(
-            id=str(aoi_id) if aoi_id else None,
-            name=props.get("name"),
-            geometry=feature.get("geometry"),
-            processings=processings,
-            hasNewImages=bool(props.get("hasNewImages", False)),
-        )
-
-    @property
-    def is_aoi(self) -> bool:
-        return True
-
-    @property
-    def can_rename(self) -> bool:
-        """Only AOIs with a persisted id can be renamed/deleted via the per-AOI endpoint."""
-        return self.id is not None
-
-    @property
-    def display_name(self) -> str:
-        return self.name if self.name else "(unnamed)"  #! Translate
-
-    @property
-    def aoi_area(self) -> Optional[float]:
-        if not self.geometry:
-            return None
-        try:
-            calculator = make_distance_calculator()
-            total = geojson_feature_area_sqkm(
-                {"type": "Feature", "geometry": self.geometry, "properties": {}},
-                calculator,
-            )
-            return round(total, 4) if total else None
-        except Exception:
-            return None
-
-    @property
-    def table_status(self) -> str:
-        """Aggregate status of the AOI's processings:
-        - any in progress / awaiting → ``In progress (ok/total)``;
-        - else any failed → ``Failed (ok/total)``;
-        - else all ok → ``OK (total)``.
-        """
-        statuses = [(p.processingStatus or "").upper() for p in self.processings]
-        total = len(statuses)
-        if total == 0:
-            return "—"
-        ok = sum(1 for s in statuses if s == "OK")
-        in_progress = sum(1 for s in statuses if s in ("IN_PROGRESS", "AWAITING"))
-        failed = sum(1 for s in statuses if s == "FAILED")
-        if in_progress:
-            return f"In progress ({ok}/{total})"  #! Translate
-        if failed:
-            return f"Failed ({ok}/{total})"  #! Translate
-        if ok == total:
-            return f"OK ({total})"  #! Translate
-        return f"OK ({ok}/{total})"  #! Translate
-
-    def as_processing_table_dict(self):
-        return {
-            "name": self.display_name,
-            "workflowDef": "AOI",  #! Translate
-            "status": self.table_status,
-            "percentCompleted": "N/A",
-            "aoiArea": self.aoi_area,
-            "cost": None,
-            "created": "",
-            "reviewUntil": None,
-            "id": self.table_id,
-        }
-
-
-@dataclass
-class NoAoiProcessingsRow(Serializable, SkipDataClass):
-    """Separator row introducing processings attached to the template but not intersecting
-    any of its AOIs (the backend omits them from ``aoiDetails``)."""
-    id: str = ""
-
-    @property
-    def is_separator(self) -> bool:
-        return True
-
-    def as_processing_table_dict(self):
-        return {
-            "name": "No AOI",  #! Translate
-            "workflowDef": "",
-            "status": "",
-            "percentCompleted": "",
-            "aoiArea": None,
-            "cost": None,
-            "created": "",
-            "reviewUntil": None,
-            "id": "",
-        }
-
-
-@dataclass
-class UpdateAoiSchema(Serializable, SkipDataClass):
-    name: Optional[str] = None
-    geometry: Optional[Mapping[str, Any]] = None
-
-
-@dataclass
-class AddSingleAoiSchema(Serializable, SkipDataClass):
-    geometry: Mapping[str, Any]
-    name: Optional[str] = None
-
-
-@dataclass
-class AddAoisSchema(Serializable, SkipDataClass):
-    aois: List[AddSingleAoiSchema]
-
-
-@dataclass
-class DeleteAoisSchema(Serializable, SkipDataClass):
-    aoiIds: List[str]
-
-
-@dataclass
-class ProcessingTemplateDetails(Serializable, SkipDataClass):
-    template: ProcessingTemplateDTO
-
-    def __post_init__(self):
-        if isinstance(self.template, dict):
-            self.template = ProcessingTemplateDTO.from_dict(self.template)
-
-
-@dataclass
-class CreateProcessingTemplateSchema(Serializable, SkipDataClass):
-    name: str
-    searchParams: Mapping[str, Any]
-    projectId: str
-    activeUntil: str
-    processingParams: Optional[Mapping[str, Any]] = None
-
-
-@dataclass
-class UpdateProcessingTemplateSchema(Serializable, SkipDataClass):
-    name: str
-    searchParams: Mapping[str, Any]
-    processingParams: Mapping[str, Any]
-    activeUntil: str
-
-
-@dataclass
-class RunTemplateProcessingSchema(Serializable, SkipDataClass):
-    name: str
-    description: Optional[str]
-    wdName: Optional[str]
-    wdId: Optional[str]
-    geometry: Mapping[str, Any]
-    params: Mapping[str, Any]
-    meta: Mapping[str, Any]
-    blocks: List[Mapping[str, Any]]
-    updateTemplateGeometry: bool
 
 
 @dataclass
@@ -631,68 +245,6 @@ class ProcessingDTO(Serializable, SkipDataClass):
             "created": self.created.astimezone().strftime('%Y-%m-%d %H:%M'),
             "reviewUntil": self.reviewUntil,
             "id": self.id
-        }
-
-
-@dataclass
-class TemplateProcessingSchema(Serializable, SkipDataClass):
-    """A processing as returned by ``GET /processings/template/{id}/processings``.
-
-    This endpoint serves the v1 ``ProcessingJson`` shape, whose ``params`` is a flat
-    ``Map[String,String]`` (e.g. ``{url, zoom, data_provider}``) — NOT the v2
-    ``{sourceParams: {...}}`` used elsewhere. There is no v2 variant of this endpoint, so
-    a dedicated schema keeps the flat params instead of forcing it through ``ProcessingDTO``
-    (whose ``ProcessingParams`` parsing would discard or choke on the flat shape).
-
-    It still carries the result layers, so a processing listed here can be loaded.
-    """
-    id: UUID
-    name: str
-    projectId: UUID
-    status: ProcessingStatus
-    workflowDef: WorkflowDef
-    created: datetime
-    rasterLayer: RasterLayer
-    vectorLayer: VectorLayer
-    params: Optional[Mapping[str, str]] = None  # v1 flat params, kept as-is
-    description: Optional[str] = None
-    aoiArea: Optional[int] = None
-    area: Optional[int] = None
-    cost: Optional[int] = None
-    percentCompleted: Optional[int] = None
-    blocks: Optional[List[BlockOption]] = None
-    messages: Optional[List[ErrorMessage]] = None
-    reviewStatus: Optional[ProcessingReviewStatus] = None
-
-    def __post_init__(self):
-        self.status = ProcessingStatus(self.status)
-        self.created = _parse_iso_datetime(self.created)
-        self.rasterLayer = RasterLayer.from_dict(self.rasterLayer)
-        self.vectorLayer = VectorLayer.from_dict(self.vectorLayer)
-        self.workflowDef = WorkflowDef.from_dict(self.workflowDef)
-        self.blocks = [BlockOption.from_dict(b) for b in (self.blocks or [])]
-        self.messages = [ErrorMessage.from_response(m) for m in (self.messages or [])]
-        if self.reviewStatus is None:
-            self.reviewStatus = ProcessingReviewStatus()
-        else:
-            self.reviewStatus = ProcessingReviewStatus.from_dict(self.reviewStatus)
-
-    @property
-    def is_final_state(self) -> bool:
-        return self.status.is_terminal and not self.reviewStatus.is_not_accepted
-
-    def as_processing_table_dict(self):
-        area = (self.aoiArea if self.aoiArea is not None else self.area) or 0
-        return {
-            "name": self.name,
-            "workflowDef": self.workflowDef.name if self.workflowDef else "",
-            "status": self.status.display_value,
-            "percentCompleted": self.percentCompleted,
-            "aoiArea": area / 1e6,
-            "cost": self.cost,
-            "created": self.created.astimezone().strftime('%Y-%m-%d %H:%M'),
-            "reviewUntil": None,
-            "id": self.id,
         }
 
 

--- a/mapflow/schema/template.py
+++ b/mapflow/schema/template.py
@@ -1,0 +1,475 @@
+"""Planned-processing (template) and AOI schemas.
+
+Split out of ``schema/processing.py`` to keep that module focused on regular processings.
+Imports are one-directional: this module depends on ``schema/processing.py`` (for the
+shared building blocks ``BlockOption`` / ``_parse_iso_datetime``) and the other schema
+modules, never the other way round.
+"""
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, Mapping, Any, List
+from uuid import UUID, uuid4
+
+from PyQt5.QtCore import QCoreApplication
+
+from .base import SkipDataClass, Serializable
+from .status import ProcessingStatus, ProcessingReviewStatus
+from .layer import RasterLayer, VectorLayer
+from .workflow_def import WorkflowDef
+from .processing import BlockOption, _parse_iso_datetime
+from ..errors import ErrorMessage
+from ..functional.geometry import geojson_feature_area_sqkm, make_distance_calculator
+
+
+def _tr(text: str) -> str:
+    """Translate table/status strings. These dataclasses are not ``QObject`` (no ``self.tr``),
+    so go through ``QCoreApplication.translate`` with a shared context."""
+    return QCoreApplication.translate("ProcessingTable", text)
+
+
+# Backend rejects AOI names longer than this; mirror the check client-side.
+AOI_NAME_MAX_LENGTH = 64
+
+
+@dataclass
+class SearchParams(Serializable, SkipDataClass):
+    aoiDetails: Optional[Mapping[str, Any]] = None
+    aoi: Optional[Mapping[str, Any]] = None
+    acquisitionDateFrom: Optional[str] = None
+    acquisitionDateTo: Optional[str] = None
+    minResolution: Optional[float] = None
+    maxResolution: Optional[float] = None
+    maxCloudCover: Optional[float] = None
+    minOffNadirAngle: Optional[float] = None
+    maxOffNadirAngle: Optional[float] = None
+    minAoiIntersectionPercent: Optional[float] = None
+    maxAoiIntersectionPercent: Optional[float] = None
+    returnErrors: Optional[bool] = None
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    hideUnavailable: Optional[bool] = None
+    dataProviders: Optional[List[str]] = None
+    productTypes: Optional[List[str]] = None
+
+
+@dataclass
+class AoiProcessingLink(Serializable, SkipDataClass):
+    """A processing launched for a template AOI (from aoiDetails feature properties).
+
+    Carries enough to display the processing as a grouped row under its AOI and to draw
+    its footprint on the map. For actions that need layers (load results), look the full
+    processing up by ``processingId`` in the ``/processings`` list (``TemplateProcessingSchema``).
+    """
+    processingId: Optional[str] = None
+    processingName: Optional[str] = None
+    processingStatus: Optional[str] = None
+    area: Optional[float] = None  # square metres, as reported by the backend
+    projectId: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+
+    @property
+    def is_aoi_processing(self) -> bool:
+        return True
+
+    @property
+    def id(self) -> str:
+        """Row id (matches ``as_processing_table_dict``); used for table selection restore."""
+        return str(self.processingId) if self.processingId else ""
+
+    @property
+    def aoi_area(self) -> Optional[float]:
+        if self.area is None:
+            return None
+        try:
+            return round(float(self.area) / 1e6, 4)
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def display_status(self) -> str:
+        raw = self.processingStatus or ""
+        try:
+            return ProcessingStatus(raw).display_value
+        except (ValueError, KeyError):
+            return raw
+
+    def as_processing_table_dict(self):
+        return {
+            "name": self.processingName,
+            "workflowDef": "",  # not provided by aoiDetails; grouped under its AOI
+            "status": self.display_status,
+            "percentCompleted": "N/A",
+            "aoiArea": self.aoi_area,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": str(self.processingId) if self.processingId else "",
+        }
+
+
+@dataclass
+class TemplateAoiDTO(Serializable, SkipDataClass):
+    """One AOI of a template, parsed from an aoiDetails GeoJSON feature.
+
+    Mirrors the backend ``TemplateAoiProperties`` (id, name, processings, hasNewImages).
+    ``table_id`` is a stable-per-render key for the processings table: the real AOI id
+    when present, otherwise a synthetic one (AOIs without ids cannot be renamed/deleted).
+    """
+    id: Optional[str] = None
+    name: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+    processings: List[AoiProcessingLink] = field(default_factory=list)
+    hasNewImages: bool = False
+    table_id: str = ""
+
+    def __post_init__(self):
+        if not self.table_id:
+            self.table_id = str(self.id) if self.id else f"aoi-{uuid4().hex}"
+
+    @classmethod
+    def from_feature(cls, feature: Mapping[str, Any]) -> "TemplateAoiDTO":
+        feature = feature or {}
+        props = feature.get("properties") or {}
+        aoi_id = feature.get("id") or props.get("id")
+        processings = [
+            AoiProcessingLink.from_dict(p)
+            for p in (props.get("processings") or [])
+            if isinstance(p, dict)
+        ]
+        return cls(
+            id=str(aoi_id) if aoi_id else None,
+            name=props.get("name"),
+            geometry=feature.get("geometry"),
+            processings=processings,
+            hasNewImages=bool(props.get("hasNewImages", False)),
+        )
+
+    @property
+    def is_aoi(self) -> bool:
+        return True
+
+    @property
+    def can_rename(self) -> bool:
+        """Only AOIs with a persisted id can be renamed/deleted via the per-AOI endpoint."""
+        return self.id is not None
+
+    @property
+    def display_name(self) -> str:
+        return self.name if self.name else _tr("(unnamed)")
+
+    @property
+    def aoi_area(self) -> Optional[float]:
+        if not self.geometry:
+            return None
+        try:
+            calculator = make_distance_calculator()
+            total = geojson_feature_area_sqkm(
+                {"type": "Feature", "geometry": self.geometry, "properties": {}},
+                calculator,
+            )
+            return round(total, 4) if total else None
+        except Exception:
+            return None
+
+    @property
+    def table_status(self) -> str:
+        """Aggregate status of the AOI's processings:
+        - any in progress / awaiting → ``In progress (ok/total)``;
+        - else any failed → ``Failed (ok/total)``;
+        - else all ok → ``OK (total)``.
+        """
+        statuses = [(p.processingStatus or "").upper() for p in self.processings]
+        total = len(statuses)
+        if total == 0:
+            return "—"
+        ok = sum(1 for s in statuses if s == "OK")
+        in_progress = sum(1 for s in statuses if s in ("IN_PROGRESS", "AWAITING"))
+        failed = sum(1 for s in statuses if s == "FAILED")
+        if in_progress:
+            return _tr("In progress ({ok}/{total})").format(ok=ok, total=total)
+        if failed:
+            return _tr("Failed ({ok}/{total})").format(ok=ok, total=total)
+        if ok == total:
+            return _tr("OK ({total})").format(total=total)
+        return _tr("OK ({ok}/{total})").format(ok=ok, total=total)
+
+    def as_processing_table_dict(self):
+        return {
+            "name": self.display_name,
+            "workflowDef": _tr("AOI"),
+            "status": self.table_status,
+            "percentCompleted": "N/A",
+            "aoiArea": self.aoi_area,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": self.table_id,
+        }
+
+
+@dataclass
+class NoAoiProcessingsRow(Serializable, SkipDataClass):
+    """Separator row introducing processings attached to the template but not intersecting
+    any of its AOIs (the backend omits them from ``aoiDetails``)."""
+    id: str = ""
+
+    @property
+    def is_separator(self) -> bool:
+        return True
+
+    def as_processing_table_dict(self):
+        return {
+            "name": _tr("No AOI"),
+            "workflowDef": "",
+            "status": "",
+            "percentCompleted": "",
+            "aoiArea": None,
+            "cost": None,
+            "created": "",
+            "reviewUntil": None,
+            "id": "",
+        }
+
+
+@dataclass
+class ProcessingTemplateDTO(Serializable, SkipDataClass):
+    id: UUID
+    name: str
+    status: str
+    createdAt: datetime
+    userId: UUID
+    searchParams: SearchParams
+    projectId: UUID
+    activeUntil: datetime
+    processingParams: Optional[Mapping[str, Any]] = None
+    lastCheckedAt: Optional[datetime] = None
+    newImagesCount: Optional[int] = None
+    isActive: bool = False
+    isArchived: bool = False
+    maxAoiIntersectionPercent: Optional[float] = None
+    area: Optional[float] = None  # AOI area in square metres, as reported by the backend
+
+    def __post_init__(self):
+        self.createdAt = _parse_iso_datetime(self.createdAt)
+        if self.lastCheckedAt:
+            self.lastCheckedAt = _parse_iso_datetime(self.lastCheckedAt)
+        self.activeUntil = _parse_iso_datetime(self.activeUntil)
+        if isinstance(self.searchParams, dict):
+            self.searchParams = SearchParams.from_dict(self.searchParams)
+
+    @property
+    def is_template(self) -> bool:
+        return True
+
+    def _aoi_features(self):
+        """Return template AOI features from either aoiDetails or aoi shape."""
+        if isinstance(self.searchParams, SearchParams):
+            aoi_details = self.searchParams.aoiDetails
+            if aoi_details:
+                return (aoi_details or {}).get("features", [])
+            if self.searchParams.aoi:
+                return [{
+                    "type": "Feature",
+                    "geometry": self.searchParams.aoi,
+                    "properties": {},
+                }]
+            return []
+
+        search_params = self.searchParams or {}
+        aoi_details = search_params.get("aoiDetails", {})
+        if aoi_details:
+            return (aoi_details or {}).get("features", [])
+
+        aoi = search_params.get("aoi")
+        if aoi:
+            return [{
+                "type": "Feature",
+                "geometry": aoi,
+                "properties": {},
+            }]
+        return []
+
+    @property
+    def aoi_area(self) -> Optional[float]:
+        """Total AOI area in sq km.
+
+        Prefers the backend-provided ``area`` (square metres), which the project
+        template list returns even though it omits ``searchParams``. Falls back to
+        computing from ``searchParams.aoiDetails`` when ``area`` is absent.
+        """
+        if self.area is not None:
+            try:
+                return round(float(self.area) / 1e6, 4)
+            except (TypeError, ValueError):
+                pass
+        try:
+            features = self._aoi_features()
+            if not features:
+                return None
+            calculator = make_distance_calculator()
+            total = sum(geojson_feature_area_sqkm(f, calculator) for f in features)
+            return round(total, 4) if total else None
+        except Exception:
+            return None
+
+    @property
+    def table_status(self) -> str:
+        """Template status for the processings/templates list:
+        - ``Searching`` while the initial (or a re-run) search is in progress;
+        - ``Failed`` on error;
+        - ``Created`` once ready but not yet checked (``lastCheckedAt`` is null);
+        - ``Updated`` after the first daily check, with a ``(newImagesCount)`` tag when there
+          are unseen images.
+        """
+        status = (self.status or "").upper()
+        if status == "FAILED":
+            return _tr("Failed")
+        if status == "SEARCHING":
+            return _tr("Searching")
+        if not self.isActive:
+            return _tr("Inactive")
+        if not self.lastCheckedAt:
+            return _tr("Created")
+        if self.newImagesCount and self.newImagesCount > 0:
+            return _tr("Updated ({count})").format(count=self.newImagesCount)
+        return _tr("Updated")
+
+    def as_processing_table_dict(self):
+        return {
+            "name": self.name,
+            "workflowDef": _tr("Planned"),
+            "status": self.table_status,
+            "percentCompleted": "N/A",
+            "aoiArea": self.aoi_area,
+            "cost": None,
+            "created": self.createdAt.astimezone().strftime('%Y-%m-%d %H:%M'),
+            "reviewUntil": None,
+            "id": self.id,
+        }
+
+    def aoi_dtos(self) -> "List[TemplateAoiDTO]":
+        """Parse the template's AOIs (with names and linked processings) from aoiDetails."""
+        return [TemplateAoiDTO.from_feature(f) for f in self._aoi_features()]
+
+
+@dataclass
+class UpdateAoiSchema(Serializable, SkipDataClass):
+    name: Optional[str] = None
+    geometry: Optional[Mapping[str, Any]] = None
+
+
+@dataclass
+class AddSingleAoiSchema(Serializable, SkipDataClass):
+    geometry: Mapping[str, Any]
+    name: Optional[str] = None
+
+
+@dataclass
+class AddAoisSchema(Serializable, SkipDataClass):
+    aois: List[AddSingleAoiSchema]
+
+
+@dataclass
+class DeleteAoisSchema(Serializable, SkipDataClass):
+    aoiIds: List[str]
+
+
+@dataclass
+class ProcessingTemplateDetails(Serializable, SkipDataClass):
+    template: ProcessingTemplateDTO
+
+    def __post_init__(self):
+        if isinstance(self.template, dict):
+            self.template = ProcessingTemplateDTO.from_dict(self.template)
+
+
+@dataclass
+class CreateProcessingTemplateSchema(Serializable, SkipDataClass):
+    name: str
+    searchParams: Mapping[str, Any]
+    projectId: str
+    activeUntil: str
+    processingParams: Optional[Mapping[str, Any]] = None
+
+
+@dataclass
+class UpdateProcessingTemplateSchema(Serializable, SkipDataClass):
+    name: str
+    searchParams: Mapping[str, Any]
+    processingParams: Mapping[str, Any]
+    activeUntil: str
+
+
+@dataclass
+class RunTemplateProcessingSchema(Serializable, SkipDataClass):
+    name: str
+    description: Optional[str]
+    wdName: Optional[str]
+    wdId: Optional[str]
+    geometry: Mapping[str, Any]
+    params: Mapping[str, Any]
+    meta: Mapping[str, Any]
+    blocks: List[Mapping[str, Any]]
+    updateTemplateGeometry: bool
+
+
+@dataclass
+class TemplateProcessingSchema(Serializable, SkipDataClass):
+    """A processing as returned by ``GET /processings/template/{id}/processings``.
+
+    This endpoint serves the v1 ``ProcessingJson`` shape, whose ``params`` is a flat
+    ``Map[String,String]`` (e.g. ``{url, zoom, data_provider}``) — NOT the v2
+    ``{sourceParams: {...}}`` used elsewhere. There is no v2 variant of this endpoint, so
+    a dedicated schema keeps the flat params instead of forcing it through ``ProcessingDTO``
+    (whose ``ProcessingParams`` parsing would discard or choke on the flat shape).
+
+    It still carries the result layers, so a processing listed here can be loaded.
+    """
+    id: UUID
+    name: str
+    projectId: UUID
+    status: ProcessingStatus
+    workflowDef: WorkflowDef
+    created: datetime
+    rasterLayer: RasterLayer
+    vectorLayer: VectorLayer
+    params: Optional[Mapping[str, str]] = None  # v1 flat params, kept as-is
+    description: Optional[str] = None
+    aoiArea: Optional[int] = None
+    area: Optional[int] = None
+    cost: Optional[int] = None
+    percentCompleted: Optional[int] = None
+    blocks: Optional[List[BlockOption]] = None
+    messages: Optional[List[ErrorMessage]] = None
+    reviewStatus: Optional[ProcessingReviewStatus] = None
+
+    def __post_init__(self):
+        self.status = ProcessingStatus(self.status)
+        self.created = _parse_iso_datetime(self.created)
+        self.rasterLayer = RasterLayer.from_dict(self.rasterLayer)
+        self.vectorLayer = VectorLayer.from_dict(self.vectorLayer)
+        self.workflowDef = WorkflowDef.from_dict(self.workflowDef)
+        self.blocks = [BlockOption.from_dict(b) for b in (self.blocks or [])]
+        self.messages = [ErrorMessage.from_response(m) for m in (self.messages or [])]
+        if self.reviewStatus is None:
+            self.reviewStatus = ProcessingReviewStatus()
+        else:
+            self.reviewStatus = ProcessingReviewStatus.from_dict(self.reviewStatus)
+
+    @property
+    def is_final_state(self) -> bool:
+        return self.status.is_terminal and not self.reviewStatus.is_not_accepted
+
+    def as_processing_table_dict(self):
+        area = (self.aoiArea if self.aoiArea is not None else self.area) or 0
+        return {
+            "name": self.name,
+            "workflowDef": self.workflowDef.name if self.workflowDef else "",
+            "status": self.status.display_value,
+            "percentCompleted": self.percentCompleted,
+            "aoiArea": area / 1e6,
+            "cost": self.cost,
+            "created": self.created.astimezone().strftime('%Y-%m-%d %H:%M'),
+            "reviewUntil": None,
+            "id": self.id,
+        }

--- a/mapflow/static/styles/aoi_template_blue.qml
+++ b/mapflow/static/styles/aoi_template_blue.qml
@@ -1,0 +1,30 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.11-Białowieża" styleCategories="Symbology">
+  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
+    <symbols>
+      <symbol type="fill" alpha="1" name="0" clip_to_extent="1" force_rhr="0">
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option type="QString" name="color" value="0,90,200,60"/>
+            <Option type="QString" name="outline_color" value="0,90,200,255"/>
+            <Option type="QString" name="outline_style" value="solid"/>
+            <Option type="QString" name="outline_width" value="0.6"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="solid"/>
+          </Option>
+          <prop k="color" v="0,90,200,60"/>
+          <prop k="outline_color" v="0,90,200,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/mapflow/static/styles/aoi_template_processing_green.qml
+++ b/mapflow/static/styles/aoi_template_processing_green.qml
@@ -1,0 +1,30 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.22.11-Białowieża" styleCategories="Symbology">
+  <renderer-v2 type="singleSymbol" referencescale="-1" forceraster="0" enableorderby="0" symbollevels="0">
+    <symbols>
+      <symbol type="fill" alpha="1" name="0" clip_to_extent="1" force_rhr="0">
+        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
+          <Option type="Map">
+            <Option type="QString" name="color" value="30,160,60,60"/>
+            <Option type="QString" name="outline_color" value="30,160,60,255"/>
+            <Option type="QString" name="outline_style" value="solid"/>
+            <Option type="QString" name="outline_width" value="0.6"/>
+            <Option type="QString" name="outline_width_unit" value="MM"/>
+            <Option type="QString" name="style" value="solid"/>
+          </Option>
+          <prop k="color" v="30,160,60,60"/>
+          <prop k="outline_color" v="30,160,60,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.6"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation/>
+    <sizescale/>
+  </renderer-v2>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerGeometryType>2</layerGeometryType>
+</qgis>

--- a/spec/002_F_plan_processing_api.md
+++ b/spec/002_F_plan_processing_api.md
@@ -173,7 +173,8 @@ returned only by endpoints that serialize the full template `searchParams` —
 `GET /processings/template/user/{userId}`. It is **absent** from
 `GET /processings/template/project/{projectId}` (returns `ProcessingTemplateShortDetails`
 without `searchParams`), which the poll uses; the plugin therefore hydrates the template by
-id when entering it (and re-hydrates on the in-template poll to refresh processing statuses).
+id when **entering** it (and again after an AOI add/rename/delete), but **not** on every
+poll tick — the grouping changes slowly, so re-fetching it each tick is wasteful.
 
 This is the source the plugin uses to **group** processings under their AOI — both in the
 in-template table (each AOI row followed by its processings) and on the map (a layer-tree
@@ -183,12 +184,14 @@ layers) for loading a processing's results on double-click.
 
 ### Setting AOI names on creation
 `POST /processings/template` accepts AOI names via `searchParams.aoiDetails`: each
-feature's `properties` is read as `{ id?, name? }` (`InputAoiProperties`). The plugin,
-when creating a template from a layer whose features carry a `name` attribute, sends
-`aoiDetails` as a FeatureCollection with one feature per AOI and `properties.name` set
-from that attribute. When the attribute is absent the AOI is created with a `null`
-name and can be renamed later via `PUT .../aoi/{aoiId}`. The legacy combined `aoi`
-geometry remains accepted as a fallback when no names are needed.
+feature's `properties` is read as `{ id?, name? }` (`InputAoiProperties`) — `name` is
+optional. The plugin **always** sends `searchParams.aoiDetails` (a FeatureCollection),
+never the legacy plain `searchParams.aoi`, which is **deprecated** because per-AOI names
+cannot be attached to it. One feature is sent per AOI; `properties.name` is set from the
+source layer's `name` attribute when present, and omitted/`null` otherwise (the AOI can be
+renamed later via `POST .../aoi/{aoiId}`). When the AOI does not come from a polygon layer
+(e.g. an image/mosaic extent), a single unnamed feature is built from the combined AOI
+geometry. The backend still accepts `aoi` as a fallback, but the plugin no longer sends it.
 
 ### Name constraints
 AOI names must not exceed **64 characters**; the plugin validates this client-side
@@ -234,6 +237,17 @@ AOI row (in-template) — aggregated from its processings' statuses:
 - any `IN_PROGRESS`/`AWAITING` → `In progress (ok/total)`;
 - else any `FAILED` → `Failed (ok/total)`;
 - else all `OK` → `OK (total)`; no processings → `—`.
+
+The AOI aggregate status is kept current from the polled `/processings` (statuses synced
+into the cached grouping), so it does not require re-fetching the full template each tick.
+
+### Polling
+
+The in-template poll is a **single** `GET …/processings` request per tick (no `get_template`,
+no `images`), and runs on a **slower** cadence than the project processings list. The
+imagery-search (`images`) endpoint is only hit on enter, on the "See search results" action,
+and on AOI selection (S7) — never from the poll. The table is re-rendered with selection
+signals blocked so a poll does not re-trigger the AOI search filter or rebuild map layers.
 
 Template Progress (`100% × covered AOI area / total AOI area`, i.e. the share of the
 template's AOI area processed at least once) is **not implemented (#WARNING)**: it is not

--- a/spec/002_F_plan_processing_api.md
+++ b/spec/002_F_plan_processing_api.md
@@ -79,6 +79,46 @@ Get all processings associated with template.
 Response:
 - array of Processing objects
 
+The response is `List[ProcessingJson]` (v1): `params` is a flat `Map[String,String]`
+(e.g. `{url, zoom, data_provider}`), **not** the v2 `{sourceParams: {...}}` shape, and
+there is no `…/processings/v2` variant. The plugin parses it with a dedicated
+`TemplateProcessingSchema` that keeps the flat `params` and the result layers, rather than
+forcing it through `ProcessingDTO` (whose v2 `ProcessingParams` parsing would choke on the
+flat shape). The in-template table groups processings under their AOI from `aoiDetails`
+(see above); this endpoint supplies the full objects (with layers) used to load a
+processing's results on double-click, keyed by id.
+
+### `POST /processings/template/{templateId}/aoi`
+Add one or more AOIs to a template.
+
+Body (one of):
+- single: `{ "geometry": <GeoJSON geometry>, "name": <string|null> }`
+- multiple: `{ "aois": [ { "geometry": ..., "name": ... }, ... ] }`
+
+Exactly one of `geometry` / `aois` must be provided.
+
+Response:
+- `{ "addedCount": <int>, "partitioningTriggered": <bool> }`
+
+### `POST /processings/template/{templateId}/aoi/{aoiId}`
+Update an AOI's name and/or geometry. (Served over POST, not PUT — PUT returns 404.)
+
+Body fields (both optional):
+- `name` (string)
+- `geometry` (GeoJSON geometry)
+
+Response:
+- updated AOI
+
+### `DELETE /processings/template/{templateId}/aoi`
+Delete one or more AOIs from a template.
+
+Body:
+- `{ "aoiIds": [<uuid>, ...] }`
+
+Response:
+- `{ "deletedCount": <int>, ... }`
+
 ### `POST /processings/template/{templateId}/image/{imageId}/seen`
 Mark one image as seen for template.
 
@@ -111,6 +151,100 @@ Response:
 - `projectId` (uuid)
 - `area` (number)
 - `newImagesCount` (integer)
+
+## AOIs, names, and `aoiDetails`
+
+A template's AOIs are carried in `searchParams.aoiDetails`, a GeoJSON
+`FeatureCollection`. Each feature's `properties` object has the shape:
+
+- `id` (uuid, optional) — the persisted AOI id. Required to rename/delete a specific
+  AOI. It may be absent for legacy `aoi`-only templates and is only guaranteed after
+  the backend has persisted the template and it is re-fetched with
+  `GET /processings/template/{templateId}`.
+- `name` (string, optional) — the AOI's human name. May be `null` (unnamed).
+- `processings` (array) — processings launched for this AOI; each item:
+  `{ processingId, processingName, processingStatus, area, geometry, projectId }`. The
+  `geometry` is the processing's footprint (used to draw it on the map).
+- `hasNewImages` (bool) — whether the AOI has unseen new images.
+
+`aoiDetails` (fully populated with per-AOI `processings`, `name`, `hasNewImages`) is
+returned only by endpoints that serialize the full template `searchParams` —
+`GET /processings/template/{templateId}`, `GET /processings/template`,
+`GET /processings/template/user/{userId}`. It is **absent** from
+`GET /processings/template/project/{projectId}` (returns `ProcessingTemplateShortDetails`
+without `searchParams`), which the poll uses; the plugin therefore hydrates the template by
+id when entering it (and re-hydrates on the in-template poll to refresh processing statuses).
+
+This is the source the plugin uses to **group** processings under their AOI — both in the
+in-template table (each AOI row followed by its processings) and on the map (a layer-tree
+subgroup per AOI containing the AOI polygon plus each processing's footprint). The flat
+`GET …/processings` list is used only to obtain the full processing objects (with result
+layers) for loading a processing's results on double-click.
+
+### Setting AOI names on creation
+`POST /processings/template` accepts AOI names via `searchParams.aoiDetails`: each
+feature's `properties` is read as `{ id?, name? }` (`InputAoiProperties`). The plugin,
+when creating a template from a layer whose features carry a `name` attribute, sends
+`aoiDetails` as a FeatureCollection with one feature per AOI and `properties.name` set
+from that attribute. When the attribute is absent the AOI is created with a `null`
+name and can be renamed later via `PUT .../aoi/{aoiId}`. The legacy combined `aoi`
+geometry remains accepted as a fallback when no names are needed.
+
+### Name constraints
+AOI names must not exceed **64 characters**; the plugin validates this client-side
+before issuing create/rename requests and surfaces a translatable error otherwise.
+
+### Scope note (#WARNING)
+Naming AOIs is currently **template-only**. Regular processings expose AOIs via
+`GET /processings/{processingId}/aois` whose `AoiJson` has no `name` field, so
+per-AOI names cannot be set on standalone processing creation yet. Spec for named
+AOIs on regular processings is deferred to a later iteration.
+
+## In-template navigation (client behavior)
+
+The plugin's projects/processings table supports a third navigation level. Levels:
+`Projects → Processings → Template`. Entering a template ("one step right", via
+double-click or the forward button) does all of:
+- fetches/hydrates the template's `searchParams` (if missing);
+- shows, in the same table, the template's AOIs and their processings **grouped**: each
+  AOI row (blue-tinted) is immediately followed by the processings launched from it
+  (green-tinted), then the next AOI. Grouping comes from `aoiDetails[].processings`;
+- loads the template's map layer group with **one subgroup per AOI** (named after the
+  AOI), each containing the AOI polygon (blue, transparent) and its processings'
+  footprints (green, transparent);
+- fills the imagery-search results table/layer (without stealing tab focus).
+
+Processings attached to the template but not intersecting any AOI are **absent from
+`aoiDetails`**; they are listed at the bottom under a non-selectable **"No AOI"** separator
+row (their ids come from `GET …/processings` minus the ids referenced by `aoiDetails`).
+
+Double-clicking a processing row loads that processing's results (the full object, with
+result layers, model and progress, comes from `GET …/processings`).
+
+### Row statuses
+
+Template row (processings/templates list):
+- `Searching` while `status == SEARCHING`;
+- `Failed` while `status == FAILED`;
+- `Inactive` when paused (`isActive == false`);
+- `Created` when ready but `lastCheckedAt` is null (no daily check yet);
+- `Updated` after the first check, with a `(newImagesCount)` tag when there are unseen images.
+
+AOI row (in-template) — aggregated from its processings' statuses:
+- any `IN_PROGRESS`/`AWAITING` → `In progress (ok/total)`;
+- else any `FAILED` → `Failed (ok/total)`;
+- else all `OK` → `OK (total)`; no processings → `—`.
+
+Template Progress (`100% × covered AOI area / total AOI area`, i.e. the share of the
+template's AOI area processed at least once) is **not implemented (#WARNING)**: it is not
+derivable from existing responses without geometric union/difference of AOI vs processing
+footprints; it should be computed by the backend and exposed on the template instead.
+
+Selecting an AOI row filters the imagery-search results (both table and footprint
+layer) to images intersecting that AOI (`aoiIds` on the template images request).
+
+Leaving a template ("one step left", back button) returns to the project's
+processings list and removes the template's layer group from the map.
 
 ## Limits and client-side validation
 

--- a/spec/index.md
+++ b/spec/index.md
@@ -22,6 +22,8 @@ Imagery Search: catalog search, external APIs (Maxar, Sentinel — legacy).
 
 ## 002_F_plan_processing_api.md
 Planned processing: create/list/update/delete, run from template, and template status/actions.
+Also covers template AOI management (add/update/delete, naming, `aoiDetails` structure)
+and the in-template navigation level (Projects → Processings → Template).
 
 ## 002_E_zoom_selector_api.md
 Zoom selector API for automatic zoom detection based on imagery source resolution.

--- a/tests/qgis/test_processing_templates.py
+++ b/tests/qgis/test_processing_templates.py
@@ -165,14 +165,16 @@ class TestTemplateSchemas:
         ("payload_updates", "expected_status"),
         [
             ({"status": "FAILED", "isActive": False}, "Failed"),
+            ({"status": "SEARCHING", "isActive": True}, "Searching"),
             ({"status": "READY", "isActive": False}, "Inactive"),
             ({"status": "READY", "isActive": True, "lastCheckedAt": None, "newImagesCount": 0}, "Created"),
             ({
+                # Before the first check, the new-images tag is not shown (Created has no count).
                 "status": "READY",
                 "isActive": True,
                 "lastCheckedAt": None,
                 "newImagesCount": 3,
-            }, "Created (3)"),
+            }, "Created"),
             ({
                 "status": "READY",
                 "isActive": True,

--- a/tests/qgis/test_processing_templates.py
+++ b/tests/qgis/test_processing_templates.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 import pytest
 
 from mapflow.functional.api.processing_api import ProcessingApi
-from mapflow.schema.processing import (
+from mapflow.schema.template import (
     CreateProcessingTemplateSchema,
     UpdateProcessingTemplateSchema,
     RunTemplateProcessingSchema,

--- a/tests/qgis/test_template_aoi.py
+++ b/tests/qgis/test_template_aoi.py
@@ -1,0 +1,310 @@
+"""QGIS-tier tests for template AOIs: parsing names/processings from aoiDetails,
+the in-template table rows, AOI rename, and AOI-filtered search (spec 002_F)."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mapflow.functional.service import processing_service as ps_mod
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.mapflow import Mapflow
+from mapflow.schema.processing import (
+    AOI_NAME_MAX_LENGTH,
+    ProcessingParams,
+    ProcessingTemplateDTO,
+    TemplateAoiDTO,
+    UpdateAoiSchema,
+)
+
+
+def _aoi_feature(aoi_id="aoi-1", name="North field", processings=None, has_new=False):
+    return {
+        "type": "Feature",
+        "id": aoi_id,
+        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+        "properties": {
+            "id": aoi_id,
+            "name": name,
+            "processings": processings or [],
+            "hasNewImages": has_new,
+        },
+    }
+
+
+def test_template_aoi_dto_parses_name_and_processings():
+    feature = _aoi_feature(
+        name="North field",
+        processings=[{
+            "processingId": "p-1",
+            "processingName": "Run 1",
+            "processingStatus": "OK",
+            "area": 123,
+            "projectId": "proj-1",
+        }],
+        has_new=True,
+    )
+    aoi = TemplateAoiDTO.from_feature(feature)
+    assert aoi.id == "aoi-1"
+    assert aoi.name == "North field"
+    assert aoi.hasNewImages is True
+    assert len(aoi.processings) == 1
+    assert aoi.processings[0].processingName == "Run 1"
+    assert aoi.can_rename is True
+
+
+def test_template_aoi_dto_null_name_is_unnamed_and_not_renamable_without_id():
+    feature = {
+        "type": "Feature",
+        "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]},
+        "properties": {"name": None},
+    }
+    aoi = TemplateAoiDTO.from_feature(feature)
+    assert aoi.name is None
+    assert aoi.display_name == "(unnamed)"
+    # No id -> cannot rename/delete via the per-AOI endpoint.
+    assert aoi.can_rename is False
+    # A synthetic table id is still assigned so the row is selectable.
+    assert aoi.table_id
+
+
+def test_template_aoi_table_dict_keys_match_processing_columns():
+    aoi = TemplateAoiDTO.from_feature(_aoi_feature())
+    row = aoi.as_processing_table_dict()
+    assert row["name"] == "North field"
+    assert row["workflowDef"] == "AOI"
+    assert row["id"] == "aoi-1"
+
+
+def _template_with_aois(features):
+    return ProcessingTemplateDTO.from_dict({
+        "id": "t-1",
+        "name": "T1",
+        "status": "READY",
+        "createdAt": "2025-09-26T06:25:55.820336Z",
+        "userId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "searchParams": {"aoiDetails": {"type": "FeatureCollection", "features": features}},
+        "projectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "activeUntil": "2026-03-15T17:00:00Z",
+    })
+
+
+def test_template_dto_aoi_dtos():
+    template = _template_with_aois([_aoi_feature("a1", "A"), _aoi_feature("a2", "B")])
+    aois = template.aoi_dtos()
+    assert {a.name for a in aois} == {"A", "B"}
+
+
+def test_combined_template_rows_groups_processings_under_their_aoi():
+    """Grouped layout: AOI row, then its processings, then the next AOI."""
+    service = ProcessingService.__new__(ProcessingService)
+    aoi1 = TemplateAoiDTO.from_feature(_aoi_feature(
+        "a1", "Alpha",
+        processings=[
+            {"processingId": "p1", "processingName": "P1", "processingStatus": "OK"},
+            {"processingId": "p2", "processingName": "P2", "processingStatus": "OK"},
+        ],
+    ))
+    aoi2 = TemplateAoiDTO.from_feature(_aoi_feature("a2", "Beta", processings=[]))
+    service.template_aois = {aoi1.table_id: aoi1, aoi2.table_id: aoi2}
+    service.template_processings = {}  # full processings not loaded -> link fallback
+
+    rows = service.combined_template_rows()
+
+    assert rows[0] is aoi1
+    assert [r.processingName for r in rows[1:3]] == ["P1", "P2"]
+    assert rows[3] is aoi2
+    # Every row must expose `.id` — update_processing_table uses it for selection restore.
+    assert [r.id for r in rows[1:3]] == ["p1", "p2"]
+    assert all(hasattr(r, "id") for r in rows)
+
+
+def test_get_template_processings_callback_keeps_full_processings(monkeypatch):
+    """The v1 /processings list is parsed into TemplateProcessingSchema, keyed by id,
+    for double-click loading (grouped display itself comes from aoiDetails)."""
+    service = ProcessingService.__new__(ProcessingService)
+
+    sentinel = SimpleNamespace(id="p-1")
+    monkeypatch.setattr(ps_mod.TemplateProcessingSchema, "from_dict", staticmethod(lambda d: sentinel))
+
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = b'[{"id":"p-1"}]'
+
+    service.get_template_processings_callback(response)
+
+    assert service.template_processings == {"p-1": sentinel}
+
+
+def test_rename_aoi_calls_update_aoi_endpoint(monkeypatch):
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    service.dlg = MagicMock()
+    service.api = MagicMock()
+    aoi = TemplateAoiDTO.from_feature(_aoi_feature("aoi-1", "Old"))
+    service.selected_aoi = MagicMock(return_value=aoi)
+    service.active_template = SimpleNamespace(id="t-1")
+
+    monkeypatch.setattr(ps_mod.QInputDialog, "getText", lambda *args, **kwargs: ("New name", True))
+
+    service.rename_aoi()
+
+    service.api.update_aoi.assert_called_once()
+    kwargs = service.api.update_aoi.call_args.kwargs
+    assert kwargs["template_id"] == "t-1"
+    assert kwargs["aoi_id"] == "aoi-1"
+    assert isinstance(kwargs["data"], UpdateAoiSchema)
+    assert kwargs["data"].name == "New name"
+
+
+def test_rename_aoi_rejects_overlong_name(monkeypatch):
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    service.dlg = MagicMock()
+    service.api = MagicMock()
+    aoi = TemplateAoiDTO.from_feature(_aoi_feature("aoi-1", "Old"))
+    service.selected_aoi = MagicMock(return_value=aoi)
+    service.active_template = SimpleNamespace(id="t-1")
+    alerts = []
+    monkeypatch.setattr(ps_mod, "alert", lambda *a, **k: alerts.append(a))
+    monkeypatch.setattr(
+        ps_mod.QInputDialog, "getText",
+        lambda *args, **kwargs: ("x" * (AOI_NAME_MAX_LENGTH + 1), True),
+    )
+
+    service.rename_aoi()
+
+    service.api.update_aoi.assert_not_called()
+    assert alerts  # user was warned
+
+
+def test_filter_search_by_selected_aoi_passes_single_aoi_id():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.processing_service = MagicMock()
+    plugin.processing_service.in_template_mode = True
+    template = SimpleNamespace(id="t-1")
+    plugin.processing_service.active_template = template
+    plugin.processing_service.selected_aoi.return_value = SimpleNamespace(id="aoi-1")
+    plugin._load_template_search = MagicMock()
+
+    plugin.filter_search_by_selected_aoi()
+
+    plugin._load_template_search.assert_called_once_with(template, aoi_ids=["aoi-1"])
+
+
+def test_filter_search_resets_to_all_when_aoi_deselected():
+    """De-selecting the AOI (or selecting a processing) restores the full template results."""
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.processing_service = MagicMock()
+    plugin.processing_service.in_template_mode = True
+    template = SimpleNamespace(id="t-1")
+    plugin.processing_service.active_template = template
+    plugin.processing_service.selected_aoi.return_value = None
+    plugin._template_search_aoi_filter = "aoi-1"  # previously filtered by an AOI
+    plugin._load_template_search = MagicMock()
+
+    plugin.filter_search_by_selected_aoi()
+
+    plugin._load_template_search.assert_called_once_with(template, aoi_ids=None)
+    assert plugin._template_search_aoi_filter is None
+
+
+def test_filter_search_noop_when_filter_unchanged():
+    """Selection churn that doesn't change the effective AOI filter must not reload."""
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.processing_service = MagicMock()
+    plugin.processing_service.in_template_mode = True
+    plugin.processing_service.active_template = SimpleNamespace(id="t-1")
+    plugin.processing_service.selected_aoi.return_value = None
+    plugin._template_search_aoi_filter = None  # already showing all results
+    plugin._load_template_search = MagicMock()
+
+    plugin.filter_search_by_selected_aoi()
+
+    plugin._load_template_search.assert_not_called()
+
+
+def test_aoi_status_aggregates_processing_statuses():
+    ok = {"processingId": "p1", "processingStatus": "OK"}
+    in_progress = {"processingId": "p2", "processingStatus": "IN_PROGRESS"}
+    failed = {"processingId": "p3", "processingStatus": "FAILED"}
+
+    all_ok = TemplateAoiDTO.from_feature(_aoi_feature(processings=[ok, dict(ok, processingId="p1b")]))
+    assert all_ok.table_status == "OK (2)"
+
+    running = TemplateAoiDTO.from_feature(_aoi_feature(processings=[ok, in_progress, failed]))
+    assert running.table_status == "In progress (1/3)"
+
+    has_failed = TemplateAoiDTO.from_feature(_aoi_feature(processings=[ok, failed]))
+    assert has_failed.table_status == "Failed (1/2)"
+
+    empty = TemplateAoiDTO.from_feature(_aoi_feature(processings=[]))
+    assert empty.table_status == "—"
+
+
+def test_combined_template_rows_appends_unbound_under_no_aoi_separator():
+    from mapflow.schema.processing import NoAoiProcessingsRow
+    service = ProcessingService.__new__(ProcessingService)
+    aoi = TemplateAoiDTO.from_feature(_aoi_feature(
+        "a1", "Alpha",
+        processings=[{"processingId": "p1", "processingName": "P1", "processingStatus": "OK"}],
+    ))
+    service.template_aois = {aoi.table_id: aoi}
+    bound = SimpleNamespace(id="p1", is_final_state=True)
+    unbound = SimpleNamespace(id="p9", is_final_state=True)
+    service.template_processings = {"p1": bound, "p9": unbound}
+
+    rows = service.combined_template_rows()
+
+    assert rows[0] is aoi
+    assert rows[1] is bound  # full processing used in place of the link
+    assert isinstance(rows[2], NoAoiProcessingsRow)
+    assert rows[3] is unbound
+
+
+def test_processing_params_legacy_flat_shape_returns_none():
+    """The template /processings endpoint returns legacy flat params (no sourceParams);
+    parsing must not raise (a raise dropped the whole processing from the list)."""
+    legacy = {"url": "1145053", "zoom": "17", "data_provider": "arcgis_world_imagery"}
+    assert ProcessingParams.from_dict(legacy) is None
+
+
+def test_processing_params_v2_shape_still_parses():
+    v2 = {"sourceParams": {"dataProvider": {"providerName": "arcgis", "zoom": "17"}}}
+    assert ProcessingParams.from_dict(v2) is not None
+
+
+def test_template_to_run_uses_active_template_in_template_mode():
+    """Inside a template there is no selected template row, so the planned-start gate must
+    use the active template — otherwise 'Start planned processing' never triggers."""
+    from mapflow.entity.provider import ImagerySearchProvider
+    service = ProcessingService.__new__(ProcessingService)
+    service.in_template_mode = True
+    template = SimpleNamespace(id="t-1")
+    service.active_template = template
+    service.app_context = SimpleNamespace(
+        data_provider=ImagerySearchProvider(proxy="https://example"),
+        open_template_results_id="t-1",
+    )
+
+    assert service.template_to_run() is template
+
+
+def test_template_to_run_none_when_open_results_belong_to_other_template():
+    from mapflow.entity.provider import ImagerySearchProvider
+    service = ProcessingService.__new__(ProcessingService)
+    service.in_template_mode = True
+    service.active_template = SimpleNamespace(id="t-1")
+    service.app_context = SimpleNamespace(
+        data_provider=ImagerySearchProvider(proxy="https://example"),
+        open_template_results_id="other",
+    )
+
+    assert service.template_to_run() is None
+
+
+def test_filter_search_by_selected_aoi_noop_outside_template_mode():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.processing_service = MagicMock()
+    plugin.processing_service.in_template_mode = False
+    plugin._load_template_search = MagicMock()
+
+    plugin.filter_search_by_selected_aoi()
+
+    plugin._load_template_search.assert_not_called()

--- a/tests/qgis/test_template_aoi.py
+++ b/tests/qgis/test_template_aoi.py
@@ -10,9 +10,23 @@ from mapflow.schema.processing import ProcessingParams
 from mapflow.schema.template import (
     AOI_NAME_MAX_LENGTH,
     ProcessingTemplateDTO,
+    SearchParams,
     TemplateAoiDTO,
     UpdateAoiSchema,
 )
+
+
+def test_template_single_data_provider_backfill_source():
+    """providerName backfill source: the template's sole search data provider, else None."""
+    plugin = Mapflow.__new__(Mapflow)
+    single = SimpleNamespace(searchParams=SearchParams(dataProviders=["arcgis_world_imagery"]))
+    assert plugin._template_single_data_provider(single) == "arcgis_world_imagery"
+    several = SimpleNamespace(searchParams=SearchParams(dataProviders=["a", "b"]))
+    assert plugin._template_single_data_provider(several) is None
+    none = SimpleNamespace(searchParams=SearchParams(dataProviders=None))
+    assert plugin._template_single_data_provider(none) is None
+    as_dict = SimpleNamespace(searchParams={"dataProviders": ["mapbox"]})
+    assert plugin._template_single_data_provider(as_dict) == "mapbox"
 
 
 def test_refresh_template_view_polls_only_processings():

--- a/tests/qgis/test_template_aoi.py
+++ b/tests/qgis/test_template_aoi.py
@@ -6,13 +6,56 @@ from unittest.mock import MagicMock
 from mapflow.functional.service import processing_service as ps_mod
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.mapflow import Mapflow
-from mapflow.schema.processing import (
+from mapflow.schema.processing import ProcessingParams
+from mapflow.schema.template import (
     AOI_NAME_MAX_LENGTH,
-    ProcessingParams,
     ProcessingTemplateDTO,
     TemplateAoiDTO,
     UpdateAoiSchema,
 )
+
+
+def test_refresh_template_view_polls_only_processings():
+    """The poll tick must be a single /processings request, not get_template + processings."""
+    service = ProcessingService.__new__(ProcessingService)
+    service.active_template = SimpleNamespace(id="t-1")
+    service.api = MagicMock()
+
+    service.refresh_template_view()
+
+    service.api.get_template_processings.assert_called_once()
+    service.api.get_template.assert_not_called()
+
+
+def test_sync_aoi_statuses_from_processings_refreshes_aoi_status():
+    """AOI status stays current from the polled processings without re-fetching the template."""
+    from mapflow.schema.status import ProcessingStatus
+    service = ProcessingService.__new__(ProcessingService)
+    aoi = TemplateAoiDTO.from_feature(
+        _aoi_feature(processings=[{"processingId": "p1", "processingStatus": "OK"}])
+    )
+    service.template_aois = {aoi.table_id: aoi}
+    service.template_processings = {"p1": SimpleNamespace(status=ProcessingStatus("FAILED"))}
+
+    service._sync_aoi_statuses_from_processings()
+
+    assert aoi.processings[0].processingStatus == "FAILED"
+    assert aoi.table_status == "Failed (0/1)"
+
+
+def test_update_processing_table_blocks_signals_during_render():
+    """The programmatic table rebuild must not emit selection signals (which would re-run
+    the AOI search filter / map rebuild every poll)."""
+    from mapflow.functional.view.processing_view import ProcessingView
+    view = ProcessingView.__new__(ProcessingView)
+    view._header_sort_by = None
+    view.dlg = MagicMock()
+    view.selected_processing_ids = MagicMock(return_value=[])
+
+    view.update_processing_table([])
+
+    block_calls = [c.args for c in view.dlg.processingsTable.blockSignals.call_args_list]
+    assert (True,) in block_calls and (False,) in block_calls
 
 
 def _aoi_feature(aoi_id="aoi-1", name="North field", processings=None, has_new=False):
@@ -239,7 +282,7 @@ def test_aoi_status_aggregates_processing_statuses():
 
 
 def test_combined_template_rows_appends_unbound_under_no_aoi_separator():
-    from mapflow.schema.processing import NoAoiProcessingsRow
+    from mapflow.schema.template import NoAoiProcessingsRow
     service = ProcessingService.__new__(ProcessingService)
     aoi = TemplateAoiDTO.from_feature(_aoi_feature(
         "a1", "Alpha",

--- a/tests/qgis/test_template_errors_pagination.py
+++ b/tests/qgis/test_template_errors_pagination.py
@@ -1,0 +1,90 @@
+"""QGIS-tier tests: meaningful translatable errors for failed template actions, and
+clearing the template search-results pagination on exit / fresh load."""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mapflow.functional.service import processing_service as ps_mod
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.mapflow import Mapflow
+
+
+def _error_response(message, code="BAD_REQUEST"):
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = json.dumps(
+        {"code": code, "message": message, "params": None}
+    ).encode()
+    return response
+
+
+def test_max_active_templates_message_is_translated():
+    from mapflow.errors.errors import ErrorMessage
+    text = ErrorMessage(
+        code="BAD_REQUEST",
+        parameters=None,
+        message="You have reached the maximum number of active templates",
+    ).to_str()
+    assert "maximum number of active planned processings" in text
+
+
+def test_template_error_text_parses_response_body():
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+
+    text = service._template_error_text(
+        _error_response("You have reached the maximum number of active templates")
+    )
+
+    assert "maximum number of active planned processings" in text
+
+
+def test_resume_error_handler_shows_meaningful_message(monkeypatch):
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    service._resume_template_state = {"template_id": "t-1"}
+    alerts = []
+    monkeypatch.setattr(ps_mod, "alert", lambda *a, **k: alerts.append(a[0]))
+
+    service.resume_template_error_handler(
+        _error_response("You have reached the maximum number of active templates")
+    )
+
+    assert service._resume_template_state == {}
+    assert any("maximum number of active planned processings" in a for a in alerts)
+
+
+def test_template_error_text_falls_back_to_unknown_on_bad_body():
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = b"not json"
+
+    assert service._template_error_text(response) == "Unknown server error"
+
+
+def test_on_template_closed_resets_search_pagination():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.app_context = SimpleNamespace(open_template_results_id="x")
+    plugin._template_search_aoi_filter = "aoi-1"
+    plugin.search_page_offset = 60
+    plugin.dlg = MagicMock()
+    plugin._remove_template_group = MagicMock()
+
+    plugin.on_template_closed(None)
+
+    assert plugin.search_page_offset == 0
+    plugin.dlg.enable_search_pages.assert_called_once_with(False)
+
+
+def test_load_template_search_starts_from_first_page():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.search_page_offset = 30
+    plugin.search_page_limit = 30
+    plugin.dlg = MagicMock()
+    plugin.processing_service = MagicMock()
+    plugin._aoi_ids_from_template = MagicMock(return_value=[])
+
+    plugin._load_template_search(SimpleNamespace(id="t-1"))
+
+    assert plugin.search_page_offset == 0
+    assert plugin.processing_service.api.get_template_images.call_args.kwargs["offset"] == 0

--- a/tests/qgis/test_template_named_aoi_create.py
+++ b/tests/qgis/test_template_named_aoi_create.py
@@ -1,0 +1,79 @@
+"""QGIS-tier tests for sending AOI names when creating a template (spec 002_F).
+
+When the source layer has a ``name`` attribute, each AOI feature in
+``searchParams.aoiDetails`` carries that name; otherwise the name is ``None``.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from qgis.core import QgsVectorLayer, QgsFeature, QgsGeometry, QgsField
+from PyQt5.QtCore import QVariant
+
+from mapflow.mapflow import Mapflow
+from mapflow.schema.processing import AOI_NAME_MAX_LENGTH
+
+
+def _layer_with(features, with_name_field=True):
+    layer = QgsVectorLayer("Polygon?crs=epsg:4326", "aois", "memory")
+    provider = layer.dataProvider()
+    if with_name_field:
+        provider.addAttributes([QgsField("name", QVariant.String)])
+        layer.updateFields()
+    qgs_features = []
+    for wkt, name in features:
+        feat = QgsFeature(layer.fields())
+        feat.setGeometry(QgsGeometry.fromWkt(wkt))
+        if with_name_field:
+            feat.setAttribute("name", name)
+        qgs_features.append(feat)
+    provider.addFeatures(qgs_features)
+    layer.updateExtents()
+    return layer
+
+
+def _plugin_with_layer(layer):
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.tr = lambda text: text
+    plugin.dlg = MagicMock()
+    plugin.dlg.polygonCombo.currentLayer.return_value = layer
+    return plugin
+
+
+def test_aoi_details_carry_names_from_layer_attribute():
+    layer = _layer_with([
+        ("POLYGON((0 0,0 1,1 1,1 0,0 0))", "North"),
+        ("POLYGON((2 2,2 3,3 3,3 2,2 2))", "South"),
+    ])
+    plugin = _plugin_with_layer(layer)
+
+    fc = plugin._build_template_aoi_details()
+
+    assert fc["type"] == "FeatureCollection"
+    names = [f["properties"]["name"] for f in fc["features"]]
+    assert names == ["North", "South"]
+
+
+def test_aoi_details_null_name_without_attribute():
+    layer = _layer_with([("POLYGON((0 0,0 1,1 1,1 0,0 0))", None)], with_name_field=False)
+    plugin = _plugin_with_layer(layer)
+
+    fc = plugin._build_template_aoi_details()
+
+    assert fc["features"][0]["properties"]["name"] is None
+
+
+def test_aoi_details_rejects_overlong_name():
+    layer = _layer_with([("POLYGON((0 0,0 1,1 1,1 0,0 0))", "x" * (AOI_NAME_MAX_LENGTH + 1))])
+    plugin = _plugin_with_layer(layer)
+
+    with pytest.raises(ValueError):
+        plugin._build_template_aoi_details()
+
+
+def test_no_layer_returns_none():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.tr = lambda text: text
+    plugin.dlg = MagicMock()
+    plugin.dlg.polygonCombo.currentLayer.return_value = None
+
+    assert plugin._build_template_aoi_details() is None

--- a/tests/qgis/test_template_named_aoi_create.py
+++ b/tests/qgis/test_template_named_aoi_create.py
@@ -3,6 +3,7 @@
 When the source layer has a ``name`` attribute, each AOI feature in
 ``searchParams.aoiDetails`` carries that name; otherwise the name is ``None``.
 """
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,7 +11,7 @@ from qgis.core import QgsVectorLayer, QgsFeature, QgsGeometry, QgsField
 from PyQt5.QtCore import QVariant
 
 from mapflow.mapflow import Mapflow
-from mapflow.schema.processing import AOI_NAME_MAX_LENGTH
+from mapflow.schema.template import AOI_NAME_MAX_LENGTH
 
 
 def _layer_with(features, with_name_field=True):
@@ -70,10 +71,27 @@ def test_aoi_details_rejects_overlong_name():
         plugin._build_template_aoi_details()
 
 
-def test_no_layer_returns_none():
+def test_no_layer_falls_back_to_aoi_as_one_unnamed_feature():
+    """Without a polygon layer (e.g. an image extent) aoiDetails is still built from the
+    combined AOI as a single unnamed feature — the deprecated plain `aoi` is never sent."""
     plugin = Mapflow.__new__(Mapflow)
     plugin.tr = lambda text: text
     plugin.dlg = MagicMock()
     plugin.dlg.polygonCombo.currentLayer.return_value = None
+    plugin.app_context = SimpleNamespace(aoi=QgsGeometry.fromWkt("POLYGON((0 0,0 1,1 1,1 0,0 0))"))
+
+    fc = plugin._build_template_aoi_details()
+
+    assert fc["type"] == "FeatureCollection"
+    assert len(fc["features"]) == 1
+    assert fc["features"][0]["properties"]["name"] is None
+
+
+def test_no_layer_no_aoi_returns_none():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.tr = lambda text: text
+    plugin.dlg = MagicMock()
+    plugin.dlg.polygonCombo.currentLayer.return_value = None
+    plugin.app_context = SimpleNamespace(aoi=None)
 
     assert plugin._build_template_aoi_details() is None

--- a/tests/qgis/test_template_navigation.py
+++ b/tests/qgis/test_template_navigation.py
@@ -100,6 +100,7 @@ def test_exit_template_view_emits_closed_signal_and_clears_state():
     service.active_template = template
     service.template_processings = {"p": object()}
     service.template_aois = {"a": object()}
+    service.processing_fetch_timer = MagicMock()
     received = []
     service.templateClosed.connect(lambda t: received.append(t))
 

--- a/tests/qgis/test_template_navigation.py
+++ b/tests/qgis/test_template_navigation.py
@@ -1,0 +1,111 @@
+"""QGIS-tier tests for the in-template navigation level (spec 002_F):
+Projects -> Processings -> Template, with left/right buttons and signals."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller.processing_controller import ProjectProcessingController
+from mapflow.functional.service.processing_service import ProcessingService
+
+
+def _bare_service():
+    """A ProcessingService with only its QObject base initialised (so signals work)."""
+    service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)
+    return service
+
+
+def _controller():
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    controller.tr = lambda text: text
+    controller.dlg = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.project_service = MagicMock()
+    controller.app_context = SimpleNamespace()
+    return controller
+
+
+def test_navigate_back_exits_template_when_inside():
+    controller = _controller()
+    controller.processing_service.in_template_mode = True
+    controller.exit_template = MagicMock()
+    controller.show_projects = MagicMock()
+
+    controller.navigate_back()
+
+    controller.exit_template.assert_called_once()
+    controller.show_projects.assert_not_called()
+
+
+def test_navigate_back_goes_to_projects_when_in_processings():
+    controller = _controller()
+    controller.processing_service.in_template_mode = False
+    controller.exit_template = MagicMock()
+    controller.show_projects = MagicMock()
+
+    controller.navigate_back()
+
+    controller.show_projects.assert_called_once()
+    controller.exit_template.assert_not_called()
+
+
+def test_navigate_into_template_requires_single_template():
+    controller = _controller()
+    controller.processing_service.in_template_mode = False
+    template = SimpleNamespace(id="t-1", name="T1")
+    controller.processing_service.selected_template.return_value = template
+    controller.processing_service.is_only_templates_selected.return_value = True
+    controller.enter_template = MagicMock()
+
+    controller.navigate_into_template()
+
+    controller.enter_template.assert_called_once_with(template)
+
+
+def test_navigate_into_template_noop_when_processing_selected():
+    controller = _controller()
+    controller.processing_service.in_template_mode = False
+    controller.processing_service.selected_template.return_value = SimpleNamespace(id="t-1")
+    controller.processing_service.is_only_templates_selected.return_value = False
+    controller.enter_template = MagicMock()
+
+    controller.navigate_into_template()
+
+    controller.enter_template.assert_not_called()
+
+
+def test_enter_template_view_emits_opened_signal():
+    service = _bare_service()
+    service.view = MagicMock()
+    service.view.sort_processings.return_value = ("CREATED", "DESC")
+    service.api = MagicMock()
+    service.processing_fetch_timer = MagicMock()
+    received = []
+    service.templateOpened.connect(lambda t: received.append(t))
+    template = SimpleNamespace(id="t-1", name="T1", aoi_dtos=lambda: [])
+    service._sort_key = lambda item, sort_by: ""
+
+    service._do_enter_template(template)
+
+    assert service.in_template_mode is True
+    assert service.active_template is template
+    assert received == [template]
+
+
+def test_exit_template_view_emits_closed_signal_and_clears_state():
+    service = _bare_service()
+    service.in_template_mode = True
+    template = SimpleNamespace(id="t-1", name="T1")
+    service.active_template = template
+    service.template_processings = {"p": object()}
+    service.template_aois = {"a": object()}
+    received = []
+    service.templateClosed.connect(lambda t: received.append(t))
+
+    service.exit_template_view()
+
+    assert service.in_template_mode is False
+    assert service.active_template is None
+    assert service.template_processings == {}
+    assert received == [template]

--- a/tests/qgis/test_template_pause_resume_permission.py
+++ b/tests/qgis/test_template_pause_resume_permission.py
@@ -23,6 +23,8 @@ def _plugin_with_template(user_role, is_active=True, status="READY"):
         isActive=is_active, status=status,
     )
     plugin.processing_service.selected_processing.return_value = None
+    # Selecting a template row happens in the processings list, not inside a template.
+    plugin.processing_service.in_template_mode = False
     plugin.app_context = SimpleNamespace(user_role=user_role)
     return plugin
 

--- a/tests/qgis/test_template_preview_layers.py
+++ b/tests/qgis/test_template_preview_layers.py
@@ -1,0 +1,76 @@
+"""QGIS-tier tests for preview-layer handling: de-duplicating by moving to top, and the
+in-template precedence (AOIs > previews > search-results footprints)."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from qgis.core import QgsProject, QgsVectorLayer
+
+from mapflow.mapflow import Mapflow
+
+
+def _mem_layer(name):
+    return QgsVectorLayer("Polygon?crs=epsg:4326", name, "memory")
+
+
+def _add(project, group, layer):
+    project.addMapLayer(layer, addToLegend=False)
+    group.addLayer(layer)
+    return layer
+
+
+def test_move_layer_to_top_brings_node_first():
+    project = QgsProject()
+    root = project.layerTreeRoot()
+    _add(project, root, _mem_layer("first"))
+    second = _add(project, root, _mem_layer("second"))
+
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.app_context = SimpleNamespace(project=project)
+
+    plugin._move_layer_to_top(second.id())
+
+    assert root.children()[0].layerId() == second.id()
+
+
+def test_relocate_preview_places_it_above_footprints_inside_template_group():
+    project = QgsProject()
+    root = project.layerTreeRoot()
+    mapflow_group = root.insertGroup(0, "Mapflow")
+    template_group = mapflow_group.insertGroup(0, "T1")
+    # AOI subgroup on top, footprints at the bottom of the template group.
+    template_group.insertGroup(0, "AOI: North")
+    footprints = _add(project, template_group, _mem_layer("metadata"))
+    # A preview added to the root (as the regular preview flow does).
+    preview = _add(project, root, _mem_layer("img-1 preview"))
+
+    plugin = Mapflow.__new__(Mapflow)
+    settings = MagicMock()
+    settings.value.return_value = "Mapflow"
+    plugin.app_context = SimpleNamespace(
+        project=project, settings=settings, plugin_name="Mapflow", metadata_layer=footprints,
+    )
+    plugin.processing_service = SimpleNamespace(
+        in_template_mode=True, active_template=SimpleNamespace(name="T1"),
+    )
+
+    plugin._relocate_preview_to_template_group(preview)
+
+    names = [c.name() for c in template_group.children()]
+    # Order within the template group: AOI subgroup, preview, footprints.
+    assert names == ["AOI: North", "img-1 preview", "metadata"]
+    # The preview no longer sits at the root.
+    assert all(getattr(c, "layerId", lambda: None)() != preview.id() for c in root.children())
+
+
+def test_relocate_preview_noop_outside_template_mode():
+    project = QgsProject()
+    root = project.layerTreeRoot()
+    preview = _add(project, root, _mem_layer("img-1 preview"))
+
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.app_context = SimpleNamespace(project=project)
+    plugin.processing_service = SimpleNamespace(in_template_mode=False, active_template=None)
+
+    plugin._relocate_preview_to_template_group(preview)
+
+    assert root.children()[-1].layerId() == preview.id()

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, call, patch
 from mapflow.functional.service import processing_service as processing_service_module
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.mapflow import Mapflow
-from mapflow.schema.processing import PostProcessingSchemaV2, RunTemplateProcessingSchema
+from mapflow.schema.processing import PostProcessingSchemaV2
+from mapflow.schema.template import RunTemplateProcessingSchema
 
 
 def _processing_payload():
@@ -216,7 +217,7 @@ def test_enter_template_view_unhydrated_fetches_then_enters():
 def test_load_template_layers_builds_per_aoi_subgroups_from_aoidetails():
 	"""Each AOI becomes a subgroup with its polygon (blue) + its processings (green),
 	all from aoiDetails — no per-processing AOI requests."""
-	from mapflow.schema.processing import AoiProcessingLink, TemplateAoiDTO
+	from mapflow.schema.template import AoiProcessingLink, TemplateAoiDTO
 
 	plugin = Mapflow.__new__(Mapflow)
 	plugin.tr = lambda text: text

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -150,39 +150,46 @@ def test_on_processings_selection_changed_restores_default_when_processing_selec
 	plugin.dlg.disable_processing_start.assert_not_called()
 
 
-def test_load_results_double_click_hydrated_template_opens_directly():
+def test_load_results_double_click_template_enters_template_view():
+	"""Double-clicking a template navigates 'one step right' via the controller."""
 	plugin = Mapflow.__new__(Mapflow)
 	plugin.processing_service = MagicMock()
-	# Template already carries its AOI (searchParams present) -> open without a refetch.
-	template = SimpleNamespace(id="template-1", _aoi_features=lambda: [{"type": "Feature"}])
+	template = SimpleNamespace(id="template-1")
 	plugin.processing_service.selected_template.return_value = template
-	plugin.select_template_processings = MagicMock()
-	plugin.show_template_search_results = MagicMock()
+	plugin.project_processing_controller = MagicMock()
 
 	plugin.load_results()
 
-	plugin.select_template_processings.assert_called_once()
-	plugin.show_template_search_results.assert_called_once()
-	plugin.processing_service.api.get_template.assert_not_called()
+	plugin.project_processing_controller.enter_template.assert_called_once_with(template)
 
 
-def test_load_results_double_click_unhydrated_template_fetches_then_opens():
-	plugin = Mapflow.__new__(Mapflow)
-	plugin.processing_service = MagicMock()
-	plugin.processing_service.templates = {}
-	# Poll list omitted searchParams -> _aoi_features is empty -> hydrate before opening.
-	template = SimpleNamespace(id="template-1", _aoi_features=lambda: [])
-	plugin.processing_service.selected_template.return_value = template
-	plugin.select_template_processings = MagicMock()
-	plugin.show_template_search_results = MagicMock()
+def test_enter_template_view_hydrated_skips_refetch():
+	"""A template that already carries its AOIs is entered without a refetch."""
+	service = ProcessingService.__new__(ProcessingService)
+	service.api = MagicMock()
+	service.templates = {}
+	service._do_enter_template = MagicMock()
+	template = SimpleNamespace(id="template-1", aoi_dtos=lambda: [object()])
 
-	plugin.load_results()
+	service.enter_template_view(template)
 
-	plugin.processing_service.api.get_template.assert_called_once()
-	assert plugin.processing_service.api.get_template.call_args.kwargs["template_id"] == "template-1"
-	# Opening is deferred to the hydration callback.
-	plugin.show_template_search_results.assert_not_called()
-	plugin.select_template_processings.assert_not_called()
+	service._do_enter_template.assert_called_once_with(template)
+	service.api.get_template.assert_not_called()
+
+
+def test_enter_template_view_unhydrated_fetches_then_enters():
+	"""A template missing its AOIs (project poll omits searchParams) is hydrated first."""
+	service = ProcessingService.__new__(ProcessingService)
+	service.api = MagicMock()
+	service.templates = {}
+	service._do_enter_template = MagicMock()
+	template = SimpleNamespace(id="template-1", aoi_dtos=lambda: [])
+
+	service.enter_template_view(template)
+
+	service.api.get_template.assert_called_once()
+	assert service.api.get_template.call_args.kwargs["template_id"] == "template-1"
+	service._do_enter_template.assert_not_called()
 
 	hydrated_payload = {
 		"template": {
@@ -198,38 +205,39 @@ def test_load_results_double_click_unhydrated_template_fetches_then_opens():
 	}
 	response = MagicMock()
 	response.readAll.return_value.data.return_value = json.dumps(hydrated_payload).encode()
-	callback = plugin.processing_service.api.get_template.call_args.kwargs["callback"]
+	callback = service.api.get_template.call_args.kwargs["callback"]
 
 	callback(response)
 
-	assert "template-1" in plugin.processing_service.templates
-	assert plugin.processing_service.templates["template-1"].searchParams is not None
-	plugin.show_template_search_results.assert_called_once()
-	plugin.select_template_processings.assert_called_once()
+	assert "template-1" in service.templates
+	service._do_enter_template.assert_called_once()
 
 
-def test_select_template_processings_deduplicates_linked_processing_aoi_requests():
+def test_load_template_layers_builds_per_aoi_subgroups_from_aoidetails():
+	"""Each AOI becomes a subgroup with its polygon (blue) + its processings (green),
+	all from aoiDetails — no per-processing AOI requests."""
+	from mapflow.schema.processing import AoiProcessingLink, TemplateAoiDTO
+
 	plugin = Mapflow.__new__(Mapflow)
 	plugin.tr = lambda text: text
-	plugin.server = "https://server"
-	plugin.http = MagicMock()
-	plugin.processing_service = MagicMock()
-	template = SimpleNamespace(id="template-1", name="Template A", _aoi_features=lambda: [])
-	plugin.processing_service.selected_template.return_value = template
-	plugin.processing_service.selected_processing.return_value = None
-	plugin._add_geojson_aoi_layer = MagicMock(return_value=SimpleNamespace(id=lambda: "layer-1"))
-	plugin._linked_processings_from_template = MagicMock(return_value=[
-		{"processingId": "proc-1", "processingName": "P1"},
-		{"processingId": "proc-1", "processingName": "P1"},
-		{"processingId": "proc-1", "processingName": "P1"},
-	])
+	plugin._add_geojson_aoi_layer = MagicMock()
 
-	with patch("mapflow.mapflow.alert"):
-		plugin.select_template_processings()
+	geom = {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
+	proc_geom = {"type": "Polygon", "coordinates": [[[0, 0], [0, 2], [2, 2], [0, 0]]]}
+	aoi = TemplateAoiDTO(
+		id="a1", name="North", geometry=geom,
+		processings=[AoiProcessingLink(processingId="p1", processingName="P1", geometry=proc_geom)],
+	)
+	template = SimpleNamespace(name="Template A", aoi_dtos=lambda: [aoi])
 
-	assert plugin.http.get.call_count == 1
-	kwargs = plugin.http.get.call_args.kwargs
-	assert kwargs["url"] == "https://server/processings/proc-1/aois"
+	plugin._load_template_layers(template)
+
+	# One AOI (blue) layer + one processing (green) layer, both in the AOI's subgroup.
+	assert plugin._add_geojson_aoi_layer.call_count == 2
+	styles = [c.kwargs["style_name"] for c in plugin._add_geojson_aoi_layer.call_args_list]
+	assert styles == ["aoi_template_blue.qml", "aoi_template_processing_green.qml"]
+	subgroups = {c.kwargs["subgroup_name"] for c in plugin._add_geojson_aoi_layer.call_args_list}
+	assert subgroups == {"AOI: North"}
 
 
 def _mark_seen_plugin(selected_rows=None):


### PR DESCRIPTION
Add a third navigation level (Projects -> Processings -> Template). Double-click or the forward arrow enters a template; the table shows its AOIs grouped with their processings (and a 'No AOI' section for unbound ones), the map gets a per-AOI subgroup (blue AOI + green processing footprints) with search footprints below, and selecting an AOI filters the search results (deselect restores all).

- Parse/send named AOIs (searchParams.aoiDetails); rename/add/delete AOIs via context menu.
- AOI status aggregates its processings; template status: Searching/Created/Updated/Failed.
- Add TemplateProcessingSchema for the v1 /processings shape (flat params); fix AOI update to POST; support DELETE-with-body in http.
- Spec 002_F updated; tests added/updated.