### PR TITLE
scope the AOI area limit to the open project's owner

### DIFF
--- a/mapflow/functional/app_context.py
+++ b/mapflow/functional/app_context.py
@@ -54,7 +54,8 @@ class AppContext:
     billing_type: Optional["BillingType"] = None
     remaining_limit: float = 0.0
     remaining_credits: float = 0.0
-    aoi_area_limit: float = 0.0
+    # None until a project is open; set from the open project's owner (user.aoiAreaLimit).
+    aoi_area_limit: Optional[float] = None
     template_area_limit: float = 0.0
     # Max AOI area (sq.km) allowed for an immediate imagery search; above it the user is
     # offered a Planned Search instead. Zero/absent disables the client-side check.

--- a/mapflow/functional/service/project_service.py
+++ b/mapflow/functional/service/project_service.py
@@ -41,10 +41,19 @@ class ProjectService(QObject):
     def set_current_project(self, project: MapflowProject):
         self.app_context.project_id = project.id
         self.app_context.current_project = project
+        self.apply_project_aoi_area_limit(project)
         if project.shareProject:
             self.app_context.user_role = project.shareProject.get_user_role(self.app_context.username)
         else:
             self.app_context.user_role = UserRole.owner
+
+    def apply_project_aoi_area_limit(self, project: Optional[MapflowProject]):
+        """Set the AOI area limit (sq.km) from the open project's owner (``user.aoiAreaLimit``,
+        sq.m), or None when there is no project / limit. For a shared project this is the owner's
+        limit — the one that actually applies — not the logged-in user's default-project limit."""
+        user = project.user if project else None
+        limit = user.aoiAreaLimit if user else None
+        self.app_context.aoi_area_limit = limit * 1e-6 if limit is not None else None
 
     def create_project(self, project: CreateProjectSchema):
         self.api.create_project(project, self.create_project_callback)
@@ -77,6 +86,7 @@ class ProjectService(QObject):
 
     def get_project_callback(self, response: QNetworkReply):
         self.app_context.current_project = MapflowProject.from_dict(json.loads(response.readAll().data()))
