### PR TITLE
chore: make WAL.md a lean forward-facing tracker

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -20,8 +20,9 @@ Follow `instructions/planning.md` exactly. Cross-reference the SESSION PROTOCOL 
 - After explicit user approval, `.plans/<branch>.md` (gitignored — see AGENTS.md PROJECT STRUCTURE for the branch-name derivation rule) with the detailed plan for handover to implementer/stabilizer
 
 **Write scope (enforce manually — your `tools:` frontmatter allows Write broadly)**
-- `.plans/<branch>.md` only.
-- Do NOT write to `mapflow/**`, `tests/**`, `spec/**`, `Makefile`, `Dockerfile.tests`, `AGENTS.md`, `WAL.md`.
+- `.plans/<branch>.md` and `WAL.md`.
+- You are one of only two authors of `WAL.md` (the other is the user) — implementer, stabilizer and reviewer read it but never write it. Add and refine `[ ]` planned entries there. Keep them short: the WAL tracks what is planned and in flight, and a step's rationale belongs in the commit message and `spec/`, not in the entry (see AGENTS.md WHERE THE WHY GOES).
+- Do NOT write to `mapflow/**`, `tests/**`, `spec/**`, `Makefile`, `Dockerfile.tests`, `AGENTS.md`.
 - Spec writes happen only after explicit user approval at the Spec Coverage Gate (step 4); if approved, update `spec/index.md` too.
 
 **Command scope**

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -11,7 +11,7 @@ Follow `instructions/review.md` for methodology, plus the matching pack under `i
 
 **Inputs (read only what is needed — token-budget aware)**
 - `agent-git diff dev...HEAD` — the staged diff (`dev` is the integration branch; see AGENTS.md BRANCH MODEL)
-- `WAL.md` — the persistent journal entry for this step (WHY + acceptance criteria)
+- `WAL.md` — the in-flight entry for this step (scope + acceptance criteria). A tracker line, not a write-up: check the WHY against the commit message and `spec/`, not the WAL.
 - Spec files referenced by the WAL step (do NOT re-read all of `/spec`)
 - Files touched by the diff and their immediate dependencies
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,11 @@ This is a **QGIS 3 plugin** (Python, Qt/PyQGIS). It ships as a zip to the QGIS p
   - /mapflow/schema: data schemas
   - /mapflow/errors: error types and user-facing messages
 - /tests: pytest suites, split by **runtime tier**, not by unit/integration — `functional/` (pure logic, no QGIS), `qgis/` (needs the QGIS runtime), `ui/` (Qt widgets, runs under xvfb)
-- WAL.md - persistent journal of completed steps and the WHY of each decision. Distilled, committed, survives across branches.
-- .plans/ - **gitignored** per-branch agent handover scratchpad. One file per feature branch: `.plans/<sanitized-branch-name>.md` (slashes in the branch name become dashes, e.g. `feature/foo-bar` → `.plans/feature-foo-bar.md`). Holds the detailed step plan, stabilization discoveries, push-back rounds, and Final Review Summary. Never reaches the remote; the distilled motivation lands in WAL.md at merge.
+- `WAL.md` — **lean, forward-facing** plan + in-flight tracker: holds only `[ ]` planned and `[ready-for-review]` in-flight steps. It is NOT a permanent journal. The **WHY** of completed work is preserved in (1) the change's **commit message** and (2) `spec/` files for durable decisions. When a step merges, its rationale is distilled into those places and the entry is **removed** from `WAL.md`.
+  - Authors: the **user** and the **planner**. Implementer, stabilizer and reviewer read it but never write it.
+  - Consult it when planning the next step — it should answer "what is left", not "what did we do".
+  - Corollary: never write anything into `WAL.md` that belongs in `spec/`. A decision that outlives the step is a spec change; the WAL entry only points at it.
+- .plans/ - **gitignored** per-branch agent handover scratchpad. One file per feature branch: `.plans/<sanitized-branch-name>.md` (slashes in the branch name become dashes, e.g. `feature/foo-bar` → `.plans/feature-foo-bar.md`). Holds the detailed step plan, stabilization discoveries, push-back rounds, and Final Review Summary. Never reaches the remote; its distilled insights land in the **commit message** (and `spec/`, if a durable decision changed) at merge.
 
 # SESSION PROTOCOL FOR FEATURE IMPLEMENTATION
 Execute it every time a session is initiated.
@@ -135,9 +138,10 @@ Execute it every time a session is initiated.
     - Reviewer inputs are limited to WAL.md, spec files referenced by the step, and the diff — the reviewer MUST NOT read `.plans/<branch>.md` (reading the implementer's step-by-step biases review toward plan-compliance instead of spec-compliance).
     - Reviewer appends Final Review Summary to `.plans/<branch>.md` before exit (fixed / push-backs accepted / push-backs confirmed / deferred / open questions / escalation reason if any) AND prints the summary in chat.
     - On escalation, STOP ITERATION and present the summary to user; do NOT proceed to step 12.
-12. Pre-merge WAL update (`AGENTS.md`):
-    - Update WAL step status to `[ready-for-review]` with concise motivation.
-    - Distil important insights from `.plans/<branch>.md` into the WAL.md motivation line. The `.plans/` file itself stays local — gitignored, no cleanup needed.
+12. Pre-merge distillation (`AGENTS.md`):
+    - Mark the WAL step `[ready-for-review]`. Keep the entry itself short — it is a tracker line, not a write-up.
+    - Distil the important insights from `.plans/<branch>.md` into **the commit message body** (the WHY), and into `spec/` for anything that outlives this step. The `.plans/` file stays local — gitignored, no cleanup needed.
+    - If a durable decision changed, the spec edit is part of THIS MR. Do not leave it as a WAL note to apply later.
 13. Commit, publish branch, and open Draft MR (`AGENTS.md`):
     - Commit work with a meaningful message — the subject doubles as the default MR title.
     - Publish branch and open the Draft MR in one shot:
@@ -151,28 +155,29 @@ Execute it every time a session is initiated.
     - Wait for user to confirm review outcome (`approved`, `changes requested`, or `merged`).
     - If `changes requested`: address feedback, push to the same MR, keep WAL status `[ready-for-review]`.
     - If `approved`: 
-    -- update WAL step status to `[v]`. 
-    -- create a follow-up commit for WAL update, and `agent-git push`. Then wait for user to merge.
+    -- **remove** the step's entry from `WAL.md` — its WHY is already in the commit message and, where durable, in `spec/`. Do not mark it done and leave it; the WAL only carries planned and in-flight work.
+    -- create a follow-up commit for the WAL removal, and `agent-git push`. Then wait for user to merge.
     -- `.plans/<branch>.md` is gitignored — no removal step needed; it stays on the local machine and is naturally orphaned when the branch is deleted.
-    - If `merged` (user merged directly without separate approval): update WAL step to `[v]` on `dev` (see step 15).
+    - If `merged` (user merged directly without separate approval): remove the entry on `dev` (see step 15).
 15. Post-merge finalization (`AGENTS.md`):
-    - If WAL was already updated to `[v]` in the MR (approval path): nothing to do, WAL is correct on `dev` after merge.
-    - If user merged without prior approval signal: `agent-git checkout dev && agent-git pull --ff-only`, mark WAL step `[v]`, then land it through a short-lived `chore/wal-*` branch + MR. A direct push from `dev` is blocked — `dev` carries none of the allowed branch prefixes (`feature/`, `fix/`, `chore/`, `refactor/`, `test/`, `agent/`).
+    - If the entry was already removed in the MR (approval path): nothing to do, `WAL.md` is correct on `dev` after merge.
+    - If user merged without prior approval signal: `agent-git checkout dev && agent-git pull --ff-only`, remove the step's entry, then land it through a short-lived `chore/wal-*` branch + MR. A direct push from `dev` is blocked — `dev` carries none of the allowed branch prefixes (`feature/`, `fix/`, `chore/`, `refactor/`, `test/`, `agent/`).
+    - Before removing, confirm the WHY actually survives elsewhere. If the rationale exists only in the WAL entry, it is not yet distilled — move it to `spec/` first, or the removal destroys it.
 
 # IMPLEMENTATION DEFINITION OF DONE (PRE-MERGE)
 - tests added/updated according to the feature specification
 - `agent-make test` runs successfully
 - review loop converged (0 open CRITICAL) or was explicitly escalated to user with Final Review Summary
 - branch pushed and `[Draft]` MR created
-- WAL step is updated to `[ready-for-review]` with concise motivation
+- WAL step is marked `[ready-for-review]`; the WHY is in the commit message body, and any durable decision is in `spec/`
 
 # APPROVAL DEFINITION OF DONE (PRE-MERGE)
 - user confirms `approved` in chat
-- WAL step is updated to `[v]` in the MR branch, pushed
+- the step's entry is **removed** from `WAL.md` in the MR branch, pushed
 - user merges the MR
 
 # WORKFLOW DEFINITION OF DONE (POST-MERGE)
-- MR is merged (WAL step already `[v]` from approval step)
+- MR is merged (the WAL entry was already removed at the approval step)
 - `dev` is up to date
 - if the step touched a watched file (`Makefile`, `Dockerfile.tests`), it has ALSO reached `master` — otherwise `agent-make` stays blocked for every later step (see BRANCH MODEL)
 
@@ -195,20 +200,47 @@ Execute it every time a session is initiated.
 - The main agent stays as orchestrator: it drives the session protocol above and dispatches each phase to the matching subagent.
 - In environments without subagent support (Copilot, generic agents), ignore `.claude/agents/` and execute the instruction files inline — the workflow is unchanged.
 
-# WAL MOTIVATION EXAMPLES
+# WHERE THE WHY GOES
+Three destinations, and the split is not optional — see PROJECT STRUCTURE for the WAL's scope.
+
+| content | destination | lifetime |
+|---|---|---|
+| what is planned / in flight | `WAL.md` | deleted when the step merges |
+| why this change was made | **commit message body** | forever, attached to the diff |
+| a decision that outlives the step | `spec/` | forever, findable without git |
+
+## WAL entries are tracker lines, not write-ups
+BAD — a WAL entry carrying rationale that belongs in the commit message:
+```
+[ready-for-review] Implement request to external service
+aiohttp is better than httpx for high throughput; limited connections to 20 because
+the server's DDoS protection starts rejecting around 40; retries use exponential
+backoff since the 502s are transient …
+```
+GOOD:
+```
+[ready-for-review] Implement request to external service
+```
+
+## Commit messages carry the WHY
 *Illustration — substitute your stack. The pattern (motivate the WHY, not the WHAT) is language-agnostic.*
 
-BAD EXAMPLE (describes WHAT, which is already obvious from code). Don't do this.
+BAD EXAMPLE (describes WHAT, which is already obvious from the diff). Don't do this.
 ```
