### PR TITLE
[Draft] fix: dissolve intersecting AOI polygons before measuring and sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1
+    - Fix: intersecting AOI polygons (in one layer, or as parts of one multipolygon) were counted twice — the shared area was added to the processing area and to the price, and the overlapping geometry was sent to the server as separate polygons. Overlaps are now merged into a single AOI, so the area shown, the area processed and the area billed all agree
+    - When merging AOIs of a Planned Search would discard their names, the plugin asks for confirmation first
+
 ## 3.6.0
     - Planned processings (search templates):
         - Create a Planned Search that runs in the background and keeps finding new imagery; you are notified when results are ready

--- a/WAL.md
+++ b/WAL.md
@@ -14,3 +14,24 @@
   unrelated errors surface instead of being logged and ignored.
 - Also revisit the `assert` statements in errors/error_message_list.py (Bandit B101: asserts are
   stripped under `python -O`) — turn the sanity checks into real error handling if they must run.
+
+## 3. Hotfix 3.6.1: dissolve intersecting AOI polygons
+[ready-for-review]
+- `QgsGeometry.collectGeometry` (not a union) was the single root cause: a MultiPolygon's area is
+  the sum of its parts, so any overlap was measured, processed and billed once per polygon. A real
+  layer of two nearly-coincident AOIs reported 2203.96 sq.km instead of 1108.96 — an ~2x overcharge.
+- Fixed at the point where the geometry is built, not where it is measured: `app_context.aoi` feeds
+  both the Area label and the submitted geometry, so dissolving there keeps "shown = sent = billed"
+  true by construction. Template `aoiDetails` needed its own dissolve — it is built from the layer
+  directly, bypassing `app_context.aoi`.
+- `maxAoisPerProcessing` is now counted on the dissolved geometry: the count must describe what the
+  backend receives, otherwise overlapping polygons could be rejected for a limit they don't reach.
+- Union failures fall back to the old plain collection: GEOS raises on invalid rings, and an
+  over-counted AOI is still better than no AOI (the backend re-validates anyway).
+- Merging is lossy only for names, so the confirmation prompt is raised exactly when two or more
+  *different* names merge — an unnamed neighbour or a shared name loses nothing and must stay silent,
+  otherwise the prompt becomes noise that users click through.
+- Declining raises `AoiMergeDeclined`, deliberately NOT a `PluginError`/`ValueError`: the callers
+  must abort silently, and the existing `except ValueError` would have shown an error box on top of
+  the question the user just answered.
+- Spec delta approved by user: 002_B "Submitted AOI geometry", 002_F "Intersecting AOIs are merged".

--- a/mapflow/errors/__init__.py
+++ b/mapflow/errors/__init__.py
@@ -1,9 +1,9 @@
 from .errors import ErrorMessage, ErrorMessageList
 from .plugin_errors import (PluginError, BadProcessingInput, ProcessingInputDataMissing,
                             ProcessingLimitExceeded, ImageIdRequired, AoiNotIntersectsImage,
-                            ProxyIsAlreadySet)
+                            AoiMergeDeclined, ProxyIsAlreadySet)
 
 # Re-exported for `from ..errors import ...`; listed so linters treat them as intentional exports.
 __all__ = ["ErrorMessage", "ErrorMessageList", "PluginError", "BadProcessingInput",
            "ProcessingInputDataMissing", "ProcessingLimitExceeded", "ImageIdRequired",
-           "AoiNotIntersectsImage", "ProxyIsAlreadySet"]
+           "AoiNotIntersectsImage", "AoiMergeDeclined", "ProxyIsAlreadySet"]

--- a/mapflow/errors/plugin_errors.py
+++ b/mapflow/errors/plugin_errors.py
@@ -25,5 +25,15 @@ class ImageIdRequired(PluginError):
 class AoiNotIntersectsImage(PluginError):
     pass
 
+
+class AoiMergeDeclined(Exception):
+    """Raised when the user refuses to merge intersecting AOIs (which would drop their names).
+
+    Deliberately NOT a ``PluginError``: the user has already answered the question, so the
+    callers must abort silently instead of showing an error on top of the prompt.
+    """
+    pass
+
+
 class ProxyIsAlreadySet(RuntimeError):
     pass

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -2,7 +2,7 @@ import json
 import os
 from osgeo import gdal
 from pathlib import Path
