### PR TITLE
docs: plan the 3.7.0 refactoring against measured structure, not intuition

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -28,16 +28,32 @@ means the extraction MRs move less code and read as pure moves.
 `entity/status.py` is byte-identical to `schema/status.py` except one relative import, and
 nothing imports `entity/processing.py` or `entity/status.py` at all. `requests/` holds only an
 empty `__init__.py`. ~340 lines plus a package.
-Note while deleting: two `ProcessingStatus` enum classes exist at runtime today, and members of
-the two are never equal. Confirm nothing compares across them before assuming this is inert.
+**Do the duplicate-enum check first**: two `ProcessingStatus` classes exist at runtime and
+members of the two are never equal. Find whether any code compares a status originating from
+`entity` with one from `schema` before assuming the deletion is inert — if it does, that is a
+live bug and gets its own fix commit ahead of the deletion.
 
-[ ] Break the `schema` ⇄ `entity.provider` import cycle
+[ ] Break the `schema` ⇄ provider import cycle
 `schema/processing.py:12` imports `entity.provider.provider.SourceType`; importing the
 `entity.provider` package runs `basemap_provider`, which imports `schema.processing` back.
 Move the provider primitives (`SourceType`, `CRS`, `BasicAuth`) into a leaf module that imports
 nothing from the plugin.
+Do this **before or with** the move of `entity/provider/` into `schema/` — relocating both ends
+of the cycle into one package does not break it.
 Acceptance: the retry loops in `tests/functional/conftest.py` and `tests/qgis/conftest.py` are
 deleted and both tiers still pass. Their absence is the regression check.
+
+[ ] Move `entity/provider/` into `schema/`, delete `entity/`
+`schema/provider.py` (the API return schema) and the provider package collide on the name;
+resolve by making `schema/provider/` a package and moving the existing module into it. The
+`__init__` re-exports, so most import sites are unchanged.
+
+[ ] Architecture invariant test
+`tests/functional/test_layering.py` — no service imports a widget, `dialogs`, or `view`; no
+`schema` module imports a layer above it; no import cycles. Current violations go in an
+explicit allowlist that later steps only shrink.
+Written now, not after the extraction, so every new line is held to the rule from the start.
+Precedent and rationale: `tests/functional/test_tier_layout.py`.
 
 [ ] Narrow the remaining broad exception handlers
 38 `except Exception` sites (processing_service 14, mapflow 11, nine files with 1–2).
@@ -66,31 +82,37 @@ the code they pin moves; no step may leave a behaviour covered by neither.
 One domain per MR, each ending with `mapflow.py` smaller and no behaviour changed. Ordered
 leaf-first so each extraction depends only on what already moved.
 