-[v] Implement request to external service
+Implement request to external service
+
 Used aiohttp; set the number of connections to 20
 ```
 GOOD EXAMPLE:
 ```
-[v] Implement request to external service
+Implement request to external service
+
 aiohttp is better than httpx for high throughput
 limited connections to avoid server DDoS protection, issues can start around 40 connections
 ```
+If that rationale constrains future work — "we cap connections at 20" is a contract, not a
+one-off — it belongs in `spec/` as well. The commit message explains this change; the spec
+tells the next person what they may not break.
 
 # COMMANDS TO RUN
 All build/test invocations go through `agent-make` (raw `make` requires manual approval per call and bypasses watched-file verification).
@@ -252,6 +284,10 @@ Note: `agent-make` does not accept `VAR=val` overrides. Every test target alread
 - Use `extend-ignore`, never `ignore` — the latter *replaces* flake8's default ignore set and silently
   re-enables rules qgis.org itself does not report. flake8 parses config with `RawConfigParser`, so
   inline comments on value lines are a syntax error; keep comments on their own line.
+- Suppressing a bandit finding: the form is `# nosec B105  # reason` — test ID first, then a
+  **second `#`** before the prose. bandit captures everything after `nosec` up to the next `#` and
+  parses it as test IDs, so `# nosec - reason` makes it warn once per word, once per run. A bare
+  `# nosec` with the reason on the preceding line also parses cleanly.
 - **Known gap:** nothing in this toolchain replaces pyright's `reportPossiblyUnbound`
   (use-before-assignment across branches). flake8's `F821` covers undefined names only. Accepted
   deliberately for qgis.org parity; revisit after the refactor lands type annotations.