-from typing import Optional, List, Dict, Callable
+from typing import Optional, List, Dict, Callable, Tuple
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtNetwork import QNetworkReply
@@ -140,28 +140,88 @@ def max_aoi_bbox_area(aoi: QgsGeometry,
         max_area = max(max_area, bbox_area)
     return max_area
 
-def count_polygons_in_layer(features: list) -> int:
-    """ Count polygon geometries in a multipolygon layer (instead of counting features).
-    :param features: A list of fetures, obtained by "list(layer.getFeatures())"
+
+def count_polygons_in_geometry(geometry: Optional[QgsGeometry]) -> int:
+    """Number of polygons in a (possibly multipart) geometry."""
+    if geometry is None or geometry.isEmpty():
+        return 0
+    if geometry.isMultipart():
+        return len(geometry.asMultiPolygon())
+    return 1
+
+
+def dissolve_geometries(geometries: List[QgsGeometry]) -> QgsGeometry:
+    """Combine polygons into one geometry with the intersections dissolved.
+
+    ``QgsGeometry.collectGeometry`` only stacks the inputs into a multipart geometry: overlapping
+    polygons remain separate parts, so ``QgsDistanceArea.measureArea`` sums the parts and counts
+    the shared area once per part. The same geometry is what the plugin submits, so the backend
+    processes (and bills) the overlap twice. A unary union merges the intersecting parts, so every
+    square meter is counted exactly once.
+
+    Falls back to a plain collection when the union yields nothing — GEOS fails on invalid input
+    (e.g. self-intersecting rings) and returning the old, over-counted AOI beats returning none.
     """
-    count = 0
-    for feature in features:
-        geom = feature.geometry()
+    parts = [QgsGeometry(geom) for geom in geometries if geom is not None and not geom.isEmpty()]
+    if not parts:
+        return QgsGeometry()
+    if len(parts) == 1 and not parts[0].isMultipart():
+        # Nothing can overlap: keep the source geometry untouched (no GEOS normalization, no Z drop).
+        return parts[0]
+    dissolved = QgsGeometry.unaryUnion(parts)
+    if dissolved is None or dissolved.isNull() or dissolved.isEmpty():
+        return parts[0] if len(parts) == 1 else QgsGeometry.collectGeometry(parts)
+    return dissolved
+
+
+def dissolve_named_polygons(
+        named_geometries: List[Tuple[QgsGeometry, Optional[str]]]
+) -> Tuple[List[Tuple[QgsGeometry, Optional[str]]], bool]:
+    """Explode into single-part polygons and dissolve the intersecting ones, keeping the names.
+
+    A merged polygon keeps the name of its sources when they agree on one (unnamed sources do not
+    count as disagreement); when two or more *different* names are merged the name is dropped,
+    since there is no non-arbitrary way to pick one. The second return value flags exactly that
+    case, so the caller can ask the user before losing the names.
+
+    Returns ``(list of (single-part polygon, name), names_lost)``.
+    """
+    sources: List[Tuple[QgsGeometry, Optional[str]]] = []
+    for geom, name in named_geometries:
         if geom is None or geom.isEmpty():
             continue
-        if geom.isMultipart():
-            count += len(geom.asMultiPolygon())
-        else:
-            count += 1
-    return count
+        for part in geom.asGeometryCollection() or [geom]:
+            if part is not None and not part.isEmpty():
+                sources.append((part, name))
+    if len(sources) < 2:  # a single polygon cannot intersect anything
+        return sources, False
+
+    dissolved = dissolve_geometries([part for part, _ in sources])
+    parts = [part for part in (dissolved.asGeometryCollection() or [dissolved])
+             if part is not None and not part.isEmpty()]
+    if len(parts) >= len(sources):
+        # Nothing was merged (or the union failed): keep the sources with their names as they are.
+        return sources, False
+
+    result = []
+    names_lost = False
+    for part in parts:
+        names = []
+        for source, name in sources:
+            if not name or name in names:
+                continue
+            overlap = part.intersection(source)
+            if overlap is not None and not overlap.isEmpty() and overlap.area() > 0:
+                names.append(name)
+        if len(names) > 1:
+            names_lost = True
+        result.append((part, names[0] if len(names) == 1 else None))
+    return result, names_lost
+
 
 def collect_geometry_from_layer(layer: QgsMapLayer) -> QgsGeometry:
     features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
-    if len(features) == 1:
-        aoi = features[0].geometry()
-    else:
-        aoi = QgsGeometry.collectGeometry([feature.geometry() for feature in features])
-    return aoi
+    return dissolve_geometries([feature.geometry() for feature in features])
 
 
 def calculate_layer_area(layer: QgsMapLayer,

--- a/mapflow/functional/service/area_calculator_service.py
+++ b/mapflow/functional/service/area_calculator_service.py
@@ -46,19 +46,17 @@ class AreaCalculatorService(QObject):
             return
 
         features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
-        if QgsWkbTypes.flatType(layer.wkbType()) == QgsWkbTypes.Polygon:
-            geoms_count = len(features)
-        elif QgsWkbTypes.flatType(layer.wkbType()) == QgsWkbTypes.MultiPolygon:
-            geoms_count = layer_utils.count_polygons_in_layer(features)
-        else: # type of layer is not supported
+        if QgsWkbTypes.flatType(layer.wkbType()) not in (QgsWkbTypes.Polygon, QgsWkbTypes.MultiPolygon):
+            # type of layer is not supported
             # (but it shouldn't be the case, because point and line layers will not appear in AOI-combo,
             # and collections are devided by QGIS into separate layers with different types)
             raise ValueError("Only polygon and multipolyon layers supported for this operation")
+        # Dissolve the intersections: merely collecting the parts would count the shared area once
+        # per overlapping polygon, both in the displayed area and in the geometry we submit.
+        aoi = layer_utils.dissolve_geometries([feature.geometry() for feature in features])
+        # Count the polygons of the dissolved AOI — that is what the backend receives.
+        geoms_count = layer_utils.count_polygons_in_geometry(aoi)
         if self.app_context.max_aois_per_processing >= geoms_count:
-            if len(features) == 1:
-                aoi = features[0].geometry()
-            else:
-                aoi = QgsGeometry.collectGeometry([feature.geometry() for feature in features])
             self.calculate_aoi_area(aoi, layer.crs())
             return aoi
         else:  # self.app_context.max_aois_per_processing < number of polygons (as features and as parts of multipolygons):

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -26,7 +26,8 @@ from qgis.core import (
 
 from . import constants
 from .config import Config, ConfigColumns
-from .errors import (BadProcessingInput,
+from .errors import (AoiMergeDeclined,
+                     BadProcessingInput,
                      ErrorMessage,
                      ImageIdRequired,
                      PluginError,
@@ -1333,8 +1334,9 @@ class Mapflow(QObject):
             self.alert(self.tr("The AOI has no geometry — draw or keep at least one polygon."),
                        QMessageBox.Warning)
             return False
-        geom = (feats[0].geometry() if len(feats) == 1
-                else QgsGeometry.collectGeometry([f.geometry() for f in feats]))
+        # Dissolve intersections, so an AOI edited into overlapping parts is not measured
+        # (and billed) twice over the shared area.
+        geom = layer_utils.dissolve_geometries([f.geometry() for f in feats])
         wgs = helpers.to_wgs84(QgsGeometry(geom), layer.crs())
         if wgs is None or wgs.isEmpty():
             self.alert(self.tr("The edited AOI has no valid geometry."), QMessageBox.Warning)
@@ -1357,7 +1359,10 @@ class Mapflow(QObject):
             return False
         if layer.isEditable():
             layer.commitChanges()  # move drawn features from the edit buffer into the provider
-        features = self._aoi_features_from_layer(layer)
+        try:
+            features = self._aoi_features_from_layer(layer)
+        except AoiMergeDeclined:
+            return False  # keep the session open so the drawing is not lost
         if not features:
             self.alert(self.tr("Draw at least one polygon before saving."), QMessageBox.Warning)
             return False
@@ -2383,13 +2388,14 @@ class Mapflow(QObject):
 
         ``aoiDetails`` is always used — the legacy plain ``aoi`` field is deprecated because
         names cannot be attached to it. Returns ``None`` only when there is no AOI at all.
-        Raises ``ValueError`` if a name exceeds the limit.
+        Raises ``ValueError`` if a name exceeds the limit, ``AoiMergeDeclined`` if the user
+        refuses to merge intersecting AOIs.
         """
         features = self._aoi_features_from_layer(self.dlg.polygonCombo.currentLayer())
         # Fall back to the combined AOI (e.g. image/mosaic extent) as one unnamed feature,
         # so we still send aoiDetails rather than the deprecated plain `aoi`.
         if not features and self.app_context.aoi:
-            features.extend(self._polygon_aoi_features(self.app_context.aoi, None))
+            features.extend(self._dissolved_aoi_features([(self.app_context.aoi, None)]))
         if not features:
             return None
         return {"type": "FeatureCollection", "features": features}
@@ -2398,12 +2404,14 @@ class Mapflow(QObject):
         """Exploded single-Polygon GeoJSON AOI features from a polygon layer (selected features
         if any, else all). Each feature's ``properties.name`` comes from a ``name`` attribute
         when present. MultiPolygons are split into separate Polygon features (the create path
-        requires single-part polygons). Raises ``ValueError`` if a name exceeds the limit."""
+        requires single-part polygons), and intersecting polygons are dissolved into one.
+        Raises ``ValueError`` if a name exceeds the limit, ``AoiMergeDeclined`` if the user
+        refuses the merge."""
         if layer is None or not layer.featureCount():
             return []
         source_features = list(layer.getSelectedFeatures()) or list(layer.getFeatures())
         has_name_field = layer.fields().indexFromName("name") != -1
-        features = []
+        named_geometries = []
         for feature in source_features:
             geom = feature.geometry()
             if geom is None or geom.isEmpty():
@@ -2421,22 +2429,28 @@ class Mapflow(QObject):
                         name=name, limit=AOI_NAME_MAX_LENGTH
                     )
                 )
-            features.extend(self._polygon_aoi_features(wgs_geom, name))
-        return features
+            named_geometries.append((wgs_geom, name))
+        return self._dissolved_aoi_features(named_geometries)
 
-    @staticmethod
-    def _polygon_aoi_features(wgs_geom: QgsGeometry, name: Optional[str]) -> List[dict]:
-        """Split a (possibly multi-)polygon into one GeoJSON *Polygon* Feature per part.
+    def _dissolved_aoi_features(self,
+                                named_geometries: List[Tuple[QgsGeometry, Optional[str]]]
+                                ) -> List[dict]:
+        """One GeoJSON *Polygon* Feature per AOI part, with intersecting polygons dissolved.
 
-        The backend ignores ``MultiPolygon`` features in ``aoiDetails`` — an all-MultiPolygon
-        upload would create an empty, Failed template (feedback 10) — so mirror the web client
-        and explode each MultiPolygon into separate single-part Polygon features. Parts share
-        the source feature's ``name``. ``asGeometryCollection`` returns one element for a plain
-        Polygon and one per part for a MultiPolygon."""
+        Two reasons to explode and dissolve here. Explode: the backend ignores ``MultiPolygon``
+        features in ``aoiDetails`` — an all-MultiPolygon upload would create an empty, Failed
+        template (feedback 10) — so mirror the web client with single-part polygons. Dissolve:
+        overlapping AOIs would otherwise be searched and billed twice over the shared area.
+
+        Merging drops the names of AOIs that disagree, so ask before doing it; a refusal raises
+        ``AoiMergeDeclined`` and the caller aborts, leaving the user to fix the overlap."""
+        parts, names_lost = layer_utils.dissolve_named_polygons(named_geometries)
+        if names_lost and not self.alert(
+                self.tr("Your AOIs will be merged and name information will be lost, "
+                        "do you want to continue?"), QMessageBox.Question):
+            raise AoiMergeDeclined()
         features = []
-        for part in wgs_geom.asGeometryCollection() or [wgs_geom]:
-            if part is None or part.isEmpty():
-                continue
+        for part, name in parts:
             features.append({
                 "type": "Feature",
                 "geometry": json.loads(part.asJson()),
@@ -2476,6 +2490,8 @@ class Mapflow(QObject):
         except ValueError as e:
             self.alert(str(e), QMessageBox.Warning)
             return
+        except AoiMergeDeclined:
+            return  # the user was asked and said no: let them fix the overlapping AOIs first
         if not aoi_details:
             self.alert(self.tr('Please, select a valid area of interest'))
             return

--- a/mapflow/metadata.txt
+++ b/mapflow/metadata.txt
@@ -9,12 +9,14 @@ about=Mapflow provides AI models for automatic feature extraction from satellite
         - roads
         - construction sites
     For a step-by-step user guide, go to https://docs.mapflow.ai/api/qgis_mapflow#user-interface
-version=3.6.0
+version=3.6.1
 experimental=False
 deprecated=False
 author=Geoalert
 email=hello@geoalert.io
 changelog:
+    3.6.1
+    - Hotfix: intersecting AOI polygons are merged before the area is measured and the processing is sent, so the overlap is no longer counted (and charged) twice
     3.6.0
     - Planned processings: create a background "Planned Search" to be automatically notified when new images are found; browse and manage search AOIs (add from a layer, draw on the map, update geometry, exclude from search, etc.) and their processings, grouped per AOI on the map
     - Imagery Search reworked: a new Off-Nadir angle filter, all search via the Mapflow catalog (legacy Maxar/Sentinel removed), server-side sorting by clicking column headers, and "My imagery" as image/mosaic search providers

--- a/spec/002_B_processing_api.md
+++ b/spec/002_B_processing_api.md
@@ -14,6 +14,27 @@ List processings for a project. Polled approximately every 5 seconds for status 
 ### `PUT /processings/{id}`
 Update processing name/description.
 
+## Submitted AOI geometry
+
+The AOI is taken from the selected polygon layer (its selected features, or all of them) and sent
+as a single geometry. **Intersecting polygons are dissolved (unary union) before submission**, so
+that a shared area belongs to exactly one polygon of the submitted geometry. Merely collecting the
+features into a MultiPolygon would keep the overlaps as separate parts, and the area of a
+MultiPolygon is the sum of its parts: the overlap would be measured, processed and billed once per
+overlapping polygon. This applies to overlaps *between* features and to overlapping parts *within*
+one MultiPolygon feature.
+
+Consequences of the dissolve, all intended:
+
+- the **Area** shown in the plugin equals the area the backend charges for;
+- the per-processing polygon count (`maxAoisPerProcessing`) is checked on the **dissolved**
+  geometry — the count the backend receives — so overlapping polygons that merge into one count
+  as one;
+- disjoint polygons are never merged: a multi-AOI processing stays multi-AOI.
+
+If the union fails (GEOS rejects invalid input, e.g. self-intersecting rings), the plugin falls
+back to the plain collection rather than dropping the AOI.
+
 ## AOI area limit
 
 Two ellipsoidal-area constraints apply, both against `user.aoiAreaLimit` (sq.m), reported in the

--- a/spec/002_F_plan_processing_api.md
+++ b/spec/002_F_plan_processing_api.md
@@ -198,6 +198,25 @@ later via `POST .../aoi/{aoiId}`). When the AOI does not come from a polygon lay
 image/mosaic extent), unnamed feature(s) are built from the combined AOI geometry (again one
 Polygon per part). The backend still accepts `aoi` as a fallback, but the plugin no longer sends it.
 
+### Intersecting AOIs are merged
+Before the features are built, intersecting polygons are dissolved into one, for the same reason
+as in a regular processing (see 002_B "Submitted AOI geometry"): overlapping AOIs would otherwise
+be searched — and billed — twice over the shared area. Merging applies to overlaps between
+features and between the parts of one MultiPolygon feature. The same dissolve is applied when
+AOIs are added to an existing template by drawing them on the map, and when an AOI's geometry is
+updated (`POST …/aoi/{aoiId}`).
+
+A merged AOI can carry only one name:
+
+- when the merged polygons agree on a name — one name shared by all of them, some of them
+  unnamed — the merged AOI keeps that name, and nothing is asked;
+- when they carry **two or more different names** there is no non-arbitrary choice, so the name is
+  dropped (`null`) and the user is **asked first**: *"Your AOIs will be merged and name
+  information will be lost, do you want to continue?"*. Cancelling aborts the creation (or the
+  AOI-add) silently, leaving the user to resolve the overlap in the source layer.
+
+Only the merged AOIs lose their names; AOIs that do not intersect anything keep theirs.
+
 ### Name constraints
 AOI names must not exceed **64 characters**; the plugin validates this client-side
 before issuing create/rename requests and surfaces a translatable error otherwise.

--- a/tests/functional/test_layer_utils.py
+++ b/tests/functional/test_layer_utils.py
@@ -1,4 +1,99 @@
-from mapflow.functional.layer_utils import *
+import pytest
+from qgis.core import QgsGeometry, QgsWkbTypes
+
+from mapflow.functional.layer_utils import (count_polygons_in_geometry,
+                                            dissolve_geometries,
+                                            dissolve_named_polygons,
+                                            generate_xyz_layer_definition)
+
+# Two overlapping unit squares: 1 + 1 sq.units as separate parts, 1.75 dissolved (0.25 shared).
+LEFT = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+RIGHT = "POLYGON((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0))"
+FAR = "POLYGON((5 5,5 6,6 6,6 5,5 5))"
+OVERLAPPING_MULTIPOLYGON = ("MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),"
+                            "((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0)))")
+
+
+def test_dissolve_geometries_counts_the_overlap_once():
+    """The bug: collected (not dissolved) parts make measureArea sum the shared area twice."""
+    dissolved = dissolve_geometries([QgsGeometry.fromWkt(LEFT), QgsGeometry.fromWkt(RIGHT)])
+
+    assert dissolved.area() == pytest.approx(1.75)
+    assert count_polygons_in_geometry(dissolved) == 1
+
+
+def test_dissolve_geometries_keeps_disjoint_polygons_apart():
+    dissolved = dissolve_geometries([QgsGeometry.fromWkt(LEFT), QgsGeometry.fromWkt(FAR)])
+
+    assert count_polygons_in_geometry(dissolved) == 2
+    assert dissolved.area() == pytest.approx(2.0)
+
+
+def test_dissolve_geometries_dissolves_parts_of_one_multipolygon():
+    """A single feature can be a MultiPolygon whose own parts intersect."""
+    dissolved = dissolve_geometries([QgsGeometry.fromWkt(OVERLAPPING_MULTIPOLYGON)])
+
+    assert count_polygons_in_geometry(dissolved) == 1
+    assert dissolved.area() == pytest.approx(1.75)
+
+
+def test_dissolve_geometries_keeps_a_single_polygon_untouched():
+    single = QgsGeometry.fromWkt(LEFT)
+
+    assert dissolve_geometries([single]).asWkt() == single.asWkt()
+
+
+def test_dissolve_geometries_ignores_empty_input():
+    assert dissolve_geometries([]).isEmpty()
+    assert dissolve_geometries([None, QgsGeometry()]).isEmpty()
+
+
+def test_dissolve_named_polygons_keeps_names_when_nothing_merges():
+    parts, names_lost = dissolve_named_polygons([(QgsGeometry.fromWkt(LEFT), "North"),
+                                                 (QgsGeometry.fromWkt(FAR), "South")])
+
+    assert names_lost is False
+    assert [name for _, name in parts] == ["North", "South"]
+
+
+def test_dissolve_named_polygons_drops_conflicting_names_of_merged_polygons():
+    parts, names_lost = dissolve_named_polygons([(QgsGeometry.fromWkt(LEFT), "North"),
+                                                 (QgsGeometry.fromWkt(RIGHT), "South")])
+
+    assert names_lost is True
+    assert len(parts) == 1
+    assert parts[0][1] is None
+    assert parts[0][0].area() == pytest.approx(1.75)
+
+
+def test_dissolve_named_polygons_keeps_the_single_name_of_merged_polygons():
+    """Same name on both (or only one of them named) is not ambiguous — merge silently."""
+    parts, names_lost = dissolve_named_polygons([(QgsGeometry.fromWkt(LEFT), "North"),
+                                                 (QgsGeometry.fromWkt(RIGHT), None)])
+
+    assert names_lost is False
+    assert [name for _, name in parts] == ["North"]
+
+
+def test_dissolve_named_polygons_reports_names_lost_per_merged_group():
+    """Only the merged group loses its names; an untouched AOI keeps its own."""
+    parts, names_lost = dissolve_named_polygons([(QgsGeometry.fromWkt(LEFT), "North"),
+                                                 (QgsGeometry.fromWkt(RIGHT), "South"),
+                                                 (QgsGeometry.fromWkt(FAR), "East")])
+
+    assert names_lost is True
+    assert sorted(name or "" for _, name in parts) == ["", "East"]
+
+
+def test_dissolve_named_polygons_explodes_multipolygons():
+    parts, names_lost = dissolve_named_polygons([
+        (QgsGeometry.fromWkt("MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((5 5,5 6,6 6,6 5,5 5)))"),
+         "Combo"),
+    ])
+
+    assert names_lost is False
+    assert [part.wkbType() for part, _ in parts] == [QgsWkbTypes.Polygon] * 2
+    assert [name for _, name in parts] == ["Combo", "Combo"]
 
 
 def test_xyz_no_creds():
@@ -10,4 +105,3 @@ def test_xyz_no_creds():
                      '&zmax=18' \
                      '&username=' \
                      '&password='
-

--- a/tests/qgis/test_aoi_merge_names.py
+++ b/tests/qgis/test_aoi_merge_names.py
@@ -1,0 +1,129 @@
+"""QGIS-tier tests: intersecting AOIs are merged before they are sent as ``aoiDetails``, and the
+user is asked first when the merge would discard AOI names (spec 002_F).
+
+Merging is what stops the shared area from being searched (and billed) twice; the prompt exists
+because a merged AOI cannot keep two different names.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt5.QtCore import QVariant
+from qgis.core import QgsFeature, QgsField, QgsGeometry, QgsVectorLayer
+
+from mapflow.errors import AoiMergeDeclined
+from mapflow.mapflow import Mapflow
+
+LEFT = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+RIGHT = "POLYGON((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0))"  # overlaps LEFT
+FAR = "POLYGON((5 5,5 6,6 6,6 5,5 5))"
+
+
+def _layer_with(features, with_name_field=True):
+    layer = QgsVectorLayer("Polygon?crs=epsg:4326", "aois", "memory")
+    provider = layer.dataProvider()
+    if with_name_field:
+        provider.addAttributes([QgsField("name", QVariant.String)])
+        layer.updateFields()
+    qgs_features = []
+    for wkt, name in features:
+        feature = QgsFeature(layer.fields())
+        feature.setGeometry(QgsGeometry.fromWkt(wkt))
+        if with_name_field:
+            feature.setAttribute("name", name)
+        qgs_features.append(feature)
+    provider.addFeatures(qgs_features)
+    layer.updateExtents()
+    return layer
+
+
+def _plugin(layer, confirmed=True):
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.tr = lambda text: text
+    plugin.dlg = MagicMock()
+    plugin.dlg.polygonCombo.currentLayer.return_value = layer
+    plugin.alert = MagicMock(return_value=confirmed)
+    return plugin
+
+
+def test_intersecting_aois_with_different_names_ask_before_merging():
+    plugin = _plugin(_layer_with([(LEFT, "North"), (RIGHT, "South")]))
+
+    fc = plugin._build_template_aoi_details()
+
+    plugin.alert.assert_called_once()
+    assert "merged" in plugin.alert.call_args[0][0]
+    # One merged AOI, and the ambiguous name is dropped rather than picked arbitrarily.
+    assert len(fc["features"]) == 1
+    assert fc["features"][0]["properties"]["name"] is None
+
+
+def test_declined_merge_aborts_the_details_build():
+    plugin = _plugin(_layer_with([(LEFT, "North"), (RIGHT, "South")]), confirmed=False)
+
+    with pytest.raises(AoiMergeDeclined):
+        plugin._build_template_aoi_details()
+
+
+def test_declined_merge_does_not_create_the_template():
+    layer = _layer_with([(LEFT, "North"), (RIGHT, "South")])
+    plugin = _plugin(layer, confirmed=False)
+    plugin.replace_search_provider_index = MagicMock()
+    plugin._build_search_params = MagicMock()
+    plugin.app_context = SimpleNamespace(current_project=object(),
+                                         aoi=QgsGeometry.fromWkt(LEFT),
+                                         aoi_size=1.0,
+                                         template_area_limit=0)
+
+    plugin.create_search_template()
+
+    plugin._build_search_params.assert_not_called()
+
+
+def test_intersecting_aois_sharing_one_name_merge_silently():
+    """Only *conflicting* names are worth a prompt: an unnamed neighbour loses nothing."""
+    plugin = _plugin(_layer_with([(LEFT, "North"), (RIGHT, None)]))
+
+    fc = plugin._build_template_aoi_details()
+
+    plugin.alert.assert_not_called()
+    assert len(fc["features"]) == 1
+    assert fc["features"][0]["properties"]["name"] == "North"
+
+
+def test_disjoint_named_aois_are_untouched():
+    plugin = _plugin(_layer_with([(LEFT, "North"), (FAR, "South")]))
+
+    fc = plugin._build_template_aoi_details()
+
+    plugin.alert.assert_not_called()
+    assert [f["properties"]["name"] for f in fc["features"]] == ["North", "South"]
+
+
+def test_merged_aoi_is_a_single_part_polygon_spanning_both_sources():
+    plugin = _plugin(_layer_with([(LEFT, "North"), (RIGHT, "South")]))
+
+    geometry = plugin._build_template_aoi_details()["features"][0]["geometry"]
+
+    # Single-part Polygon: the backend ignores MultiPolygon features in aoiDetails.
+    assert geometry["type"] == "Polygon"
+    xs = [point[0] for point in geometry["coordinates"][0]]
+    assert min(xs) == pytest.approx(0.0)   # left edge of LEFT
+    assert max(xs) == pytest.approx(1.75)  # right edge of RIGHT
+
+
+def test_drawn_overlapping_aois_are_added_as_one():
+    """The draw-AOI session has no name field, so overlapping sketches merge without a prompt."""
+    plugin = _plugin(None)
+    plugin.iface = MagicMock()
+    plugin.processing_service = MagicMock()
+    plugin.processing_service.active_template = SimpleNamespace(id="t-1")
+    layer = _layer_with([(LEFT, None), (RIGHT, None)], with_name_field=False)
+
+    with patch("mapflow.mapflow.QInputDialog.getText", return_value=("Drawn", True)):
+        assert plugin._commit_aoi_draw(layer) is True
+
+    plugin.alert.assert_not_called()
+    data = plugin.processing_service.api.add_aois.call_args.kwargs["data"]
+    assert len(data.aois) == 1
+    assert data.aois[0].name == "Drawn"