-[ ] Extract AOI editing and AOI layers → `service/aoi_service.py` + controller
-[ ] Extract preview → `service/preview_service.py`
-[ ] Extract imagery search and the local filter → `service/search_service.py` + `view/search_view.py`
-[ ] Extract templates → `service/template_service.py` (the largest domain, ~55 methods)
+Service and controller boundaries are tabulated in `spec/007_architecture.md`.
+
+[ ] Extract AOI editing and AOI layers → `AoiService` + `ProcessingController` wiring
+[ ] Extract preview → `PreviewService`
+[ ] Extract imagery search → `SearchService` + `SearchController` + `view/search_view.py`
+[ ] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
+[ ] Extract templates → `TemplateService` + `TemplateController` (largest domain, ~55 methods
+    in `mapflow.py` plus the template half of `processing_service.py`)
 [ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
-[ ] Extract session and account status → `service/session_service.py`
-[ ] Reduce what remains to `plugin.py` — initGui/unload, wiring, construction
-Acceptance for the phase: no `self.dlg.<widget>` access in `plugin.py`, and no service imports a
-widget (`spec/007_architecture.md` invariants 1 and 5).
+[ ] Split auth from account status → `SessionService` + `AccountService`
+[ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction
+Acceptance for the phase: no `self.dlg.<widget>` access in `mapflow.py`, and the layering test's
+allowlist is empty (`spec/007_architecture.md` invariants 1 and 5).
 
 ### Phase D — move the packages
 
 Mechanical, and cheaper here than earlier: the god object is gone, so fewer files churn.
 
 [ ] `functional/` dissolved: `api/`, `controller/`, `service/`, `view/` to the root; `app_context`
-    → `context.py`; `auth`, `geometry`, `helpers`, `layer_utils` to their layer homes
-[ ] `schema/` + the live `entity/provider/` → `model/`; `http`, `error_guard`, `report_throttle`,
-    `log_config`, `styles` → `infra/`
+    → `context.py`; `geometry`, `helpers`, `styles` to the root; `auth` → `SessionService`;
+    `layer_utils` → `ResultService` plus the layer-tree helpers in `view/`
+[ ] `http`, `error_guard`, `report_throttle`, `log_config` → `infra/`
 
 ### Phase E — UI consistency
 
-[ ] One consistent way to build a dialog
-All 13 dialogs load a `.ui` file, so the inconsistency is how much Python is layered on top —
-`main_dialog.py` is 803 lines and builds widgets programmatically in several places. Decide the
-rule, then apply it.
+[ ] Move static widgets out of Python and into the `.ui` files
+The loading pattern is already right — every dialog uses `uic.loadUiType` and no `pyuic5`
+output is committed. What breaks Designer is the Python layered on top, chiefly in
+`main_dialog.py` (803 lines), which builds statically-placed widgets in code where Designer
+cannot see them. Rules and the acceptance test in `spec/007_architecture.md` § Dialogs and
+.ui files.
 
 [ ] Review what the plugin stores in settings
 Against `spec/003_local_storage.md`; drop what is no longer read.

--- a/WAL.md
+++ b/WAL.md
@@ -33,24 +33,19 @@ members of the two are never equal. Find whether any code compares a status orig
 `entity` with one from `schema` before assuming the deletion is inert — if it does, that is a
 live bug and gets its own fix commit ahead of the deletion.
 
-[ ] Break the `schema` ⇄ provider import cycle
-`schema/processing.py:12` imports `entity.provider.provider.SourceType`; importing the
-`entity.provider` package runs `basemap_provider`, which imports `schema.processing` back.
-Move the provider primitives (`SourceType`, `CRS`, `BasicAuth`) into a leaf module that imports
-nothing from the plugin.
-Do this **before or with** the move of `entity/provider/` into `schema/` — relocating both ends
-of the cycle into one package does not break it.
+[ ] Split `schema/` and `model/`, break the import cycle, delete `entity/`
+One step, because the cycle fix and the split are the same change seen twice
+(`spec/007_architecture.md` § schema/ versus model/).
+- provider primitives (`SourceType`, `CRS`, `BasicAuth`) → a leaf module in `schema/`
+- `entity/provider/` → `model/provider/`, importing those primitives from `schema/`
+- `schema/processing_history.py` → `model/` (it persists to QgsSettings, not to the wire)
+- everything else stays in `schema/`; `entity/` is gone
 Acceptance: the retry loops in `tests/functional/conftest.py` and `tests/qgis/conftest.py` are
 deleted and both tiers still pass. Their absence is the regression check.
 
-[ ] Move `entity/provider/` into `schema/`, delete `entity/`
-`schema/provider.py` (the API return schema) and the provider package collide on the name;
-resolve by making `schema/provider/` a package and moving the existing module into it. The
-`__init__` re-exports, so most import sites are unchanged.
-
 [ ] Architecture invariant test
-`tests/functional/test_layering.py` — no service imports a widget, `dialogs`, or `view`; no
-`schema` module imports a layer above it; no import cycles. Current violations go in an
+`tests/functional/test_layering.py` — no service imports a widget, `dialogs`, or `view`;
+`schema/` imports nothing from `model/` or above; no import cycles. Current violations go in an
 explicit allowlist that later steps only shrink.
 Written now, not after the extraction, so every new line is held to the rule from the start.
 Precedent and rationale: `tests/functional/test_tier_layout.py`.
@@ -104,6 +99,8 @@ Mechanical, and cheaper here than earlier: the god object is gone, so fewer file
     → `context.py`; `geometry`, `helpers`, `styles` to the root; `auth` → `SessionService`;
     `layer_utils` → `ResultService` plus the layer-tree helpers in `view/`
 [ ] `http`, `error_guard`, `report_throttle`, `log_config` → `infra/`
+Note: the `schema/` ⇄ `model/` split already happened in Phase A, so this phase is package
+moves only — no type is reclassified here.
 
 ### Phase E — UI consistency
 

--- a/WAL.md
+++ b/WAL.md
@@ -16,89 +16,120 @@ However, as we don't want to release an "empty" version (without any user-facing
 
 ## 1. Refactoring
 
+Target structure, layer rules and invariants: **`spec/007_architecture.md`**. The steps below
+are the route there. Phases run in order; each step is one MR.
 
-[ ] Narrow the broad exception handlers
-The 3.6.0 security scan flagged `try/except Exception` blocks that only log. Narrow them to the
-exceptions actually expected, so unrelated errors surface instead of being swallowed.
-Scope: 16 bare `except:` (provider_service 5, geometry 4, mapflow 2, http 2, layer_utils 2,
-catalog 1) and 38 `except Exception` (processing_service 14, mapflow 11, 9 files with 1–2).
-Acceptance: `E722` comes out of the `.flake8` ledger, and bandit reports no `B110`.
-Sequenced after the untiered tests: those 23 tests exercise provider_service and
-processing_service, the two heaviest files here, so they are the safety net for this change.
+### Phase A — clear the ground
 
-[ready-for-review] Deduplicate error-guard reports
+Everything here is behaviour-preserving and verifiable by the current suite. Doing it first
+means the extraction MRs move less code and read as pure moves.
+
+[ ] Delete the dead modules and the empty package
+`entity/status.py` is byte-identical to `schema/status.py` except one relative import, and
+nothing imports `entity/processing.py` or `entity/status.py` at all. `requests/` holds only an
+empty `__init__.py`. ~340 lines plus a package.
+Note while deleting: two `ProcessingStatus` enum classes exist at runtime today, and members of
+the two are never equal. Confirm nothing compares across them before assuming this is inert.
+
+[ ] Break the `schema` ⇄ `entity.provider` import cycle
+`schema/processing.py:12` imports `entity.provider.provider.SourceType`; importing the
+`entity.provider` package runs `basemap_provider`, which imports `schema.processing` back.
+Move the provider primitives (`SourceType`, `CRS`, `BasicAuth`) into a leaf module that imports
+nothing from the plugin.
+Acceptance: the retry loops in `tests/functional/conftest.py` and `tests/qgis/conftest.py` are
+deleted and both tiers still pass. Their absence is the regression check.
+
+[ ] Narrow the remaining broad exception handlers
+38 `except Exception` sites (processing_service 14, mapflow 11, nine files with 1–2).
+Acceptance: `E722` out of the `.flake8` ledger, bandit reports no `B110`.
+Kept in Phase A rather than deferred with the other lint work: a handler that swallows
+everything hides a broken extraction, and Phase C moves code past these sites constantly.
+
+[ ] Merge `constants.py` into `config.py`
+Five values, no principle separating them from the other ~150 lines.
+
+### Phase B — a test surface that survives the move
+
+[ ] Behavioral test tier
+43 of 51 QGIS-tier test files build objects with `Class.__new__(Class)` and hand-set attributes,
+so they pin internal structure and break the moment a method moves. They cannot be the safety
+net for Phase C.
+Build `tests/behavioral/`: drive a user journey from a controller entry point with `Http`
+replaced by a recording fake, and assert only on the four surfaces in `spec/007_architecture.md`
+§ The test surface that survives a move — HTTP conversation, QGIS layer state, settings, and
+widget-visible state.
+Cover, at minimum, one journey per domain moved in Phase C. Existing `__new__` tests stay until
+the code they pin moves; no step may leave a behaviour covered by neither.
+
+### Phase C — dissolve the god object
+
+One domain per MR, each ending with `mapflow.py` smaller and no behaviour changed. Ordered
+leaf-first so each extraction depends only on what already moved.
+
+[ ] Extract AOI editing and AOI layers → `service/aoi_service.py` + controller
+[ ] Extract preview → `service/preview_service.py`
+[ ] Extract imagery search and the local filter → `service/search_service.py` + `view/search_view.py`
+[ ] Extract templates → `service/template_service.py` (the largest domain, ~55 methods)
+[ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
+[ ] Extract session and account status → `service/session_service.py`
+[ ] Reduce what remains to `plugin.py` — initGui/unload, wiring, construction
+Acceptance for the phase: no `self.dlg.<widget>` access in `plugin.py`, and no service imports a
+widget (`spec/007_architecture.md` invariants 1 and 5).
+
+### Phase D — move the packages
+
+Mechanical, and cheaper here than earlier: the god object is gone, so fewer files churn.
+
+[ ] `functional/` dissolved: `api/`, `controller/`, `service/`, `view/` to the root; `app_context`
+    → `context.py`; `auth`, `geometry`, `helpers`, `layer_utils` to their layer homes
+[ ] `schema/` + the live `entity/provider/` → `model/`; `http`, `error_guard`, `report_throttle`,
+    `log_config`, `styles` → `infra/`
+
+### Phase E — UI consistency
+
+[ ] One consistent way to build a dialog
+All 13 dialogs load a `.ui` file, so the inconsistency is how much Python is layered on top —
+`main_dialog.py` is 803 lines and builds widgets programmatically in several places. Decide the
+rule, then apply it.
+
+[ ] Review what the plugin stores in settings
+Against `spec/003_local_storage.md`; drop what is no longer read.
+
+### Phase F — after the structure is settled
+
+[ ] Wrap user interactions in error_guard
+`guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher` is
+guarded. Everything entering plugin code from Qt without passing through `Http` still escapes to
+QGIS's raw unhandled-exception dialog: button clicks, selection changes, timer ticks,
+drag-and-drop, dialog accept/reject.
+Cheap once Phase C lands — a controller slot is the definition of an entry point
+(`spec/007_architecture.md` § Entry points), so the sites are enumerable instead of guessed.
 
 [ ] Restore user-facing errors on the polled paths
 Three call sites opt out of the default error handler purely to avoid stacked modals:
-`mapflow.py:482` (`refresh_status`), `mapflow.py:3042`, and `processing_api.py:89`
-(`get_processings`). The cost is that a real server error on those paths is invisible to
-the user. The throttle removes the reason for the workaround, so each can go back to
-`use_default_error_handler=True` — but `report_http_error` needs its own signature (Qt
-error code + endpoint path) before that is safe. Do this after the entry-point wrapping,
-so both dialog paths land on one suppression policy rather than two.
+`mapflow.py` `refresh_status`, `mapflow.py:3042`, and `processing_api.py` `get_processings`. A real
+server error on those paths is invisible to the user. The throttle removes the reason for the
+workaround, but `report_http_error` needs its own signature (Qt error code + endpoint path) first,
+so both dialog paths land on one suppression policy.
 
-[ ] Wrap user interactions in error_guard
-`guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher`
-is guarded today. Everything entering plugin code from Qt without passing through `Http` still
-escapes to QGIS's raw unhandled-exception dialog: button clicks, combo/selection changes,
-QTimer ticks, drag-and-drop, dialog accept/reject.
-Do this **after** the dedup above, and after "Plan the refactoring" has defined what an entry
-point is — `mapflow.py`'s god object currently blurs the boundary, so picking sites now would
-mean guessing at it and re-doing the work.
+[ ] Gate the features whose prerequisites never arrived
+Startup stops retrying `/user/status` and `/rasters/memory` instead of polling forever, which is
+right for the traffic and wrong for the UI: the prerequisites those responses carry are simply
+missing, and the affected actions currently fail late or behave as if the limits were zero.
+- no `/user/status` → no billing type, no remaining limit/credits, no area caps. Processings and
+  templates must not be launchable. Viewing them stays available.
+- no `/rasters/memory` → no storage quota. My Imagery uploads must not be startable.
+Blocked controls should not be silently disabled: show why, plus a **Retry** button that re-runs
+the request and unblocks on success.
+Needs one owner for "is this prerequisite satisfied"; today the answer is scattered across
+`app_context` fields written from inside `set_processing_limit`.
 
 [ ] Normalise the residual whitespace findings
 Clears most of the `.flake8` ledger (~450: W291/W292/W293/W391, E501, E1xx/E2xx/E3xx).
-**Ordering constraint:** must come *after* `feature/track-uploaded-image-status` is rebased and
-landed (§3), and immediately *before* the refactor branch cut. A whole-tree whitespace diff makes
-that rebase materially worse, and the findings concentrate in `mapflow.py` and the service layer,
-which the refactoring rewrites — normalising earlier means doing the work twice.
-
-[ ] Plan the refactoring
-Address known problems, be open to push back if the proposals are wrong; 
-assess the code for good/bad practices and evaluate what to improve (maximum impact, minimum effort)
-The ultimate goals are:
-- consistency of the codebase (a developer or AI agent who knows one part of functionality should easily find the corresponding parts in others)
-- industry standards (a new developer should not be surprised or turned off by the code structure or smells)
-- cheap to maintain in case of API changes
-- ready to transfer to QGIS4 (Qt6)
-
-Known problems:
-- Current code has obviously problematic god-object (in mapflow.py) which tightly couples a lot of functionality. 
-- Code/folder structure is uneven: 
-  - there are orphans like `./mapflow/requests`
-  - `./mapflow/entity` and `./mapflow/schema` don't have clear responsibilities
-  - same for `constants.py` and `config.py` 
-  - ???
-I would suggest the following:
-- minimize `mapflow.py` responsibilities
-- create a classic folder structure "api/controller/service/view", practically moving them out of `functional` to the root 
-- create services and other instances for the other parts of functionality.
-- move templates to a separate template_service (controller probably stays the same, but let's decide later)
-- refactor dialogs (ui + py dialog files). Some of them are created manually in the Qt designer,
-and some are heavily python-coded or generated, and they are inconsistent in how can you change them. We need to select a consistent way.
-- review the settings and what do we store there
-
-[ ] Improve test coverage (behavioral/e2e)
-- Document the current behavior and cover it with the tests BEFORE the refactoring
-- Factor the refactoring structure plan in to match the proposed tests to the final functionality rather than the current functions and code
-
-[ ] Implement the refactoring
-- Should follow the plan proposed before
-- Should not break the tests implemented before (behavioral/e2e), allowed to rewrite/add unit tests
-
-[ ] Gate the features whose prerequisites never arrived — AFTER the refactoring
-Startup now stops retrying `/user/status` and `/rasters/memory` instead of polling forever,
-which is right for the traffic and wrong for the UI: the prerequisites those responses carry
-are simply missing, and the affected actions currently fail late or behave as if the limits
-were zero.
-- no `/user/status` → no billing type, no remaining limit/credits, no area caps. Processings
-  and templates must not be launchable. Viewing them stays available.
-- no `/rasters/memory` → no storage quota. My Imagery uploads must not be startable.
-Blocked controls should not be silently disabled: show why, plus a **Retry** button that
-re-runs the request and unblocks on success. Deferred past the refactoring because it needs
-one owner for "is this prerequisite satisfied" — today the answer is scattered across
-`app_context` fields set from inside `set_processing_limit`, which is exactly the god-object
-coupling the refactoring removes.
+Last on purpose: the refactoring rewrites most of the offending lines anyway, and a whole-tree
+whitespace diff would collide with every in-flight branch, including
+`feature/track-uploaded-image-status` (§3).
+Until then the ledger only shrinks — new and moved code adds nothing to it.
 
 ## 2. Add new zoom-selector feature
 [ ]

--- a/spec/007_architecture.md
+++ b/spec/007_architecture.md
@@ -42,25 +42,40 @@ motivating failure gets "simplified away" by the next reader.
 ```
 mapflow/
   __init__.py          classFactory only
-  plugin.py            QGIS entry point: initGui/unload, menu and toolbar wiring,
+  mapflow.py           QGIS entry point: initGui/unload, menu and toolbar wiring,
                        construction of services and controllers. No domain logic.
   context.py           AppContext — shared session state
   config.py            all configuration and constants (constants.py merged in)
   helpers.py           free functions with no plugin state
   geometry.py          geometry helpers
+  styles.py            .qml style lookup for result layers
 
   api/                 one module per backend area; builds requests, parses responses
   service/             business logic and state
   controller/          signal wiring: widget signal -> service call -> view update
   view/                widget reads and writes
   dialogs/             .ui files and thin dialog classes
-  model/               domain types (former schema/ plus the live part of entity/)
+  schema/              domain types: API DTOs and the domain objects built from them
   errors/
-  infra/               http, error_guard, report_throttle, log_config, styles
+  infra/               http, error_guard, report_throttle, log_config
 ```
 
-Deleted: `requests/`, `entity/processing.py`, `entity/status.py`, `functional/` as a
-container, `constants.py`.
+Deleted: `requests/`, `entity/` (its only live package, `provider/`, moves into `schema/`),
+`functional/` as a container, `constants.py`.
+
+`mapflow.py` keeps its name. It stays the entry point; what changes is that it holds
+wiring instead of domain logic.
+
+**`schema/` holds both DTOs and behaviour-carrying domain types.** The provider classes have
+real methods (`to_processing_params` and friends), so "schema" is a loose fit for them — but
+one home for domain types beats a second package whose boundary has to be re-litigated, which
+is exactly how `entity/` became a graveyard. One package, documented scope.
+
+**Moving `entity/provider/` into `schema/` does not by itself break the import cycle** — it
+relocates both ends of it into one package. The fix is separate and must happen first or
+together: the provider primitives (`SourceType`, `CRS`, `BasicAuth`) move to a leaf module
+that imports nothing from the plugin, so `schema/processing.py` depends on the leaf rather
+than on the package that imports it back.
 
 ### Layer rules
 
@@ -69,21 +84,89 @@ below it and from `model/`, `errors/`, `infra/`, `config`, `helpers`, `geometry`
 
 | layer | may import | must never |
 |---|---|---|
-| `plugin.py` | everything | contain domain logic |
-| `controller/` | service, view, model | touch `Http`, hold domain state |
-| `view/` | model, dialogs | issue requests, contain business rules |
-| `service/` | api, model, other services | import `view/`, `dialogs/`, or touch a widget |
-| `api/` | model, infra | know about widgets or business rules |
-| `model/` | errors, config | import anything above it |
+| `mapflow.py` | everything | contain domain logic |
+| `controller/` | service, view, schema | touch `Http`, hold domain state |
+| `view/` | schema, dialogs | issue requests, contain business rules |
+| `service/` | api, schema, other services | import `view/`, `dialogs/`, or touch a widget |
+| `api/` | schema, infra | know about widgets or business rules |
+| `schema/` | errors, config | import anything above it |
 
 **The rule that does the work: `service/` may not touch a widget.** Every current
 layering violation is an instance of it, and it is mechanically checkable — a service
-module must not import `PyQt5.QtWidgets`, `dialogs`, or receive a `dlg` argument.
+module must not import `PyQt5.QtWidgets`, `dialogs`, or `view`, and must not receive a
+`dlg` argument.
 
-`model/` must import nothing from `api/`, `service/`, `view/`, `controller/` or
-`dialogs/`. This is what keeps the import cycle from coming back, and it is why
-`SourceType` and the other provider primitives belong in `model/` rather than being
-imported *from* a package that imports schemas.
+`schema/` must import nothing from `api/`, `service/`, `view/`, `controller/` or
+`dialogs/`. This is what keeps the import cycle from coming back.
+
+### Services
+
+State and business rules. Each owns one question, and nobody else answers it.
+
+| service | owns | boundary |
+|---|---|---|
+| `SessionService` | credentials, login (basic/oauth), logout, plugin-version check | knows how to authenticate; knows nothing about what the account may do |
+| `AccountService` | everything derived from `/user/status`: billing type, limits, area caps, provider min-areas | the only parser of that response. Read by many services, which is why it is separate from `SessionService` — credentials are consulted by nothing but `Http` |
+| `ProviderService` | the provider list (built-in, Mapflow, user-defined), persistence in settings, current selection | what imagery sources exist and which is chosen; not what is done with one |
+| `AoiService` | AOI geometry, AOI layers, the on-map draw/update edit sessions, the selected-AOIs layer | AOI *as geometry and layers*. Which AOIs a template has belongs to `TemplateService` |
+| `SearchService` | imagery-search requests, the result set, the footprints layer, pagination, sort | fetching and holding results |
+| `LocalFilterService` | client-side narrowing of an already-fetched result set, and the "filter is wider than what was fetched" warning | pure computation over a result set plus filter values; issues no request |
+| `TemplateService` | planned processings: CRUD, status polling, template AOIs, search params, seen/new markers, exclude-from-search, pause/resume/restart | everything scoped to a template id |
+| `ProcessingService` | processings list and polling, start/duplicate/delete/restart, cost, review and rating | loses templates to `TemplateService` |
+| `PreviewService` | preview layers (XYZ, PNG, mosaic, catalog image), their dedup and placement | preview layers only; result layers are `ResultService` |
+| `CatalogService` | My Imagery: mosaics, images, upload, storage quota | |
+| `ProjectService` | projects CRUD, sharing, roles, the current project | |
+| `ResultService` | downloading and loading processing results, applying styles | from `layer_utils.ResultsLoader` |
+| `AreaCalculatorService` | area computation and limit comparison | unchanged |
+| `AlertService` | the *message* tier of `spec/006_error_reporting.md` | unchanged |
+
+Services communicate through Qt signals, never by calling a controller. Several already do
+this (`DataCatalogService.mosaicsUpdated`); it becomes the rule. A service that needs to tell
+the UI something emits, and a controller subscribes.
+
+### Controllers
+
+One per UI region, not one per service — a region typically drives several services. A
+controller wires signals and holds no domain state.
+
+| controller | region |
+|---|---|
+| `MainController` | dialog shell: tab switching, login/logout wiring, global menus |
+| `ProcessingController` | the start-processing panel: model and options, AOI and provider selection, cost, start-button state |
+| `ProjectProcessingController` | the projects/processings table and navigation between projects, processings and a template |
+| `SearchController` | imagery-search tab: params, run, filter widgets, pagination, sort, table↔layer selection sync |
+| `TemplateController` | template view: details, AOIs, search params, template processings, seen markers |
+| `CatalogController` | My Imagery |
+| `ProviderController` | provider add/edit/remove dialogs and the provider combos |
+
+Controllers must not call each other. Cross-region effects travel as a service signal, so
+adding a second listener never means editing the first controller.
+
+### Dialogs and .ui files
+
+Qt Designer is the source of truth for structure. The current pattern is already right —
+every dialog calls `uic.loadUiType()` at runtime and **no `pyuic5` output is committed** —
+so the inconsistency to fix is the Python layered on top: `main_dialog.py` is 803 lines and
+builds static widgets programmatically in several places, which is exactly what makes those
+widgets invisible in Designer.
+
+Rules:
+
+1. **Static structure lives in the `.ui` file.** Anything with a fixed place in the layout is
+   defined in Designer, not created in Python.
+2. **Never commit generated Python.** `.ui` files are loaded at runtime with
+   `uic.loadUiType`; unreadable generated code is the reason.
+3. **Python may create a widget only when Designer cannot express it** — genuinely dynamic
+   sets (one checkbox per model option), or content that depends on runtime data. Widgets
+   created this way are added to a container that *is* defined in the `.ui`.
+4. **QGIS and custom widget classes go in through promotion**, not through Python
+   construction, so they keep their place in the Designer tree.
+5. `.ui` is XML and may be edited directly — by a human or an agent — but it must stay
+   valid and round-trippable through Designer. Structural edits are verified by opening the
+   file in Designer before merge.
+
+The test of a correct dialog: opening its `.ui` in Designer shows the whole layout, and the
+matching `.py` contains behaviour only.
 
 ### Entry points
 
@@ -120,9 +203,26 @@ covered by neither.
 ### Invariants
 
 1. A service module imports no widget and receives no dialog.
-2. `model/` imports nothing from the layers above it.
+2. `schema/` imports nothing from the layers above it.
 3. There are no import cycles. The test-tier bootstraps must not need a retry loop; when
    the cycle is gone, that workaround is deleted, and its absence is the check.
 4. One concept has one home. A type is defined once — no parallel copies across packages.
-5. `plugin.py` contains no `self.dlg.<widget>` access.
+5. `mapflow.py` contains no `self.dlg.<widget>` access.
 6. New and moved code adds nothing to the `.flake8` debt ledger. The ledger only shrinks.
+
+### Enforcement
+
+Invariants 1–3 are checked by a test, not by review. `tests/functional/test_layering.py`
+walks the import statements of each package and fails with the offending module and import
+when a rule is broken.
+
+This is deliberate, and `tests/functional/test_tier_layout.py` is the precedent: the
+stranded-test-file problem it now guards against had survived review for a long time
+precisely because nothing executed the rule. View isolation decays the same way — it is
+invisible in a diff that adds one import to one service — so the rule ships with its check
+or it does not hold.
+
+The check is written **before** the extraction starts, with the current violations recorded
+as an explicit allowlist. Each extraction MR removes entries; the list only shrinks, like
+the `.flake8` ledger. That way the invariant is enforced for all new code from day one
+instead of only after the last domain moves.

--- a/spec/007_architecture.md
+++ b/spec/007_architecture.md
@@ -55,27 +55,50 @@ mapflow/
   controller/          signal wiring: widget signal -> service call -> view update
   view/                widget reads and writes
   dialogs/             .ui files and thin dialog classes
-  schema/              domain types: API DTOs and the domain objects built from them
+  schema/              shapes that cross the network
+  model/               types the plugin owns and persists locally
   errors/
   infra/               http, error_guard, report_throttle, log_config
 ```
 
-Deleted: `requests/`, `entity/` (its only live package, `provider/`, moves into `schema/`),
-`functional/` as a container, `constants.py`.
+Deleted: `requests/`, `entity/`, `functional/` as a container, `constants.py`.
 
 `mapflow.py` keeps its name. It stays the entry point; what changes is that it holds
 wiring instead of domain logic.
 
-**`schema/` holds both DTOs and behaviour-carrying domain types.** The provider classes have
-real methods (`to_processing_params` and friends), so "schema" is a loose fit for them — but
-one home for domain types beats a second package whose boundary has to be re-litigated, which
-is exactly how `entity/` became a graveyard. One package, documented scope.
+### schema/ versus model/
 
-**Moving `entity/provider/` into `schema/` does not by itself break the import cycle** — it
-relocates both ends of it into one package. The fix is separate and must happen first or
-together: the provider primitives (`SourceType`, `CRS`, `BasicAuth`) move to a leaf module
-that imports nothing from the plugin, so `schema/processing.py` depends on the leaf rather
-than on the package that imports it back.
+**`schema/` is what crosses the network. `model/` is what the plugin owns and persists
+locally.** "API object versus in-app DTO" is close, but has a grey zone this codebase sits
+in, so the test is the wire, not the usage.
+
+The distinction is already marked mechanically, and `schema/base.py` says so: `Serializable`
+carries `as_dict`/`as_json` and builds request bodies; `SkipDataClass` carries `from_dict` and
+exists so response parsing survives non-breaking API changes. Exactly two modules in the
+current tree inherit neither — `billing.py`, a vocabulary parsed from `/user/status`, which
+stays; and `processing_history.py`, which reads and writes `processing_history_{project_id}`
+in QgsSettings, which moves.
+
+So `model/` is small on purpose:
+
+- `model/provider/` — the provider classes. Configured by the user, persisted under
+  `mapflow_data_providers`, and carrying real behaviour (`to_processing_params`).
+- `model/processing_history.py` — the local per-project processing cache.
+
+**Do not grow `model/` by mirroring response types.** Most of what looks like an in-app DTO
+*is* the parsed API object: `MapflowProject`, `ProcessingDTO`, `MosaicReturnSchema` and
+`ImageReturnSchema` are all held directly in `AppContext`. Wrapping those in parallel domain
+classes buys nothing and costs a hand-written mapping per type, which then drifts — the same
+failure `entity/` died of. A response type earns a place in `model/` only when the plugin
+starts owning state the response does not describe.
+
+**The split makes the import cycle structurally impossible rather than fixed once.** `model/`
+may import `schema/` — a locally-owned provider legitimately produces a request shape.
+`schema/` may never import `model/`. Today's cycle is exactly a violation of that direction:
+`schema/processing.py` reaches into the provider package for `SourceType`. The fix then
+follows from the rule rather than being a one-off: the provider primitives (`SourceType`,
+`CRS`, `BasicAuth`) belong in `schema/` as a leaf module, and `model/provider/` imports them
+from there.
 
 ### Layer rules
 
@@ -85,19 +108,21 @@ below it and from `model/`, `errors/`, `infra/`, `config`, `helpers`, `geometry`
 | layer | may import | must never |
 |---|---|---|
 | `mapflow.py` | everything | contain domain logic |
-| `controller/` | service, view, schema | touch `Http`, hold domain state |
-| `view/` | schema, dialogs | issue requests, contain business rules |
-| `service/` | api, schema, other services | import `view/`, `dialogs/`, or touch a widget |
-| `api/` | schema, infra | know about widgets or business rules |
-| `schema/` | errors, config | import anything above it |
+| `controller/` | service, view, model, schema | touch `Http`, hold domain state |
+| `view/` | model, schema, dialogs | issue requests, contain business rules |
+| `service/` | api, model, schema, other services | import `view/`, `dialogs/`, or touch a widget |
+| `api/` | model, schema, infra | know about widgets or business rules |
+| `model/` | schema, errors, config | import anything above it |
+| `schema/` | errors, config | import `model/`, or anything above it |
 
 **The rule that does the work: `service/` may not touch a widget.** Every current
 layering violation is an instance of it, and it is mechanically checkable — a service
 module must not import `PyQt5.QtWidgets`, `dialogs`, or `view`, and must not receive a
 `dlg` argument.
 
-`schema/` must import nothing from `api/`, `service/`, `view/`, `controller/` or
-`dialogs/`. This is what keeps the import cycle from coming back.
+**The rule that keeps the import cycle dead: `schema/` may not import `model/`.** The
+dependency between the two runs one way only, so the cycle cannot be reintroduced by
+someone who does not know it once existed.
 
 ### Services
 
@@ -203,7 +228,7 @@ covered by neither.
 ### Invariants
 
 1. A service module imports no widget and receives no dialog.
-2. `schema/` imports nothing from the layers above it.
+2. `schema/` imports nothing from `model/` or from the layers above it.
 3. There are no import cycles. The test-tier bootstraps must not need a retry loop; when
    the cycle is gone, that workaround is deleted, and its absence is the check.
 4. One concept has one home. A type is defined once — no parallel copies across packages.

--- a/spec/007_architecture.md
+++ b/spec/007_architecture.md
@@ -1,0 +1,128 @@
+# 007 Architecture
+
+## Purpose
+Define the target module structure, the layers and what each may depend on, and the
+invariants that keep the structure from decaying back. This is the destination for the
+3.7.0 refactoring; the ordered steps to reach it live in `WAL.md`.
+
+## Content
+
+### Why the current structure fails
+
+Recorded because each item below is a rule in this document, and a rule without its
+motivating failure gets "simplified away" by the next reader.
+
+- **`mapflow.py` is a god object**: ~4500 lines, ~200 methods, spanning twelve unrelated
+  domains (auth, account status, AOI editing, imagery search, local filtering, templates,
+  previews, providers, processing, review/rating, results, projects). It holds 351 direct
+  `self.dlg.<widget>` references, so business rules and widget manipulation are the same
+  code.
+- **A `view/` layer exists but is bypassed.** Services reach into dialog widgets directly:
+  `provider_service` 38 references, `project_service` 28, `data_catalog` 29,
+  `processing_service` 29, `layer_utils` 11. A layer that can be skipped is not a layer.
+- **There is a live import cycle.** `schema/processing.py` imports
+  `entity.provider.provider.SourceType`; importing the `entity.provider` package runs
+  `basemap_provider`, which imports `schema.processing` back. Both test tiers work around
+  it by importing the tree twice and swallowing the first `ImportError`.
+- **`entity/` is mostly dead.** `entity/status.py` is a byte-for-byte duplicate of
+  `schema/status.py` apart from one relative import, and `entity/processing.py` has no
+  importers at all. Only `entity/provider/` is live. Two independent `ProcessingStatus`
+  enum classes exist at runtime, and enum members from the two are never equal.
+- **`requests/` is an empty package.**
+- **`constants.py` (5 values) and `config.py` (~150 lines) split on no principle.**
+- **`functional/` names nothing.** It contains the api/controller/service/view packages
+  *and* loose modules (`auth`, `geometry`, `helpers`, `layer_utils`, `app_context`).
+- **The test suite is welded to the current class shapes.** 43 of 51 QGIS-tier test files
+  construct objects with `Class.__new__(Class)` and hand-set attributes. They are unit
+  tests of internal structure, so moving a method breaks them by construction. They cannot
+  serve as the safety net for a refactoring that moves methods.
+
+### Target structure
+
+```
+mapflow/
+  __init__.py          classFactory only
+  plugin.py            QGIS entry point: initGui/unload, menu and toolbar wiring,
+                       construction of services and controllers. No domain logic.
+  context.py           AppContext — shared session state
+  config.py            all configuration and constants (constants.py merged in)
+  helpers.py           free functions with no plugin state
+  geometry.py          geometry helpers
+
+  api/                 one module per backend area; builds requests, parses responses
+  service/             business logic and state
+  controller/          signal wiring: widget signal -> service call -> view update
+  view/                widget reads and writes
+  dialogs/             .ui files and thin dialog classes
+  model/               domain types (former schema/ plus the live part of entity/)
+  errors/
+  infra/               http, error_guard, report_throttle, log_config, styles
+```
+
+Deleted: `requests/`, `entity/processing.py`, `entity/status.py`, `functional/` as a
+container, `constants.py`.
+
+### Layer rules
+
+Dependencies point downward only. The list is ordered; a layer may import from any layer
+below it and from `model/`, `errors/`, `infra/`, `config`, `helpers`, `geometry`.
+
+| layer | may import | must never |
+|---|---|---|
+| `plugin.py` | everything | contain domain logic |
+| `controller/` | service, view, model | touch `Http`, hold domain state |
+| `view/` | model, dialogs | issue requests, contain business rules |
+| `service/` | api, model, other services | import `view/`, `dialogs/`, or touch a widget |
+| `api/` | model, infra | know about widgets or business rules |
+| `model/` | errors, config | import anything above it |
+
+**The rule that does the work: `service/` may not touch a widget.** Every current
+layering violation is an instance of it, and it is mechanically checkable — a service
+module must not import `PyQt5.QtWidgets`, `dialogs`, or receive a `dlg` argument.
+
+`model/` must import nothing from `api/`, `service/`, `view/`, `controller/` or
+`dialogs/`. This is what keeps the import cycle from coming back, and it is why
+`SourceType` and the other provider primitives belong in `model/` rather than being
+imported *from* a package that imports schemas.
+
+### Entry points
+
+A controller method connected to a Qt signal is **the** definition of an entry point in
+this plugin. That matters beyond tidiness: `error_guard.guard_entry_point` is applied at
+entry points, and today "entry point" cannot be identified because `mapflow.py` mixes
+slots, callbacks and helpers in one class. Once controllers own the signal connections,
+the set of places needing the guard is enumerable rather than a judgement call.
+
+See `spec/006_error_reporting.md` for what the guard does and the constraint that a
+guarded callback is interrupted rather than completed.
+
+### The test surface that survives a move
+
+A test that names a method of a class is invalidated when that method moves. A test that
+names an *observable effect* is not. The refactoring is verified against four surfaces,
+all of which outlive any file layout:
+
+1. **The HTTP conversation** — which endpoints are called, with which bodies, in what
+   order. Specified in `spec/002_api.md` and its sub-files.
+2. **QGIS state** — which layers exist, in which groups, with which styles.
+3. **Settings** — the keys written and read, per `spec/003_local_storage.md`.
+4. **Widget-visible state** — enabled/disabled controls, displayed text, table contents.
+
+Behavioral tests drive a user journey from a controller entry point with `Http` replaced
+by a recording fake, and assert only on those four. They are the safety net for every
+extraction step, and they are written **before** the first method moves.
+
+The existing `Class.__new__(Class)` tests are not deleted wholesale — they stay until the
+code they pin has moved, then are rewritten against the new owner or dropped where the
+behavioral test already covers them. A step that moves code must not leave a behaviour
+covered by neither.
+
+### Invariants
+
+1. A service module imports no widget and receives no dialog.
+2. `model/` imports nothing from the layers above it.
+3. There are no import cycles. The test-tier bootstraps must not need a retry loop; when
+   the cycle is gone, that workaround is deleted, and its absence is the check.
+4. One concept has one home. A type is defined once — no parallel copies across packages.
+5. `plugin.py` contains no `self.dlg.<widget>` access.
+6. New and moved code adds nothing to the `.flake8` debt ledger. The ledger only shrinks.

--- a/spec/index.md
+++ b/spec/index.md
@@ -40,5 +40,8 @@ Integration boundaries: Mapflow backend, Keycloak OAuth2, QGIS application, loca
 ## 006_error_reporting.md
 How failures reach the user: the expected/unexpected split, the three presentation tiers (log / message / report dialog), and the suppression contract that bounds dialog volume on timer-driven paths.
 
+## 007_architecture.md
+Target module structure for the 3.7.0 refactoring: the layers (api / service / controller / view / model), what each may import, where the entry points are, and the test surfaces the refactoring is verified against.
+
 ## etc.
-Additional documents can be added with increasing numeric prefixes (for example: `007_security.md`, `008_observability.md`).
+Additional documents can be added with increasing numeric prefixes (for example: `008_security.md`, `009_observability.md`).


### PR DESCRIPTION
spec/007_architecture.md is the destination; WAL section 1 is the route. Splitting them
this way because the target survives the release and the step list does not.

The survey changed the plan in four places, so the numbers are recorded in the spec
rather than left as impressions:

mapflow.py holds ~200 methods across twelve domains and 351 direct self.dlg.<widget>
references. A view/ layer already exists and is bypassed - provider_service 38 widget
references, data_catalog 29, processing_service 29, project_service 28. The layer is not
missing, it is optional, so the rule that carries the refactoring is "a service may not
touch a widget": every current violation is an instance of it, and it is mechanically
checkable rather than a matter of taste.

entity/status.py is byte-identical to schema/status.py apart from one relative import,
and nothing imports entity/processing.py or entity/status.py at all. So the entity-versus-
schema question has no answer to find - entity is a superseded home that only provider/
ever left. Two ProcessingStatus enum classes exist at runtime and their members are never
equal; whether anything compares across them is called out as a check, not assumed inert.

The import cycle is tighter than the conftest comments claim. They describe a four-hop
chain through layer_utils and dialogs; the actual cycle is direct, schema.processing to
entity.provider and back via basemap_provider. Both test tiers import the tree twice and
swallow the first ImportError to get past it, so deleting those retry loops is the
acceptance check for the fix.

43 of 51 QGIS-tier test files construct objects with Class.__new__(Class) and hand-set
attributes. They pin internal structure, so they break the moment a method moves and
cannot serve as the safety net for the extraction. That is why the behavioral tier is its
own phase before any code moves, and why it asserts on four surfaces that outlive file
layout - the HTTP conversation, QGIS layer state, settings keys, and widget-visible state
- rather than on method names.

Sequencing notes worth keeping:
- narrowing the broad exception handlers stays early, against the general "defer lint
  work" decision. A handler that swallows everything hides a broken extraction, and the
  extraction phase moves code past those sites constantly.
- whitespace normalisation goes last instead of immediately before the refactor cut. The
  refactoring rewrites most of the offending lines anyway, so normalising first is work
  done twice, and a whole-tree diff would collide with every in-flight branch.
- wrapping entry points in error_guard becomes cheap only after the extraction, because a
  controller slot is then the definition of an entry point instead of a judgement call.

Also removes the merged deduplicate-error-guard-reports entry.

## Manual test
none - documentation only, no runtime code touched.
