### PR TITLE
test: bring the stranded imagery-search suite into the qgis tier

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -16,14 +16,7 @@ However, as we don't want to release an "empty" version (without any user-facing
 
 ## 1. Refactoring
 
-[ ] Bring `tests/test_imagery_search_multi.py` into a tier
-Discovered while wiring up the lint gate. The file sits at the tests root with 23 test
-functions, outside all three tiers. `make test` runs `pytest tests/functional`, `pytest
-tests/qgis`, `pytest tests/ui` with explicit paths, which override `testpaths = tests` in
-pytest.ini — so these 23 tests have **never run in CI**, and the spec's three-tier coverage
-claim is wrong by that much. Pick the tier by runtime need, not by scope (spec/004_stack.md):
-the file is heavily mocked but imports `Config`, so confirm by running rather than assuming.
-Sizing is unknown until it runs — treat the failures as the real work, not the move.
+[ready-for-review] Bring `tests/test_imagery_search_multi.py` into a tier
 
 [ ] Narrow the broad exception handlers
 The 3.6.0 security scan flagged `try/except Exception` blocks that only log. Narrow them to the

--- a/tests/functional/test_tier_layout.py
+++ b/tests/functional/test_tier_layout.py
@@ -1,0 +1,34 @@
+"""Every test file must live inside a tier directory, or it silently never runs.
+
+`make test` invokes pytest three times with explicit paths — `tests/functional`,
+`tests/qgis`, `tests/ui` — which override `testpaths = tests` in pytest.ini. A file
+dropped at the `tests/` root is therefore collected by neither, and CI stays green
+while the tests inside it never execute.
+
+That is not hypothetical: `tests/test_imagery_search_multi.py` sat there with 23 test
+functions that had never run once. Four of them failed the moment they were wired in,
+and three of those were masked by a harness bug that made the assertions vacuous.
+
+This guard is deliberately a test rather than a lint rule: it costs nothing, it runs in
+the same CI job as everything else, and it fails loudly with the offending filename.
+"""
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent.parent
+TIERS = ("functional", "qgis", "ui")
+
+
+def test_no_test_files_outside_a_tier():
+    stranded = sorted(path.name for path in TESTS_ROOT.glob("test_*.py"))
+    assert not stranded, (
+        f"Test file(s) at the tests/ root will never be collected by `make test`: "
+        f"{stranded}. Move each into one of {TIERS} — pick the tier by runtime need "
+        f"(see spec/004_stack.md), not by whether it looks like a unit test."
+    )
+
+
+def test_every_tier_directory_exists():
+    """A renamed or deleted tier would make `make test` fail obscurely at the pytest
+    invocation rather than here, where the reason is stated."""
+    missing = [tier for tier in TIERS if not (TESTS_ROOT / tier).is_dir()]
+    assert not missing, f"Missing tier director{'y' if len(missing) == 1 else 'ies'}: {missing}"

--- a/tests/qgis/test_imagery_search_multi.py
+++ b/tests/qgis/test_imagery_search_multi.py
@@ -2,6 +2,12 @@
 
 Spec reference: spec/002_B_processing_api.md (ImagerySearchSchema.imageIds: List[str]).
 
+Tier: qgis. Most cases here are mock-driven and would sit happily in the functional
+tier, but ``duplicate_imagery_search`` builds a real in-memory ``QgsVectorLayer`` and
+real ``QgsFeature``s, which is real QGIS state per spec/004_stack.md. The suite is kept
+together rather than split across tiers — both run in the same image, so the split would
+buy nothing and separate tests that belong side by side.
+
 Covers:
 1. Bug #1 — get_search_images_ids returns every selected row's image ID, not just row 0.
 2. Bug #3 — duplicate_imagery_search recreates one row per imageId so the