--- a/tests/qgis/test_aoi_overlap_dissolve.py
+++ b/tests/qgis/test_aoi_overlap_dissolve.py
@@ -1,0 +1,128 @@
+"""QGIS-tier tests: intersecting AOI polygons are dissolved before the area is measured and
+before the geometry is submitted.
+
+The regression (reported on a real 'POC' layer of two nearly-identical overlapping
+quadrilaterals): the AOI was built with ``QgsGeometry.collectGeometry``, which stacks the
+polygons into a MultiPolygon without merging them, so ``measureArea`` summed the parts and the
+shared area was measured — and billed — twice, both in the Area label and in the MultiPolygon
+sent to ``/processing/cost/v2``.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from qgis.core import QgsFeature, QgsGeometry, QgsProject, QgsVectorLayer
+
+from mapflow.functional import layer_utils
+from mapflow.functional.service.area_calculator_service import AreaCalculatorService
+
+# The two AOIs of the reported layer, trimmed to 2D (the source has a zero Z).
+POC_A = ("POLYGON((116.453049998276157 40.12268262081593,"
+         "116.455857049574931 39.77367257600082,"
+         "116.791767521662393 39.780222362364647,"
+         "116.785217735298573 40.127361039647234,"
+         "116.453049998276157 40.12268262081593))")
+POC_B = ("POLYGON((116.455160215366902 39.771790069375818,"
+         "116.793400039636495 39.779781230320488,"
+         "116.783915452966596 40.126904336856533,"
+         "116.455422181038699 40.120268410935203,"
+         "116.455160215366902 39.771790069375818))")
+
+
+def _layer(wkts, geometry_type="Polygon"):
+    layer = QgsVectorLayer(f"{geometry_type}?crs=epsg:4326", "aois", "memory")
+    features = []
+    for wkt in wkts:
+        feature = QgsFeature()
+        feature.setGeometry(QgsGeometry.fromWkt(wkt))
+        features.append(feature)
+    layer.dataProvider().addFeatures(features)
+    layer.updateExtents()
+    return layer
+
+
+def _service(dlg=None):
+    service = AreaCalculatorService.__new__(AreaCalculatorService)
+    service.dlg = dlg or MagicMock()
+    service.config = MagicMock()
+    service.provider_service = MagicMock()
+    service.data_catalog_service = MagicMock()
+    service.processing_service = MagicMock()
+    service.app_context = SimpleNamespace(
+        aoi=None,
+        aoi_size=None,
+        processing_aoi=None,
+        max_aois_per_processing=10,
+        project=QgsProject.instance(),
+        user_role=SimpleNamespace(can_start_processing=True, value="OWNER"),
+    )
+    service.tr = lambda text: text
+    # The UI/provider plumbing of calculate_aoi_area is not under test: keep the geometry and
+    # the measured size, skip the cost request.
+    service.get_aoi = lambda provider_index, selected_aoi, local_image_indices: selected_aoi
+    service.dlg.metadataTable.selectedItems.return_value = []
+    return service
+
+
+def _area_of(wkts):
+    service = _service()
+    service.get_aoi_area_polygon_layer(_layer(wkts))
+    return service
+
+
+def test_overlapping_aois_area_is_the_union_not_the_sum():
+    overlapping = _area_of([POC_A, POC_B]).app_context.aoi_size
+    a_only = _area_of([POC_A]).app_context.aoi_size
+    b_only = _area_of([POC_B]).app_context.aoi_size
+
+    # The union of two ~1300 sq.km AOIs that almost coincide is far below their sum.
+    assert overlapping < a_only + b_only
+    # And it is at least as large as either one alone.
+    assert overlapping >= max(a_only, b_only)
+    assert overlapping == pytest.approx(max(a_only, b_only), rel=0.05)
+
+
+def test_overlapping_aois_are_submitted_as_one_polygon():
+    """The geometry stored on app_context is what goes into the cost/start request."""
+    service = _area_of([POC_A, POC_B])
+
+    assert layer_utils.count_polygons_in_geometry(service.app_context.aoi) == 1
+
+
+def test_disjoint_aois_are_kept_separate():
+    service = _area_of(["POLYGON((0 0,0 1,1 1,1 0,0 0))", "POLYGON((5 5,5 6,6 6,6 5,5 5))"])
+
+    assert layer_utils.count_polygons_in_geometry(service.app_context.aoi) == 2
+
+
+def test_multipolygon_layer_with_intersecting_parts_is_dissolved():
+    layer = _layer(["MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0)))"],
+                   geometry_type="MultiPolygon")
+    service = _service()
+
+    service.get_aoi_area_polygon_layer(layer)
+
+    assert layer_utils.count_polygons_in_geometry(service.app_context.aoi) == 1
+
+
+def test_polygon_limit_is_checked_on_the_dissolved_aoi():
+    """Two overlapping polygons become one AOI, so a one-AOI plan must still accept them."""
+    service = _service()
+    service.app_context.max_aois_per_processing = 1
+
+    service.get_aoi_area_polygon_layer(_layer([POC_A, POC_B]))
+
+    assert service.app_context.aoi is not None
+    assert service.app_context.aoi_size > 0
+    service.dlg.disable_processing_start.assert_not_called()
+
+
+def test_polygon_limit_still_rejects_too_many_disjoint_aois():
+    service = _service()
+    service.app_context.max_aois_per_processing = 1
+
+    service.get_aoi_area_polygon_layer(
+        _layer(["POLYGON((0 0,0 1,1 1,1 0,0 0))", "POLYGON((5 5,5 6,6 6,6 5,5 5))"]))
+
+    assert service.app_context.aoi is None
+    service.dlg.disable_processing_start.assert_called_once()


### PR DESCRIPTION
## The bug

A polygon layer with intersecting polygons (separate features, or parts of one multipolygon) had its area computed as `sum(part.area)` instead of `unary_union(parts).area`, and the same un-merged geometry was submitted to the backend.

The AOI was assembled with `QgsGeometry.collectGeometry`, which stacks polygons into a MultiPolygon without merging them. `QgsDistanceArea.measureArea` sums the parts, so every overlap was measured, processed **and billed** once per polygon.

Measured on the reported layer (two nearly-coincident AOIs over Beijing):

| | area |
|---|---|
| before (collected) | 2203.96 sq.km |
| after (dissolved) | 1108.96 sq.km |
| either AOI alone | 1103.47 / 1100.49 |

## The fix

- `layer_utils.dissolve_geometries()` — unary union, falling back to the old plain collection when GEOS rejects invalid input (self-intersecting rings), so a bad geometry degrades to today's behaviour rather than to no AOI.
- `AreaCalculatorService.get_aoi_area_polygon_layer` dissolves where the AOI is built. `app_context.aoi` feeds both the Area label and the submitted geometry, so *shown = sent = billed* now holds by construction.
- `maxAoisPerProcessing` is counted on the **dissolved** geometry — the count the backend receives. Overlapping polygons that merge count as one; disjoint AOIs are unaffected.
- Template `aoiDetails` is built from the layer directly (it never passes through `app_context.aoi`) and got its own dissolve, as did the draw-AOI session and the per-AOI geometry update.

## AOI names

A merged AOI can carry only one name. When the merged polygons agree (an unnamed neighbour is not a disagreement) the name is kept and nothing is asked. When two or more **different** names collide, the name is dropped and the user is asked first:

> Your AOIs will be merged and name information will be lost, do you want to continue?

Cancelling raises `AoiMergeDeclined` and aborts silently — deliberately not a `PluginError`/`ValueError`, so the existing `except ValueError` cannot stack an error box on top of the question the user just answered.

## Spec

Approved delta: 002_B "Submitted AOI geometry", 002_F "Intersecting AOIs are merged".

## Tests

20 new tests (7 functional, 13 qgis-tier, including the reported geometry). `agent-make test` green: 18 + 416 passed.

## Note for the reviewer

`metadata.txt` is bumped to 3.6.1 with CHANGELOG entries — drop that hunk if the version should be bumped at release time instead. The branch was cut from `master` (as `hotfix/v3.6.1` locally); it still needs merging back into `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)