--- a/WAL.md
+++ b/WAL.md
@@ -1,4 +1,8 @@
-# Journal for active implementation planning
+# Planned and in-flight work
+
+Forward-facing only: `[ ]` planned, `[ready-for-review]` in flight. Entries are removed when they
+merge — the WHY lives in the commit message and, for durable decisions, in `spec/`.
+See AGENTS.md § WHERE THE WHY GOES.
 
 # V 3.7.0 LTR
 
@@ -12,60 +16,30 @@ However, as we don't want to release an "empty" version (without any user-facing
 
 ## 1. Refactoring
 
-[ ] Address the security check problems
-- The 3.6.0 security scan flagged several broad `try/except Exception` blocks that only logged
-  (previously swallowed silently). Narrow them to the specific exceptions actually expected, so
-  unrelated errors surface instead of being logged and ignored.
-- [ready-for-review] Move the `assert` key-collision checks in errors/error_message_list.py
-  `update()` to a unit test (Bandit B101). Decided: the merge only combines the statically-defined
-  ProcessingErrors/DataErrors/ApiErrors dicts at import, so the invariant is a source-code property
-  — a test catches it in CI, runs even under `python -O`, and costs nothing in production.
-  **Landed in `tests/functional/`, not `tests/qgis/` as this bullet originally said.** The check is
-  pure dict-key logic and touches no QGIS state, so spec/004_stack.md's tier definition puts it in
-  the functional tier; AGENTS.md SPECIFICATION GUIDELINES rule 2 makes the spec win over this WAL
-  line. `tests/functional/test_error_message.py` already imports the same module — precedent.
-  Tests are pairwise across the three registries rather than one merged-length check, so a failure
-  names the offending pair and the colliding key instead of just reporting a count mismatch.
-  Verified by mutation: planting a duplicate key makes exactly the relevant pair fail and leaves the
-  others passing. Without that check the test could have been vacuous.
-  These two asserts were the last thing blocking a green `agent-make lint` after the bandit `-ll`
-  removal, so this bullet had to land with the lint gate rather than after it.
-- [ready-for-review] Change the linter from current **ruff** to **flake8** and add **bandit** and
-  **detect-secrets** to match the qgis.org checks.
-  Verified against the qgis.org scanner rather than assumed: it runs exactly these three, and
-  **pyright is not among them** — so pyright is dropped. That is a real coverage loss, not just
-  cleanup: `reportPossiblyUnbound` (use-before-assignment across branches) has no replacement in
-  the new toolchain — flake8's F821 catches undefined names only — and this codebase has broad
-  `except Exception` handlers that would mask exactly that class of bug. Accepted for qgis.org
-  parity; revisit when the refactor lands type annotations.
-  The old ruff config (`select = ["F","B"]`) was *narrower* than qgis.org's default rule set, which
-  is why the 3.6.0 scan surfaced E-codes local lint could never report. Matching them raised the
-  count to ~1425, of which ~811 remain in a documented `.flake8` ledger.
-  CI ran **no lint at all** before this. That is the reason the gate went in first, ahead of the
-  cleanup bullets: without a ratchet, every finding-reduction MR is a snapshot the next MR silently
-  undoes — which is how 1425 findings accumulated. Ledger entries name the step that removes them
-  and the list only shrinks.
-  Closed outright rather than deferred: W191 (539 findings, 38% of the total, all in one test file
-  with uniform tab indentation — `git diff -w` empty proves the conversion was semantics-free) and
-  F403/F405 (one star-import line). Whitespace normalisation of the ~450 residual is deliberately
-  **deferred to immediately before the refactor branch cut**: it concentrates in `mapflow.py` and
-  the service layer, which the refactoring rewrites, so doing it now means doing it twice, and it
-  would make the in-flight `feature/track-uploaded-image-status` rebase materially worse.
-  F401 outside `__init__.py` is ledgered, not fixed: `tests/functional/conftest.py` documents a
-  circular-import chain that only resolves via partial-module caching, so a nominally unused import
-  may be load-bearing.
-  `# nosec` comments were emitting a bandit warning per site per run. The fix is not an ID prefix —
-  bandit captures everything after `nosec` up to the next `#`, so prose keeps getting parsed as test
-  IDs. Correct form is `# nosec B105  # reason`, with a second `#` terminating the capture.
-
 [ ] Bring `tests/test_imagery_search_multi.py` into a tier
 Discovered while wiring up the lint gate. The file sits at the tests root with 23 test
 functions, outside all three tiers. `make test` runs `pytest tests/functional`, `pytest
 tests/qgis`, `pytest tests/ui` with explicit paths, which override `testpaths = tests` in
 pytest.ini — so these 23 tests have **never run in CI**, and the spec's three-tier coverage