+        self.apply_project_aoi_area_limit(self.app_context.current_project)
         if self.app_context.current_project:
             self.app_context.project_id = self.app_context.current_project.id
             elided_name = self.dlg.currentProjectLabel.fontMetrics().elidedText(
@@ -208,6 +218,7 @@ class ProjectService(QObject):
             return
         if selected_id is None:
             self.app_context.current_project = self.app_context.project_id = None
+            self.apply_project_aoi_area_limit(None)  # no project open -> no AOI area limit
             self.app_context.settings.setValue("project_id", None)
             self.setup_project_change_rights()
             self.dlg.setWindowTitle(helpers.generate_plugin_header(self.app_context.plugin_name,
@@ -226,8 +237,9 @@ class ProjectService(QObject):
                         self.dlg.currentProjectLabel.width() - 50)
                     self.dlg.currentProjectLabel.setText(self.tr("Project: <b>{}").format(elided_name))
             if self.app_context.current_project:
+                self.apply_project_aoi_area_limit(self.app_context.current_project)
                 self.get_project_sharing()
-                self.view.setup_workflow_defs(self.app_context.current_project.workflowDefs, 
+                self.view.setup_workflow_defs(self.app_context.current_project.workflowDefs,
                                               self.config.DEFAULT_MODEL)
             self.setup_project_change_rights()
             self.app_context.settings.setValue("project_id", self.app_context.project_id)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -4220,7 +4220,6 @@ class Mapflow(QObject):
         default_project = MapflowProject.from_dict(response)
 
         self.update_processing_limit()
-        self.app_context.aoi_area_limit = userinfo['aoiAreaLimit'] * 1e-6
         # We have different behavior for admin as he has access to all processings
         self.is_admin = userinfo.get("role") == "ADMIN"
 

--- a/mapflow/schema/project.py
+++ b/mapflow/schema/project.py
@@ -55,6 +55,23 @@ class MapflowProjectInfo(SkipDataClass):
     ownerEmail: str
 
 @dataclass
+class MapflowProjectUser(SkipDataClass):
+    """The project owner's info from a project response's ``user`` section. For a SHARED project
+    this is the owner (not the logged-in user), so ``aoiAreaLimit`` here is the limit that applies
+    while the project is open. All limits are in square metres, as reported by the backend."""
+    id: Optional[str] = None
+    email: Optional[str] = None
+    role: Optional[str] = None
+    areaLimit: Optional[float] = None
+    aoiAreaLimit: Optional[float] = None
+    templateAreaLimit: Optional[float] = None
+    processedArea: Optional[float] = None
+    isPremium: Optional[bool] = None
+    reviewWorkflowEnabled: Optional[bool] = None
+    isCustomer: Optional[bool] = None
+
+
+@dataclass
 class MapflowProject(SkipDataClass):
     id: str
     name: str
@@ -62,6 +79,7 @@ class MapflowProject(SkipDataClass):
     description: Optional[str]
     workflowDefs: Optional[dict] = None
     shareProject: Optional[ShareProject] = None
+    user: Optional[MapflowProjectUser] = None
     updated: Optional[datetime] = None
     created: Optional[datetime] = None
     processingCounts: Optional[Dict[str, int]] = None
@@ -69,6 +87,8 @@ class MapflowProject(SkipDataClass):
     total: Optional[int] = Config.PROJECTS_PAGE_LIMIT
 
     def __post_init__(self):
+        if isinstance(self.user, dict):
+            self.user = MapflowProjectUser.from_dict(self.user)
         if self.workflowDefs:
             self.workflowDefs = {item['id']: WorkflowDef.from_dict(item) for item in self.workflowDefs}
         else:

--- a/tests/qgis/test_project_aoi_limit.py
+++ b/tests/qgis/test_project_aoi_limit.py
@@ -1,0 +1,56 @@
+"""QGIS-tier tests: the AOI area limit follows the OPEN project's owner (user.aoiAreaLimit).
+
+For a shared project the owner's limit applies, not the logged-in user's default-project limit,
+so the limit is set from the project's `user` section when a project is entered and reset to None
+on exit.
+"""
+from types import SimpleNamespace
+
+from mapflow.schema.project import MapflowProject, MapflowProjectUser
+from mapflow.functional.service.project_service import ProjectService
+
+
+def test_project_parses_user_section():
+    project = MapflowProject.from_dict({
+        "id": "p1", "name": "N", "isDefault": False, "description": None,
+        "user": {"aoiAreaLimit": 25000000, "areaLimit": 25000000, "role": "USER",
+                 "email": "owner@example.io", "isCustomer": True},
+    })
+    assert isinstance(project.user, MapflowProjectUser)
+    assert project.user.aoiAreaLimit == 25000000
+    assert project.user.email == "owner@example.io"
+
+
+def test_project_without_user_section_is_none():
+    project = MapflowProject.from_dict(
+        {"id": "p1", "name": "N", "isDefault": False, "description": None})
+    assert project.user is None
+
+
+def _service(initial=None):
+    service = ProjectService.__new__(ProjectService)
+    service.app_context = SimpleNamespace(aoi_area_limit=initial)
+    return service
+
+
+def test_apply_limit_from_owner_converts_sqm_to_sqkm():
+    service = _service()
+    service.apply_project_aoi_area_limit(
+        SimpleNamespace(user=SimpleNamespace(aoiAreaLimit=25_000_000)))  # 25 sq.km
+    assert service.app_context.aoi_area_limit == 25.0
+
+
+def test_apply_limit_resets_to_none_on_exit():
+    service = _service(initial=25.0)
+    service.apply_project_aoi_area_limit(None)
+    assert service.app_context.aoi_area_limit is None
+
+
+def test_apply_limit_none_when_user_or_limit_absent():
+    service = _service(initial=25.0)
+    service.apply_project_aoi_area_limit(SimpleNamespace(user=None))
+    assert service.app_context.aoi_area_limit is None
+
+    service.app_context.aoi_area_limit = 25.0
+    service.apply_project_aoi_area_limit(SimpleNamespace(user=SimpleNamespace(aoiAreaLimit=None)))
+    assert service.app_context.aoi_area_limit is None


### PR DESCRIPTION
aoi_area_limit was taken from the login/default-project user, so a shared project used the wrong (logged-in user's) limit instead of the owner's. Now it is None until a project is open and set from that project's user.aoiAreaLimit (the owner, for shared projects) on entering — from the cached /projects/page project, no extra request — and reset to None on exit. Expanded MapflowProject with the user section (MapflowProjectUser); app_context default is now None.