### PR TITLE
feat: bound the number of dialogs one recurring failure can open

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -86,6 +86,20 @@ and some are heavily python-coded or generated, and they are inconsistent in how
 - Should follow the plan proposed before
 - Should not break the tests implemented before (behavioral/e2e), allowed to rewrite/add unit tests
 
+[ ] Gate the features whose prerequisites never arrived — AFTER the refactoring
+Startup now stops retrying `/user/status` and `/rasters/memory` instead of polling forever,
+which is right for the traffic and wrong for the UI: the prerequisites those responses carry
+are simply missing, and the affected actions currently fail late or behave as if the limits
+were zero.
+- no `/user/status` → no billing type, no remaining limit/credits, no area caps. Processings
+  and templates must not be launchable. Viewing them stays available.
+- no `/rasters/memory` → no storage quota. My Imagery uploads must not be startable.
+Blocked controls should not be silently disabled: show why, plus a **Retry** button that
+re-runs the request and unblocks on success. Deferred past the refactoring because it needs
+one owner for "is this prerequisite satisfied" — today the answer is scattered across
+`app_context` fields set from inside `set_processing_limit`, which is exactly the god-object
+coupling the refactoring removes.
+
 ## 2. Add new zoom-selector feature
 [ ]
 - Use 002_E_zoom_selector_api.md