-claim is wrong by that much. Decide the correct tier (likely `qgis/`, it exercises search
-against real objects), move it, and fix whatever fails once it actually runs. Sizing is
-unknown until it runs — treat the failures as the real work, not the move.
+claim is wrong by that much. Pick the tier by runtime need, not by scope (spec/004_stack.md):
+the file is heavily mocked but imports `Config`, so confirm by running rather than assuming.
+Sizing is unknown until it runs — treat the failures as the real work, not the move.
+
+[ ] Narrow the broad exception handlers
+The 3.6.0 security scan flagged `try/except Exception` blocks that only log. Narrow them to the
+exceptions actually expected, so unrelated errors surface instead of being swallowed.
+Scope: 16 bare `except:` (provider_service 5, geometry 4, mapflow 2, http 2, layer_utils 2,
+catalog 1) and 38 `except Exception` (processing_service 14, mapflow 11, 9 files with 1–2).
+Acceptance: `E722` comes out of the `.flake8` ledger, and bandit reports no `B110`.
+Sequenced after the untiered tests: those 23 tests exercise provider_service and
+processing_service, the two heaviest files here, so they are the safety net for this change.
+
+[ ] Normalise the residual whitespace findings
+Clears most of the `.flake8` ledger (~450: W291/W292/W293/W391, E501, E1xx/E2xx/E3xx).
+**Ordering constraint:** must come *after* `feature/track-uploaded-image-status` is rebased and
+landed (§3), and immediately *before* the refactor branch cut. A whole-tree whitespace diff makes
+that rebase materially worse, and the findings concentrate in `mapflow.py` and the service layer,
+which the refactoring rewrites — normalising earlier means doing the work twice.
 
 [ ] Plan the refactoring
 Address known problems, be open to push back if the proposals are wrong; 