@@ -89,11 +95,16 @@ def _make_service(rows, provider_names, product_types, zooms=None,
 def _rows_with_ids(ids):
     from mapflow.config import Config
     config = Config()
-    width = config.SEARCH_ID_COLUMN_INDEX + 1
+    # Must be wide enough for LOCAL_INDEX_COLUMN, not just the ID column:
+    # get_local_image_indices() reads the local_index cell, and a short row makes
+    # metadataTable.item() return None -> AttributeError -> the service swallows it
+    # and returns [], silently skipping every provider/zoom/min-area validation.
+    width = max(config.SEARCH_ID_COLUMN_INDEX, config.LOCAL_INDEX_COLUMN) + 1
     rows = []
-    for image_id in ids:
+    for row_index, image_id in enumerate(ids):
         row = [""] * width
         row[config.SEARCH_ID_COLUMN_INDEX] = image_id
+        row[config.LOCAL_INDEX_COLUMN] = str(row_index)
         rows.append(row)
     return rows
 
@@ -292,8 +303,13 @@ class TestDuplicateImagerySearchMultiRow:
         dlg.metadataTable.rowCount.side_effect = lambda: row_count_holder["n"]
         set_items = []
         dlg.metadataTable.setItem.side_effect = lambda r, c, item: set_items.append((r, c, item))
+        # A real QgsGeometry, not a MagicMock: duplicate_imagery_search builds a real
+        # in-memory QgsVectorLayer and calls QgsFeature.setGeometry(), which rejects
+        # anything that is not a genuine geometry. This is why the file sits in the
+        # qgis tier — see the module docstring.
+        from qgis.core import QgsGeometry
         aoi_feature = MagicMock()
-        aoi_feature.geometry.return_value = MagicMock()
+        aoi_feature.geometry.return_value = QgsGeometry.fromWkt("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
         layer = MagicMock()
         layer.getFeatures.return_value = [aoi_feature]
         dlg.polygonCombo.currentLayer.return_value = layer
@@ -317,12 +333,12 @@ class TestDuplicateImagerySearchMultiRow:
         id_col = config.SEARCH_ID_COLUMN_INDEX
         id_items = [(r, item) for (r, c, item) in set_items if c == id_col]
         assert len(id_items) == 3
-        seen_ids = set()
-        for _r, item in id_items:
-            for call in item.setData.call_args_list:
-                args = call.args
-                if len(args) >= 2:
-                    seen_ids.add(args[1])
+        # Read the value off the real QTableWidgetItem rather than inspecting mock call
+        # history: the service constructs genuine items (setData(Qt.DisplayRole, value)),
+        # so there is no call_args_list — and asserting on stored state is the better
+        # check anyway, since it survives a refactor that sets the text differently.
+        from PyQt5.QtCore import Qt
+        seen_ids = {item.data(Qt.DisplayRole) for _r, item in id_items}
         assert seen_ids == set(image_ids)
         # Keys must be ints — `get_local_image_indices` casts the table text via int(),
         # so a string-keyed dict would KeyError downstream and leave the request without dataProvider.


### PR DESCRIPTION
tests/test_imagery_search_multi.py sat at the tests root with 23 test
functions that had never executed. make test invokes pytest three times with
explicit tier paths, which override testpaths in pytest.ini, so a file at the
root is collected by neither. Suite count goes 418 -> 441.

## What the tests found once they ran
Four failed immediately. Three shared one cause, and it was the interesting
one: the harness built table rows of width SEARCH_ID_COLUMN_INDEX + 1, which
is one column short of LOCAL_INDEX_COLUMN. metadataTable.item() then returned
None, .text() raised AttributeError, and get_local_image_indices swallowed it
into an empty list -- so every provider, zoom and min-area validation was
skipped.

That did not merely break three tests. It made their passing counterparts
vacuous: test_same_image_provider_no_error asserted 'no error' and passed
because the validation never ran at all. Fixing the row width turned three
failures into passes and, more importantly, made the green ones mean
something.

Worth noting for the handler-narrowing step: the reason this stayed silent is
provider_service.py catching (AttributeError, KeyError) around the whole
lookup. A narrower handler would have made it loud.

## Tier: qgis, not functional
Most cases are mock-driven and would fit the functional tier, but
duplicate_imagery_search builds a real in-memory QgsVectorLayer and real
QgsFeatures. QgsFeature.setGeometry rejects a MagicMock, and a real
QTableWidgetItem has no setData.call_args_list to inspect. Both were fixed by
using real objects: a real QgsGeometry for the AOI, and reading the stored
value via item.data(Qt.DisplayRole) instead of mock call history -- which is
the better assertion regardless, since it checks state rather than calls.

The suite is kept in one file rather than split across tiers. Both tiers run
in the same image, so a split would buy no runtime and separate tests that
belong together.

## Guard against recurrence
Adds tests/functional/test_tier_layout.py, which fails if any test_*.py sits
at the tests root. This cost 23 silently-dead tests for an unknown period; a
ten-line guard makes the next occurrence fail loudly with the filename.

## Verification
- agent-make test: 17 functional, 426 qgis, UI harness green
- agent-make lint: exit 0
