### PR TITLE
chore: run the qgis.org lint checks in Docker

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,143 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "\\.secrets\\.baseline$"
+      ]
+    }
+  ],
+  "results": {
+    "spec/002_E_zoom_selector_api.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "spec/002_E_zoom_selector_api.md",
+        "hashed_secret": "fd527137dc714da7f19bf01e668352e1ca5d0027",
+        "is_verified": false,
+        "line_number": 490
+      }
+    ]
+  },
+  "generated_at": "2026-08-05T09:09:38Z"
+}

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -22,6 +22,20 @@ RUN python3 -m pip install --no-cache-dir \
         pytest \
         pytest-qt
 
+# Static-analysis tools, mirroring the three checks plugins.qgis.org runs
+# on plugin submission (see spec/004_stack.md). They live in this image
+# rather than a host venv so every developer and CI get identical results
+# instead of whatever each machine happened to pip-install.
+#
+# Pinned deliberately: an unpinned linter silently changes its verdict when
+# upstream adds a rule, which turns an unrelated MR red. Bump on purpose.
+# detect-secrets in particular must match the version that generated
+# .secrets.baseline, or it rejects the baseline as unreadable.
+RUN python3 -m pip install --no-cache-dir \
+        flake8==7.3.0 \
+        bandit==1.9.4 \
+        detect-secrets==1.5.0
+
 # Run Qt without an X display by default; the UI tier overrides this
 # by wrapping pytest in `xvfb-run` (provides a real X server).
 ENV QT_QPA_PLATFORM=offscreen \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Test runner for mapflow-qgis.
+# Test and lint runner for mapflow-qgis.
 #
 # All targets run inside the qgis/qgis:release-3_28 Docker image so
 # host setup is irrelevant. See spec/004_stack.md and tests/README.md
@@ -7,12 +7,6 @@
 IMAGE ?= mapflow-qgis-tests
 DOCKERFILE ?= Dockerfile.tests
 DOCKER_RUN = docker run --rm -v "$(CURDIR)":/app -w /app $(IMAGE)
-
-# Linting runs on the HOST (not in the Docker image): ruff is AST-only and
-# pyright runs in lenient/basic mode, so neither needs the QGIS runtime. Both
-# are installed in the project venv; override RUFF/PYRIGHT to point elsewhere.
-RUFF ?= venv/bin/ruff
-PYRIGHT ?= venv/bin/pyright
 
 .PHONY: help docker-build test test-functional test-qgis test-ui lint clean
 
@@ -23,7 +17,7 @@ help:
 	@echo "  test-qgis         Run QGIS-runtime tests under tests/qgis/"
 	@echo "  test-ui           Run UI tests under tests/ui/ (xvfb-run)"
 	@echo "  test              Run all three tiers"
-	@echo "  lint              Run ruff + pyright on the host (uses project venv)"
+	@echo "  lint              Run the plugins.qgis.org checks (flake8 + bandit + detect-secrets)"
 	@echo "  clean             Remove pytest cache + bytecode"
 
 docker-build:
@@ -43,12 +37,18 @@ test-ui: docker-build
 
 test: test-functional test-qgis test-ui
 
-# Static analysis. Ruff catches unused code / real-bug patterns; pyright adds
-# flow analysis (possibly-unbound, undefined names) that ruff can't do.
-# Config lives in pyproject.toml (ruff) and pyrightconfig.json (pyright).
-lint:
-	$(RUFF) check mapflow tests
-	$(PYRIGHT)
+# Static analysis mirrors the three checks plugins.qgis.org runs on plugin
+# submission, using their invocations so a green run here predicts a clean
+# scan there: default flake8 rules at line-length 120, bandit at medium-or-
+# higher severity, detect-secrets against the committed baseline.
+#
+# Scope differs per tool on purpose. flake8 covers tests too — style debt in
+# tests is still debt. bandit covers only mapflow/: it is the code that ships,
+# and B101 (assert_used) would otherwise fire on every pytest assertion.
+lint: docker-build
+	$(DOCKER_RUN) flake8 --max-line-length=120 mapflow tests
+	$(DOCKER_RUN) bandit -r mapflow -ll --quiet
+	$(DOCKER_RUN) bash -c 'detect-secrets-hook --baseline .secrets.baseline $$(find mapflow tests -type f)'
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +


### PR DESCRIPTION
Replaces the host-venv ruff+pyright lint with the three tools that
plugins.qgis.org actually runs on plugin submission, executed in the same
image as the tests so results do not depend on what each developer happened
to pip-install.

## Why these three
Verified against the QGIS plugin repository's scanner rather than assumed:
bandit and detect-secrets are the blocking validators, flake8 is advisory.
Their invocations are mirrored here -- default flake8 rules at
--max-line-length=120, bandit -ll (medium+ severity), detect-secrets against
a committed .secrets.baseline, which is the same file their scanner looks
for. pyright is NOT part of the qgis.org checks and is dropped; the old
select=[F,B] ruff config was also narrower than qgis.org's default rule set,
which is why the 3.6.0 scan surfaced E-codes local lint could never report.

## Current baseline
- bandit: passes (exit 0)
- detect-secrets: passes (exit 0)
- flake8: ~1400 findings, ~1100 of them pure whitespace (W191 tabs 539,
  W293 157, W291 109). The substantive ones are E722 bare-except x16,
  F401 x73 (mostly intentional __init__.py re-exports, needs the
  per-file-ignore ruff used to have), F403/F405 star-import x2, E501 x93.
  Cleanup is WAL 3.7.0 step 1 work and lands on dev, not here.

## Scope
Watched files only, so agent-make unblocks in one merge. Tool versions are
pinned: an unpinned linter changes its verdict on upstream releases and turns
an unrelated MR red. detect-secrets in particular must match the version that
generated the baseline.

.secrets.baseline is included because the lint target references it -- writing
the target without it would force a second watched-file MR later just to add
the flag.