--- a/instructions/review.md
+++ b/instructions/review.md
@@ -9,7 +9,7 @@ Run a bounded, autonomous review loop over the staged diff to catch issues that 
 
 ## Inputs (read only what is needed — token-budget aware)
 - Diff vs. branch base (`agent-git diff master...HEAD`).
-- `WAL.md`: the persistent journal entry for this step — the WHY and acceptance criteria.
+- `WAL.md`: the in-flight entry for this step — scope and acceptance criteria. It is a tracker, not a write-up; the WHY lives in the commit message and in `spec/`.
 - Spec files referenced by the WAL step (do NOT re-read all of `/spec`).
 - Files touched by the diff and their immediate dependencies.
 


### PR DESCRIPTION
WAL.md was defined as a permanent journal of completed steps. It is now a
plan + in-flight tracker holding only planned and in-flight entries; a step's
entry is removed when it merges.

## Why
The WHY of a completed change has two better homes. The commit message keeps
it attached to the diff that made it, and spec/ keeps durable decisions
findable without knowing which commit to look at. A journal entry is a third
copy that drifts from both and grows without bound -- the two entries removed
here had reached 15 and 27 lines against an instruction that asked for a
concise motivation, which is what prompted this.

## Changes
- PROJECT STRUCTURE: new WAL definition, plus its two authors -- user and
  planner. Implementer, stabilizer and reviewer read it, never write it.
- Steps 12, 14, 15 and both Definition-of-Done sections: mark
  ready-for-review, then REMOVE on approval rather than marking done.
- Step 15 gains a guard: before removing an entry, confirm the WHY actually
  survives elsewhere. If it exists only in the WAL, it is not distilled yet
  and removal destroys it.
- WAL MOTIVATION EXAMPLES becomes WHERE THE WHY GOES: a table splitting
  content across WAL / commit message / spec, with examples of a tracker line
  versus a write-up.
- planner.md: WAL.md moved from its forbidden list to its write scope. The
  file previously forbade the planner from writing the very document it is
  now one of two authors of -- a direct contradiction of this convention.
- review.md and reviewer.md: 'persistent journal entry' rewritten, with the
  reviewer told to check the WHY against the commit message and spec rather
  than the WAL.

## WAL cleanup, applying the new rule to itself
Removed the two merged entries. Before deleting, verified their rationale
survives: the toolchain policy is in spec/004_stack.md, the ledger discipline
and pyright gap are in AGENTS.md, the deferral reasons are in .flake8's
comments, and the assert-to-test reasoning is in the test's docstring.

One gap surfaced and was fixed rather than lost: the '# nosec B105  # reason'
syntax rule existed only in a commit message, so it is now in AGENTS.md
STATIC ANALYSIS. That is the step-15 guard working on its first use.

Also promoted the whitespace-normalisation work out of a merged entry's prose
into its own planned entry -- it was forward-looking work buried inside a
completed step's write-up -- and reordered entries into execution order.