--- a/WAL.md
+++ b/WAL.md
@@ -26,16 +26,16 @@ Acceptance: `E722` comes out of the `.flake8` ledger, and bandit reports no `B11
 Sequenced after the untiered tests: those 23 tests exercise provider_service and
 processing_service, the two heaviest files here, so they are the safety net for this change.
 
-[ ] Deduplicate error-guard reports
-`report_unexpected_error` shows one dialog per occurrence. That is already wrong for the
-network path it is wired into: the status polls are timer-driven (`config.py` —
-PROCESSING_TABLE_REFRESH_INTERVAL 6s, TEMPLATE_TABLE_REFRESH_INTERVAL 15s,
-USER_STATUS_UPDATE_INTERVAL 30s), so one recurring bug in a poll callback spawns a dialog
-every few seconds and makes QGIS unusable — worse than the crash it replaced.
-Suppress by exception signature (type + final frame) within a window: report once, keep
-logging the rest, and say how many were suppressed when the dialog is finally shown.
-**Blocks the entry-point wrapping below** — widening the guard before this multiplies the
-failure mode rather than containing it.
+[ready-for-review] Deduplicate error-guard reports
+
+[ ] Restore user-facing errors on the polled paths
+Three call sites opt out of the default error handler purely to avoid stacked modals:
+`mapflow.py:482` (`refresh_status`), `mapflow.py:3042`, and `processing_api.py:89`
+(`get_processings`). The cost is that a real server error on those paths is invisible to
+the user. The throttle removes the reason for the workaround, so each can go back to
+`use_default_error_handler=True` — but `report_http_error` needs its own signature (Qt
+error code + endpoint path) before that is safe. Do this after the entry-point wrapping,
+so both dialog paths land on one suppression policy rather than two.
 
 [ ] Wrap user interactions in error_guard
 `guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher`

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -107,6 +107,11 @@ class Config:
     MAX_ZOOM = 21
     DEFAULT_ZOOM = MAX_FREE_ZOOM
     USER_STATUS_UPDATE_INTERVAL = 30  # seconds
+    STARTUP_STATUS_RETRY_INTERVAL = 500  # milliseconds
+    #: How many times startup may re-ask for /user/status before giving up. The plugin cannot
+    #: configure itself without that response, so it retries rather than failing on one
+    #: hiccup — but an unreachable server must not leave it retrying for the whole session.
+    STARTUP_STATUS_MAX_ATTEMPTS = 20
 
     MAX_FILE_SIZE_PIXELS = 30_000
     MAX_FILE_SIZE_BYTES = 2*(1024**3)

--- a/mapflow/error_guard.py
+++ b/mapflow/error_guard.py
@@ -21,6 +21,8 @@ import functools
 import logging
 from typing import Callable, Optional
 
+from .report_throttle import ReportThrottle, exception_signature
+
 logger = logging.getLogger(__name__)
 
 #: Shown above the traceback in the dialog. Deliberately plain: the user did nothing
@@ -30,6 +32,14 @@ DEFAULT_USER_TEXT = (
     "The plugin is still running — you can keep working. Sending the report below helps "
     "us fix it."
 )
+
+#: Appended when the same failure recurred while suppressed. A single dialog reads as a
+#: one-off glitch; the count is what tells the user (and us) it is systematic.
+REPEATED_USER_TEXT = "\n\nThis has happened {count} more time(s) since the last message."
+
+#: Process-wide, because the storm it prevents is process-wide: every guarded call site
+#: shares one budget. Tests substitute their own instance rather than reaching in here.
+_throttle = ReportThrottle()
 
 
 def _resolve_plugin_version(obj: object) -> str:
@@ -57,8 +67,17 @@ def report_unexpected_error(exception: BaseException,
 
     Never raises. A reporting path that can fail is worse than none: it would replace the
     original exception with its own, losing the very thing being reported.
+
+    Logging happens for every occurrence; only the *dialog* is throttled. The log is where
+    a developer reconstructs how often something fired, so thinning it would trade the one
+    complete record for nothing the user benefits from.
     """
     logger.error("Unexpected error during %s", context, exc_info=exception)
+
+    suppressed_count = _throttle.should_report(exception_signature(exception))
+    if suppressed_count is None:
+        return
+
     try:
         # Imported here, not at module scope: this module is imported early, and the
         # dialog pulls in the Qt widget tree. Keeping it lazy also means a headless
@@ -67,9 +86,13 @@ def report_unexpected_error(exception: BaseException,
         from .dialogs.error_message_widget import ErrorMessageWidget
         from .http import get_exception_report_body
 
-        summary, email_body = get_exception_report_body(exception, plugin_version, context)
+        summary, email_body = get_exception_report_body(exception, plugin_version, context,
+                                                        suppressed_count=suppressed_count)
+        text = DEFAULT_USER_TEXT
+        if suppressed_count:
+            text += REPEATED_USER_TEXT.format(count=suppressed_count)
         widget = ErrorMessageWidget(parent=parent or QApplication.activeWindow(),
-                                    text=DEFAULT_USER_TEXT,
+                                    text=text,
                                     title=summary,
                                     email_body=email_body)
         widget.show()

--- a/mapflow/http.py
+++ b/mapflow/http.py
@@ -306,7 +306,8 @@ def get_error_report_body(response: QNetworkReply,
 
 def get_exception_report_body(exception: BaseException,
                               plugin_version: str,
-                              context: str = ''):
+                              context: str = '',
+                              suppressed_count: int = 0):
     """Build (user-facing text, mailto body) for an unexpected internal exception.
 
     The counterpart of get_error_report_body for failures that never reached the network.
@@ -316,6 +317,10 @@ def get_exception_report_body(exception: BaseException,
 
     `context` names the operation that failed, in user-facing terms, because the exception
     type alone rarely tells the user what they were doing when it happened.
+
+    `suppressed_count` is how many identical failures were hidden since the last report
+    (see report_throttle). It changes the triage completely — a failure that fired 200
+    times sits on a timer-driven path, which the single traceback cannot reveal.
     """
     summary = f'{type(exception).__name__}: {exception}'
     traceback_lines = traceback.format_exception(type(exception), exception, exception.__traceback__)
@@ -328,7 +333,9 @@ def get_exception_report_body(exception: BaseException,
     report = {
         'Error summary': html.escape(summary),
         'Operation': context or 'unspecified',
-        **_environment_report(plugin_version),
-        'Traceback': '\n' + '\n'.join(traceback_text),
     }
+    if suppressed_count:
+        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
+    report.update(_environment_report(plugin_version))
+    report['Traceback'] = '\n' + '\n'.join(traceback_text)
     return summary, _format_email_body(report)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -205,11 +205,15 @@ class Mapflow(QObject):
         self.user_status_update_timer = QTimer(self.dlg)
         self.user_status_update_timer.setInterval(self.config.USER_STATUS_UPDATE_INTERVAL * 1000)
         self.user_status_update_timer.timeout.connect(self.refresh_status)
-        # Timer for user update at startup, in case get_processings request takes too long
-        # Stopped as soon as first /user/status request is made
+        # Retries /user/status until the response that configures the plugin arrives.
+        # A tick is skipped while a request is still in flight, so a slow or unreachable
+        # server produces one outstanding request rather than two per second.
         self.app_startup_user_update_timer = QTimer(self.dlg)
-        self.app_startup_user_update_timer.setInterval(500)
+        self.app_startup_user_update_timer.setInterval(self.config.STARTUP_STATUS_RETRY_INTERVAL)
         self.app_startup_user_update_timer.timeout.connect(self.first_status_request)
+        self._startup_status_attempts = 0
+        self._startup_status_pending = False
+        self._startup_status_given_up = False
 
         # ========== 5. SETUP TEMP DIRECTORY ==========
         # AlertService must exist before setup_tempdir: an unavailable working directory below (and
@@ -483,13 +487,52 @@ class Mapflow(QObject):
         )
 
     def first_status_request(self):
+        if self._startup_status_given_up or self._startup_status_pending:
+            return
+        if self._startup_status_attempts >= self.config.STARTUP_STATUS_MAX_ATTEMPTS:
+            # Latched rather than left to the stopped timer: giving up must be a terminal
+            # state, so a stray call cannot turn one warning into a modal per invocation.
+            self._startup_status_given_up = True
+            self.stop_startup_status_polling()
+            self.alert(self.tr('Could not load your account status from Mapflow.\n\n'
+                               'Some features stay unavailable until you reconnect and '
+                               'reopen the plugin.'),
+                       icon=QMessageBox.Warning)
+            return
+        self._startup_status_attempts += 1
+        self._startup_status_pending = True
         self.http.get(
             url=f'{self.server}/user/status',
-            callback=self.set_processing_limit,
-            callback_kwargs={'app_startup_request': True},
+            callback=self.first_status_callback,
+            error_handler=self.first_status_error_handler,
             use_default_error_handler=False
         )
+
+    def stop_startup_status_polling(self):
+        self.app_startup_user_update_timer.stop()
+        self._startup_status_pending = False
+
+    def first_status_callback(self, response: QNetworkReply) -> None:
+        """Apply the startup configuration carried by the first /user/status response.
+
+        The timer is stopped *before* the configuration runs, not after it. `set_processing_limit`
+        is invoked through the error guard, which swallows an exception and skips the rest of the
+        callback — so a stop placed after the configuration would never run on a bad response, and
+        the plugin would re-attempt the whole setup twice a second for the rest of the session.
+        See spec/006_error_reporting.md § Consequences for new code.
+        """
+        self.stop_startup_status_polling()
+        self.set_processing_limit(response, app_startup_request=True)
+        # Storage quota for My Imagery: needed once at startup, and refreshed later by
+        # mosaicsUpdated. Issuing it per retry would mean a second endpoint polled at the
+        # retry interval, with its own error dialog on every failed tick.
         self.data_catalog_service.get_user_limit()
+
+    def first_status_error_handler(self, response: QNetworkReply) -> None:
+        """Let the next tick retry, and surface the failure once the attempts run out."""
+        self._startup_status_pending = False
+        logger.warning("Startup /user/status attempt %s failed with Qt error %s",
+                       self._startup_status_attempts, response.error())
 
     def setup_add_layer_menu(self):
         self.add_layer_menu.addAction(self.draw_aoi)
@@ -3072,7 +3115,6 @@ class Mapflow(QObject):
 
         if app_startup_request:
             self.processing_service.update_processing_cost()
-            self.app_startup_user_update_timer.stop()
             self.dlg.setup_for_billing(self.app_context.billing_type)
             self.dlg.setup_for_review(self.app_context.review_workflow_enabled)
             self.dlg.modelCombo.activated.emit(self.dlg.modelCombo.currentIndex())
@@ -4087,6 +4129,7 @@ class Mapflow(QObject):
         self.app_context.settings.setValue('token', '')
         self.processing_service.processing_fetch_timer.stop()
         self.user_status_update_timer.stop()
+        self.stop_startup_status_polling()
         self.app_context.logged_in = False
         self.http.logout()
         self.dlg.close()
@@ -4246,6 +4289,10 @@ class Mapflow(QObject):
         self.dlg.setup_for_billing(self.app_context.billing_type)
         self.dlg.show()
         self.user_status_update_timer.start()
+        # Logging in again after a failed startup must get a full budget of retries.
+        self._startup_status_attempts = 0
+        self._startup_status_pending = False
+        self._startup_status_given_up = False
         self.app_startup_user_update_timer.start()
 
     def check_plugin_version_callback(self, response: QNetworkReply) -> None:

--- a/mapflow/report_throttle.py
+++ b/mapflow/report_throttle.py
@@ -1,0 +1,122 @@
+"""Suppression policy for repeated error reports.
+
+An error dialog is shown from paths that can fire on a timer. `AlertService.alert` and
+`ErrorMessageWidget` both open on top of QGIS's event loop, and a modal `exec()` runs a
+*nested* event loop — so QTimer keeps firing while a dialog is up, and dialogs stack rather
+than queue. One recurring failure in a poll callback therefore does not produce one dialog;
+it produces a new one every few seconds until QGIS is unusable.
+
+This module decides whether a given failure has already been reported recently enough to
+stay quiet about. It holds no Qt or QGIS imports on purpose: it must be usable from the
+earliest-imported modules, and it is the kind of arithmetic that should be testable without
+a QApplication.
+"""
+import time
+import traceback
+from typing import Callable, Dict, Optional
+
+#: Gap before the same failure may be shown again. Above the slowest poll
+#: (`config.py` USER_STATUS_UPDATE_INTERVAL, 30s), so a recurring failure in any poll
+#: callback cannot produce a second dialog on the following tick.
+FIRST_WINDOW_SECONDS = 60.0
+
+#: Ceiling for the doubling below. A persistent failure still resurfaces a couple of times
+#: an hour: going permanently silent would leave the user with broken behaviour and no
+#: remaining prompt to report it.
+MAX_WINDOW_SECONDS = 30 * 60.0
+
+#: Minimum gap between any two reports, whatever failed. Per-signature suppression alone
+#: does not stop several *different* exceptions rotating through the same callback — with
+#: PROCESSING_TABLE_REFRESH_INTERVAL at 6s, three alternating bugs would still yield a
+#: dialog every 6 seconds while each individual signature stayed within its window.
+GLOBAL_FLOOR_SECONDS = 10.0
+
+
+def exception_signature(exception: BaseException) -> str:
+    """Identity of a failure for suppression purposes: type plus the line it failed on.
+
+    Excludes the exception *message*, which routinely embeds ids, paths and counts — the
+    same bug would present a new signature on every occurrence and never be suppressed.
+    Excludes the operation context too: one failing line reached from two call paths is one
+    bug, and reporting it twice tells the maintainer nothing extra.
+    """
+    name = type(exception).__name__
+    traceback_object = getattr(exception, '__traceback__', None)
+    if traceback_object is None:
+        return name
+    frames = traceback.extract_tb(traceback_object)
+    if not frames:
+        return name
+    last_frame = frames[-1]
+    return f'{name}@{last_frame.filename}:{last_frame.lineno}'
+
+
+class _SignatureState:
+    """Per-signature bookkeeping. `shown_at` is None until the first report is shown."""
+
+    __slots__ = ('shown_at', 'window', 'suppressed')
+
+    def __init__(self, window: float) -> None:
+        self.shown_at: Optional[float] = None
+        self.window = window
+        self.suppressed = 0
+
+
+class ReportThrottle:
+    """Decides which error reports reach the user, and counts the ones that do not.
+
+    Every method is total — no input makes it raise. It is consulted while the plugin is
+    already handling a failure, so an exception escaping from here would replace the error
+    being reported with its own.
+
+    Unsynchronised on purpose: every caller is a Qt slot or a network-reply handler, all of
+    which run on the main thread. A lock here would guard against nothing.
+
+    Per-signature state is kept for the life of the session and never evicted. Signatures
+    are source locations, so the dictionary is bounded by the number of distinct raise
+    sites in the plugin — expiring entries would only discard the suppression counts that
+    make a report worth reading.
+    """
+
+    def __init__(self,
+                 first_window: float = FIRST_WINDOW_SECONDS,
+                 max_window: float = MAX_WINDOW_SECONDS,
+                 global_floor: float = GLOBAL_FLOOR_SECONDS,
+                 clock: Callable[[], float] = time.monotonic) -> None:
+        self._first_window = first_window
+        self._max_window = max_window
+        self._global_floor = global_floor
+        self._clock = clock
+        self._states: Dict[str, _SignatureState] = {}
+        self._last_shown_at: Optional[float] = None
+
+    def should_report(self, signature: str) -> Optional[int]:
+        """Return None to suppress, otherwise how many occurrences were suppressed since
+        the last shown report of this signature.
+
+        A suppressed occurrence is still counted, so the next dialog can say how much was
+        hidden. Callers log unconditionally — suppression governs the dialog, never the log.
+        """
+        now = self._clock()
+        state = self._states.get(signature)
+        if state is None:
+            state = _SignatureState(window=self._first_window)
+            self._states[signature] = state
+        elif state.shown_at is not None and now - state.shown_at < state.window:
+            state.suppressed += 1
+            return None
+
+        if self._last_shown_at is not None and now - self._last_shown_at < self._global_floor:
+            state.suppressed += 1
+            return None
+
+        if state.shown_at is not None:
+            # Doubling starts only from the second report: the first one defines the
+            # baseline window rather than consuming it.
+            state.window = min(state.window * 2, self._max_window)
+        state.shown_at = now
+        self._last_shown_at = now
+
+        suppressed = state.suppressed
+        state.suppressed = 0
+        return suppressed

--- a/spec/006_error_reporting.md
+++ b/spec/006_error_reporting.md
@@ -68,10 +68,33 @@ introduced to replace.
   and the report body. A traceback that fired 200 times describes a different bug from one
   that fired once, and the single traceback cannot show the difference.
 
+### A guarded callback is interrupted, not completed
+
+The guard swallows the exception and returns. Everything after the raise point in that
+callback **does not run** — including work the callback owns rather than merely performs:
+stopping a timer, clearing an in-flight flag, closing a dialog, releasing a lock.
+
+So a callback that owns a state transition must perform it **before** anything that can
+raise, or in a `finally`. Placing it at the end is only correct for code that cannot fail,
+and a network callback parsing a server payload always can.
+
+This is not theoretical. `set_processing_limit` ended with the stop for the 500 ms startup
+retry timer. When the response was malformed, the callback raised on the way there, the
+guard absorbed it, the timer was never stopped, and the plugin re-issued /user/status and
+/rasters/memory twice a second for the rest of the session — while the UI looked healthy.
+The guard did not cause that loop, but by absorbing the exception it removed the only
+signal that it was running.
+
+Corollary for retry loops: a poll that retries until it succeeds needs a bound and a
+terminal state, and the terminal state must be latched rather than implied by a stopped
+timer. "It cannot fire again because we stopped the timer" is the same reasoning that
+failed above.
+
 ### Consequences for new code
 
 - Any new timer-driven or event-loop-driven entry point must route unexpected failures
   through `error_guard`, never to a raw modal, and never to a bare log-and-continue.
+- A callback reached through the guard must not leave cleanup after code that can raise.
 - A network call that opts out of user-facing error handling
   (`use_default_error_handler=False`) must say in a comment why. Opting out to dodge repeat
   alerts is superseded by the throttle and should be reconsidered rather than copied.

--- a/spec/006_error_reporting.md
+++ b/spec/006_error_reporting.md
@@ -1,0 +1,78 @@
+# 006 Error reporting
+
+## Purpose
+Define how a failure reaches the user, which failures are allowed to interrupt them, and
+the volume limit that keeps an interruption from becoming a lockout.
+
+## Content
+
+### Expected versus unexpected
+
+Two categories, handled differently. Deciding which one a failure belongs to is the first
+question at every `except`.
+
+**Expected** — the failure is a foreseeable outcome of the operation: a validation error, a
+rejected input, a missing selection, a documented API error code. It is caught narrowly at
+the point it occurs, and answered there with a message that tells the user what to do
+("Please select a valid area of interest"). It is not a bug, and it must never open a
+report dialog: training users to send reports for their own typos guarantees the real
+reports get ignored too.
+
+**Unexpected** — the failure means plugin code is wrong. There is no correct local
+handling, because the code that would handle it is the code that is broken. It goes through
+`mapflow/error_guard.py`, which logs it with a traceback and offers a pre-filled report the
+user can send.
+
+An unexpected failure must never reach Qt's event loop unguarded. QGIS then shows its own
+raw unhandled-exception dialog, which names the plugin, offers the user no action, and is
+dismissed without a report ever being sent.
+
+### The three presentation tiers
+
+| tier | mechanism | use for |
+|---|---|---|
+| log | `logging` → QGIS message log | everything, always; the complete record |
+| message | `AlertService` modal / message bar | expected failures the user can act on |
+| report | `ErrorMessageWidget` + "Send a report" | unexpected failures only |
+
+The log tier is unconditional and is never thinned by suppression. It is where a developer
+reconstructs how often something fired and in what order, which is exactly the information
+the other two tiers discard.
+
+### Volume limit
+
+**Contract: no failure, however often it recurs, may produce an unbounded number of
+dialogs.**
+
+This is not a nicety. Plugin modals are opened with `exec()`, which runs a nested event
+loop, so `QTimer` keeps firing while a dialog is up and dialogs *stack* rather than queue.
+Several plugin operations are timer-driven — processing table refresh (6s), template table
+refresh (15s), user status (30s) — so an unthrottled failure on any polled path renders
+QGIS unusable. That is a worse outcome than the unhandled exception the reporting was
+introduced to replace.
+
+`mapflow/report_throttle.py` implements the limit:
+
+- Failures are identified by **signature** — exception type plus the source line it was
+  raised from. Not the message (messages carry ids and would make every occurrence look
+  new) and not the operation context (one broken line reached from two call paths is one
+  bug).
+- A signature that has just been reported is suppressed for a **window**, starting at 60s —
+  above the slowest poll interval — and **doubling on each further report**, capped at
+  30 minutes. A persistent failure therefore still resurfaces a couple of times an hour
+  rather than going permanently silent.
+- A **global floor** of 10s applies between any two reports regardless of signature. Per-
+  signature suppression alone does not stop several *different* exceptions rotating through
+  the same 6-second callback.
+- Suppressed occurrences are counted, and the count is carried into both the dialog text
+  and the report body. A traceback that fired 200 times describes a different bug from one
+  that fired once, and the single traceback cannot show the difference.
+
+### Consequences for new code
+
+- Any new timer-driven or event-loop-driven entry point must route unexpected failures
+  through `error_guard`, never to a raw modal, and never to a bare log-and-continue.
+- A network call that opts out of user-facing error handling
+  (`use_default_error_handler=False`) must say in a comment why. Opting out to dodge repeat
+  alerts is superseded by the throttle and should be reconsidered rather than copied.
+- Suppression must never be implemented by dropping log records.

--- a/spec/index.md
+++ b/spec/index.md
@@ -37,5 +37,8 @@ Used libraries, pinned versions where important, external system implementation 
 ## 005_interactions.md
 Integration boundaries: Mapflow backend, Keycloak OAuth2, QGIS application, local filesystem.
 
+## 006_error_reporting.md
+How failures reach the user: the expected/unexpected split, the three presentation tiers (log / message / report dialog), and the suppression contract that bounds dialog volume on timer-driven paths.
+
 ## etc.
-Additional documents can be added with increasing numeric prefixes (for example: `006_security.md`, `007_observability.md`).
+Additional documents can be added with increasing numeric prefixes (for example: `007_security.md`, `008_observability.md`).

--- a/tests/functional/test_error_guard.py
+++ b/tests/functional/test_error_guard.py
@@ -12,6 +12,7 @@ import pytest
 
 from mapflow import error_guard
 from mapflow.http import MAX_TRACEBACK_LINES, get_exception_report_body
+from mapflow.report_throttle import ReportThrottle
 
 
 class Boom(Exception):
@@ -20,6 +21,17 @@ class Boom(Exception):
 
 def _raise_boom():
     raise Boom("something specific went wrong")
+
+
+@pytest.fixture(autouse=True)
+def fresh_throttle(monkeypatch):
+    """A private suppression budget per test.
+
+    The production throttle is process-wide, so without this the first test to report an
+    error would push every later one inside the global floor and silently turn its dialog
+    assertions vacuous.
+    """
+    monkeypatch.setattr(error_guard, "_throttle", ReportThrottle())
 
 
 # ---------- report_unexpected_error ----------
@@ -53,6 +65,53 @@ def test_never_raises_even_if_the_dialog_fails(caplog):
 
     # Both the original failure and the reporting failure are recorded.
     assert "doing the thing" in caplog.text
+
+
+def test_a_repeated_failure_shows_one_dialog(caplog):
+    """The whole point: a bug on a 6-second poll must not open a dialog every 6 seconds."""
+    with patch("mapflow.dialogs.error_message_widget.ErrorMessageWidget") as widget, \
+            caplog.at_level(logging.ERROR, logger="mapflow.error_guard"):
+        for _ in range(20):
+            try:
+                _raise_boom()
+            except Boom as exc:
+                error_guard.report_unexpected_error(exc, "polling for processings", "1.0")
+
+    assert widget.call_count == 1
+    # Suppression governs the dialog only — the log keeps the full record.
+    assert len(caplog.records) == 20
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def test_the_next_dialog_reports_how_many_were_hidden(monkeypatch):
+    clock = _FakeClock()
+    # The floor is irrelevant with a single signature; the per-signature window is the
+    # mechanism under test.
+    monkeypatch.setattr(error_guard, "_throttle",
+                        ReportThrottle(first_window=60.0, global_floor=0.0, clock=clock))
+
+    with patch("mapflow.dialogs.error_message_widget.ErrorMessageWidget") as widget:
+        for _ in range(5):
+            try:
+                _raise_boom()
+            except Boom as exc:
+                error_guard.report_unexpected_error(exc, "polling", "1.0")
+        clock.now += 61.0
+        try:
+            _raise_boom()
+        except Boom as exc:
+            error_guard.report_unexpected_error(exc, "polling", "1.0")
+
+    assert widget.call_count == 2
+    text = widget.call_args.kwargs["text"]
+    assert "4 more time(s)" in text, "the count is what proves the failure is systematic"
 
 
 # ---------- guard_entry_point ----------
@@ -167,6 +226,30 @@ def test_short_traceback_is_not_truncated():
         _summary, body = get_exception_report_body(exc, "1.0", "ctx")
 
     assert "omitted" not in unquote(body)
+
+
+def test_report_body_states_how_many_repeats_were_suppressed():
+    """A traceback that fired 41 times is a timer-driven bug; one that fired once is not."""
+    from urllib.parse import unquote
+
+    try:
+        _raise_boom()
+    except Boom as exc:
+        _summary, body = get_exception_report_body(exc, "1.0", "ctx", suppressed_count=41)
+
+    decoded = unquote(body)
+    assert "41" in decoded and "suppressed" in decoded
+
+
+def test_report_body_omits_the_repeat_line_for_a_one_off():
+    from urllib.parse import unquote
+
+    try:
+        _raise_boom()
+    except Boom as exc:
+        _summary, body = get_exception_report_body(exc, "1.0", "ctx")
+
+    assert "suppressed" not in unquote(body)
 
 
 @pytest.mark.parametrize("context", ["", None])

--- a/tests/functional/test_report_throttle.py
+++ b/tests/functional/test_report_throttle.py
@@ -1,0 +1,174 @@
+"""Suppression policy for repeated error reports.
+
+The property under test is bounded dialog volume: a failure that fires on a 6-second timer
+must not produce a 6-second dialog cadence, while a failure the user has not seen yet must
+still get through. Time is injected rather than slept — the windows are minutes long.
+"""
+import pytest
+
+from mapflow.report_throttle import ReportThrottle, exception_signature
+
+
+class Boom(Exception):
+    pass
+
+
+class OtherBoom(Exception):
+    pass
+
+
+class FakeClock:
+    """Monotonic clock the test drives by hand."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock():
+    return FakeClock()
+
+
+@pytest.fixture
+def throttle(clock):
+    return ReportThrottle(first_window=60.0, max_window=480.0, global_floor=10.0, clock=clock)
+
+
+# ---------- exception_signature ----------
+
+def _raise_boom(message="id=8f21e0 failed"):
+    raise Boom(message)
+
+
+def _raise_boom_elsewhere():
+    raise Boom("id=8f21e0 failed")
+
+
+def _capture(func) -> BaseException:
+    try:
+        func()
+    except Exception as exception:
+        return exception
+    raise AssertionError("expected the helper to raise")
+
+
+def test_the_message_does_not_change_the_signature():
+    """Messages embed ids; keying on them would let one bug report on every poll tick."""
+    first = _capture(lambda: _raise_boom("id=8f21e0 failed"))
+    second = _capture(lambda: _raise_boom("id=c74b19 failed"))
+    assert exception_signature(first) == exception_signature(second)
+
+
+def test_the_same_exception_from_a_different_line_is_a_different_signature():
+    """Two unrelated bugs of the same type must not silence each other."""
+    assert exception_signature(_capture(_raise_boom)) \
+        != exception_signature(_capture(_raise_boom_elsewhere))
+
+
+def test_different_exception_types_differ():
+    def raise_other():
+        raise OtherBoom("boom")
+
+    assert exception_signature(_capture(_raise_boom)) != exception_signature(_capture(raise_other))
+
+
+def test_signature_survives_a_missing_traceback():
+    """Exceptions constructed but never raised have no traceback; reporting must not break."""
+    assert exception_signature(Boom("never raised")) == "Boom"
+
+
+# ---------- suppression ----------
+
+def test_first_occurrence_is_reported(throttle):
+    assert throttle.should_report("sig") == 0
+
+
+def test_immediate_repeat_is_suppressed(throttle, clock):
+    throttle.should_report("sig")
+    clock.advance(6.0)  # PROCESSING_TABLE_REFRESH_INTERVAL
+    assert throttle.should_report("sig") is None
+
+
+def test_a_six_second_poll_yields_a_handful_of_dialogs(throttle, clock):
+    """The failure this whole module exists for: a bug on the processings poll."""
+    reports = 0
+    for _ in range(60):  # six minutes at PROCESSING_TABLE_REFRESH_INTERVAL
+        if throttle.should_report("sig") is not None:
+            reports += 1
+        clock.advance(6.0)
+    # Shown at 0s, 60s and 180s as the window doubles 60 -> 120 -> 240.
+    assert reports == 3
+
+
+def test_report_after_the_window_carries_the_suppressed_count(throttle, clock):
+    throttle.should_report("sig")
+    for _ in range(5):
+        clock.advance(6.0)
+        assert throttle.should_report("sig") is None
+    clock.advance(60.0)
+    assert throttle.should_report("sig") == 5
+
+
+def test_the_count_resets_after_it_is_reported(throttle, clock):
+    throttle.should_report("sig")
+    clock.advance(30.0)
+    throttle.should_report("sig")  # suppressed, count 1
+    clock.advance(60.0)
+    assert throttle.should_report("sig") == 1
+    clock.advance(300.0)
+    assert throttle.should_report("sig") == 0
+
+
+def test_the_window_doubles_up_to_the_cap(throttle, clock):
+    throttle.should_report("sig")          # window 60
+    clock.advance(60.0)
+    throttle.should_report("sig")          # shown, window -> 120
+    clock.advance(61.0)
+    assert throttle.should_report("sig") is None, "61s is inside the 120s window"
+    clock.advance(60.0)
+    throttle.should_report("sig")          # shown at 121s, window -> 240
+
+    clock.advance(240.0)
+    throttle.should_report("sig")          # shown, window -> 480 (the cap)
+    clock.advance(480.0)
+    throttle.should_report("sig")          # shown, window stays 480
+    clock.advance(480.0)
+    assert throttle.should_report("sig") == 0, "the cap must stop the doubling"
+
+
+# ---------- the global floor ----------
+
+def test_a_different_failure_is_held_back_by_the_global_floor(throttle, clock):
+    """Distinct exceptions rotating through one poll callback would otherwise still storm."""
+    assert throttle.should_report("first") == 0
+    clock.advance(6.0)
+    assert throttle.should_report("second") is None
+
+
+def test_a_different_failure_passes_once_the_floor_has_elapsed(throttle, clock):
+    throttle.should_report("first")
+    clock.advance(11.0)
+    assert throttle.should_report("second") == 0
+
+
+def test_the_floor_still_counts_what_it_hides(throttle, clock):
+    throttle.should_report("first")
+    clock.advance(1.0)
+    assert throttle.should_report("second") is None
+    clock.advance(20.0)
+    assert throttle.should_report("second") == 1
+
+
+def test_three_alternating_failures_stay_bounded(throttle, clock):
+    reports = 0
+    for index in range(60):  # six minutes of a 6-second poll cycling three bugs
+        if throttle.should_report(f"sig-{index % 3}") is not None:
+            reports += 1
+        clock.advance(6.0)
+    assert reports <= 12, "the point of the floor is that this cannot approach 60"

--- a/tests/qgis/test_startup_status_poll.py
+++ b/tests/qgis/test_startup_status_poll.py
@@ -1,0 +1,136 @@
+"""The startup /user/status retry loop.
+
+The loop exists because the plugin cannot configure itself until that response arrives, so
+it re-asks every 500 ms. What it must never do is re-ask forever: each tick issues a
+request, and nothing else in the plugin bounds it. Two ways it used to run away —
+
+* the response arrived but `set_processing_limit` raised part-way through, so the stop that
+  sat at the end of that callback never ran (the error guard swallows the exception, and
+  everything after the raise point is skipped);
+* the response never arrived at all, because the error branch had no handler.
+
+Both left the plugin polling /user/status and /rasters/memory twice a second for the rest
+of the session, while looking healthy on screen.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QTimer
+from PyQt5.QtNetwork import QNetworkReply
+
+from mapflow.config import Config
+from mapflow.mapflow import Mapflow
+
+
+@pytest.fixture
+def plugin():
+    instance = Mapflow.__new__(Mapflow)
+    instance.tr = lambda text: text
+    instance.config = Config
+    instance.server = "https://example.invalid/api"
+    instance.http = MagicMock()
+    instance.alert = MagicMock()
+    instance.data_catalog_service = MagicMock()
+    instance.app_startup_user_update_timer = QTimer()
+    instance.app_startup_user_update_timer.setInterval(Config.STARTUP_STATUS_RETRY_INTERVAL)
+    instance._startup_status_attempts = 0
+    instance._startup_status_pending = False
+    instance._startup_status_given_up = False
+    instance.app_startup_user_update_timer.start()
+    return instance
+
+
+def _failed_response():
+    response = MagicMock()
+    response.error.return_value = QNetworkReply.HostNotFoundError
+    return response
+
+
+def test_a_tick_is_skipped_while_a_request_is_in_flight(plugin):
+    """Ticks are not synchronised with responses, so without this a slow server would
+    accumulate one outstanding request per 500 ms."""
+    plugin.first_status_request()
+    plugin.first_status_request()
+    plugin.first_status_request()
+
+    assert plugin.http.get.call_count == 1
+
+
+def test_the_next_tick_retries_once_the_previous_request_failed(plugin):
+    plugin.first_status_request()
+    plugin.first_status_error_handler(_failed_response())
+    plugin.first_status_request()
+
+    assert plugin.http.get.call_count == 2
+    assert plugin.app_startup_user_update_timer.isActive(), "a single failure is not fatal"
+
+
+def test_polling_stops_and_the_user_is_told_after_the_attempt_budget(plugin):
+    for _ in range(Config.STARTUP_STATUS_MAX_ATTEMPTS):
+        plugin.first_status_request()
+        plugin.first_status_error_handler(_failed_response())
+
+    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
+    assert plugin.app_startup_user_update_timer.isActive(), "the budget is not spent yet"
+
+    plugin.first_status_request()
+
+    assert not plugin.app_startup_user_update_timer.isActive()
+    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS, "no further requests"
+    plugin.alert.assert_called_once()
+
+
+def test_no_further_requests_after_the_budget_is_spent(plugin):
+    for _ in range(Config.STARTUP_STATUS_MAX_ATTEMPTS + 5):
+        plugin.first_status_request()
+        plugin.first_status_error_handler(_failed_response())
+
+    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
+    assert plugin.alert.call_count == 1, "give up once, not once per tick"
+
+
+def test_a_raising_configuration_still_stops_the_poll(plugin):
+    """The regression: the stop must not depend on the configuration succeeding."""
+    plugin.set_processing_limit = MagicMock(side_effect=TimeoutError("injected"))
+
+    with pytest.raises(TimeoutError):
+        plugin.first_status_callback(MagicMock())
+
+    assert not plugin.app_startup_user_update_timer.isActive()
+
+
+def test_the_storage_quota_is_requested_once_on_success_not_per_retry(plugin):
+    """/rasters/memory used to be issued from every tick, doubling the runaway traffic."""
+    plugin.set_processing_limit = MagicMock()
+
+    plugin.first_status_request()
+    plugin.first_status_error_handler(_failed_response())
+    plugin.first_status_request()
+    plugin.data_catalog_service.get_user_limit.assert_not_called()
+
+    plugin.first_status_callback(MagicMock())
+    plugin.data_catalog_service.get_user_limit.assert_called_once()
+
+
+def test_a_successful_startup_stops_the_poll(plugin):
+    plugin.set_processing_limit = MagicMock()
+
+    plugin.first_status_callback(MagicMock())
+
+    assert not plugin.app_startup_user_update_timer.isActive()
+    plugin.set_processing_limit.assert_called_once()
+    assert plugin.set_processing_limit.call_args.kwargs == {"app_startup_request": True}
+
+
+def test_logout_stops_a_startup_poll_that_never_finished(plugin):
+    """Otherwise a failed startup keeps polling the account endpoint after logging out."""
+    plugin.app_context = SimpleNamespace(settings=MagicMock(), logged_in=True)
+    plugin.processing_service = MagicMock()
+    plugin.user_status_update_timer = MagicMock()
+    plugin.dlg = MagicMock()
+    plugin.dlg_login = MagicMock()
+
+    plugin.logout()
+
+    assert not plugin.app_startup_user_update_timer.isActive()


### PR DESCRIPTION
The guard added in 8161ca0 shows a report dialog per occurrence, and it is wired into
Http.response_dispatcher, which runs on every async response. Both branches there go
through call_guarded, so use_default_error_handler=False does not cover it: a callback
that raises on the 6-second processings poll opens a dialog every six seconds.

Stacking, not queueing, is what makes that fatal. Plugin modals open with exec(), which
runs a nested event loop, so QTimer keeps firing while a dialog is up. The guard as it
stood could therefore leave QGIS less usable than the unhandled exception it replaced.

Failures are keyed by exception type plus the line they were raised from. The message is
excluded because messages carry ids and paths, which would make every occurrence look
new; the operation context is excluded because one broken line reached from two call
paths is one bug. The window starts at 60s - above USER_STATUS_UPDATE_INTERVAL, the
slowest poll - and doubles per report to a 30-minute cap, so a persistent failure still
resurfaces a couple of times an hour instead of going silent for good. A 10s global floor
covers the case per-signature suppression cannot: several different exceptions rotating
through the same 6-second callback.

Suppressed occurrences are counted and the count reaches both the dialog and the mail
body. A traceback that fired 200 times is a timer-driven bug and a traceback that fired
once is not, and the traceback alone cannot show which one you have. Logging stays
unconditional - the log is the only complete record of ordering and frequency.

Placed at mapflow/ root rather than functional/service/: it must be importable from
error_guard, and functional/service/ sits on the circular import chain documented in
tests/functional/conftest.py.

The contract this establishes - no failure may produce unbounded dialogs, and expected
failures never reach the report path - is recorded in spec/006_error_reporting.md, since
it constrains every future entry point wired into the guard.

Follow-up now unblocked and added to WAL: three call sites opt out of the default error
handler purely to avoid stacked modals (mapflow.py:482, mapflow.py:3042,
processing_api.py:89), which hides real server errors from users. The throttle removes
the reason for that workaround.

## Manual test

New behaviour - make a polled callback fail repeatedly, e.g. raise unconditionally in
ProcessingService.get_processings_callback, then open a project so the 6s poll runs:
- exactly one report dialog appears, and QGIS stays usable; before this change a new
  dialog appeared every six seconds and could not be outrun
- leave it failing for ~2 minutes: a second dialog appears saying "This has happened N
  more time(s) since the last message", and "Send a report" contains a Repeated: line
- make two different callbacks fail on the same poll: dialogs are spaced ~10s apart at
  minimum, not one per failure

Regression surface:
- a single one-off unexpected failure must still open its dialog immediately, with no
  "This has happened" line and no Repeated: line in the report body
- HTTP error dialogs (report_http_error) are untouched and are NOT throttled - trigger a
  server error from a button press twice in a row and confirm both still show, since
  those are user-paced and suppressing them would hide a second, different failure
- the guard must still not swallow anything: the QGIS log panel gets a full traceback for
  every occurrence, including the suppressed ones
