### PR TITLE
[Draft] 3.6.1: count an overlapping AOI's area once, and name My Imagery results readably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.6.1
     - Fix: the area of an AOI layer with intersecting polygons (separate features, or parts of one multipolygon) was overstated — the shared area was counted once per polygon, inflating the Area shown, the price estimated from it and the area-limit checks. The overlap is now counted once, as the server counts it
+    - Search results from My imagery are listed as "My Image" and "My Collection" instead of the internal provider names
 
 ## 3.6.0
     - Planned processings (search templates):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.6.1
+    - Fix: the area of an AOI layer with intersecting polygons (separate features, or parts of one multipolygon) was overstated — the shared area was counted once per polygon, inflating the Area shown, the price estimated from it and the area-limit checks. The overlap is now counted once, as the server counts it
+
 ## 3.6.0
     - Planned processings (search templates):
         - Create a Planned Search that runs in the background and keeps finding new imagery; you are notified when results are ready

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.6.1
     - Fix: the area of an AOI layer with intersecting polygons (separate features, or parts of one multipolygon) was overstated — the shared area was counted once per polygon, inflating the Area shown, the price estimated from it and the area-limit checks. The overlap is now counted once, as the server counts it
     - Search results from My imagery are listed as "My Image" and "My Collection" instead of the internal provider names
+    - The overlap is counted once even when one of the polygons is broken (self-intersecting): such a layer is repaired before the area is measured, instead of falling back to the doubled area
 
 ## 3.6.0
     - Planned processings (search templates):

--- a/WAL.md
+++ b/WAL.md
@@ -14,3 +14,24 @@
   unrelated errors surface instead of being logged and ignored.
 - Also revisit the `assert` statements in errors/error_message_list.py (Bandit B101: asserts are
   stripped under `python -O`) — turn the sanity checks into real error handling if they must run.
+
+## 3. Hotfix 3.6.1: count an overlapping AOI's area once
+[ready-for-review]
+- Root cause is `measureArea` over a collected (not unioned) MultiPolygon: its area is the sum of
+  the parts, so an overlap is added once per polygon. A real layer of two nearly-coincident AOIs
+  showed 2203.96 sq.km instead of 1108.96 — the price follows the same number.
+- Scope deliberately stops at the measurement. The first attempt also unioned the submitted
+  geometry; that is unnecessary (the backend unions on start, and cost will union too) and actively
+  wrong for Planned Search, where intersecting named AOIs are a feature: "City" enclosing
+  "District 1"/"District 2", each keeping its own results. Union what we measure, send what the
+  user drew.
+- The union sits inside `layer_utils.calculate_aoi_area`, so every consumer of `aoi_size` (Area
+  label, cost estimate, aoiAreaLimit / templateAreaLimit / provider-minimum checks) agrees with the
+  backend without each caller remembering to dissolve.
+- A failed union falls back to measuring the geometry as-is: GEOS raises on invalid rings, and an
+  over-counted area beats a broken area display.
+- Not touched, on purpose: `maxAoisPerProcessing` still counts the source polygons, and
+  `max_aoi_bbox_area` still takes the per-part bounding box. Both now differ slightly from what the
+  backend sees after its own union — worth revisiting if a user hits it, not worth widening a
+  hotfix for.
+- Spec delta approved by user: 002_B "AOI area measurement".

--- a/WAL.md
+++ b/WAL.md
@@ -14,29 +14,3 @@
   unrelated errors surface instead of being logged and ignored.
 - Also revisit the `assert` statements in errors/error_message_list.py (Bandit B101: asserts are
   stripped under `python -O`) — turn the sanity checks into real error handling if they must run.
-
-## 3. Hotfix 3.6.1: count an overlapping AOI's area once
-[ready-for-review]
-- Root cause is `measureArea` over a collected (not unioned) MultiPolygon: its area is the sum of
-  the parts, so an overlap is added once per polygon. A real layer of two nearly-coincident AOIs
-  showed 2203.96 sq.km instead of 1108.96 — the price follows the same number.
-- Scope deliberately stops at the measurement. The first attempt also unioned the submitted
-  geometry; that is unnecessary (the backend unions on start, and cost will union too) and actively
-  wrong for Planned Search, where intersecting named AOIs are a feature: "City" enclosing
-  "District 1"/"District 2", each keeping its own results. Union what we measure, send what the
-  user drew.
-- The union sits inside `layer_utils.calculate_aoi_area`, so every consumer of `aoi_size` (Area
-  label, cost estimate, aoiAreaLimit / templateAreaLimit / provider-minimum checks) agrees with the
-  backend without each caller remembering to dissolve.
-- A failed union falls back to measuring the geometry as-is: GEOS raises on invalid rings, and an
-  over-counted area beats a broken area display.
-- Not touched, on purpose: `maxAoisPerProcessing` still counts the source polygons, and
-  `max_aoi_bbox_area` still takes the per-part bounding box. Both now differ slightly from what the
-  backend sees after its own union — worth revisiting if a user hits it, not worth widening a
-  hotfix for.
-- Spec delta approved by user: 002_B "AOI area measurement".
-
-## 4. Show readable provider names for My Imagery search results
-[ready-for-review]
-- Ships with hotfix 3.6.1, same branch as step 3.
-- Spec delta approved by user: 002_D "My Imagery search providers".

--- a/WAL.md
+++ b/WAL.md
@@ -35,3 +35,8 @@
   backend sees after its own union — worth revisiting if a user hits it, not worth widening a
   hotfix for.
 - Spec delta approved by user: 002_B "AOI area measurement".
+
+## 4. Show readable provider names for My Imagery search results
+[ready-for-review]
+- Ships with hotfix 3.6.1, same branch as step 3.
+- Spec delta approved by user: 002_D "My Imagery search providers".

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -34,6 +34,22 @@ class ConfigColumns():
         ]
         self.MAX_WIDTH = 200
 
+
+# Display labels for search-result provider names that are not meant for a user's eyes. The raw
+# values are the catalog API's and stay untouched everywhere else — requests, footprint attributes,
+# provider lookups and the local filter all keep matching on them; this map is for the table only.
+PROVIDER_DISPLAY_NAMES = {
+    'my_imagery_images': QCoreApplication.translate('Config', 'My Image'),
+    'my_imagery_mosaics': QCoreApplication.translate('Config', 'My Collection'),
+}
+
+
+def provider_display_name(provider_name):
+    """The label to show for a search result's provider. A name without a mapping (and a missing
+    name) is passed through untouched, so a new provider shows up as-is rather than blank."""
+    return PROVIDER_DISPLAY_NAMES.get(provider_name, provider_name)
+
+
 @dataclass
 class Config:
     TIMEZONE = time.localtime().tm_zone

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -11,7 +11,7 @@ from qgis.core import QgsMapLayerProxyModel, QgsSettings
 from qgis.gui import QgsRangeSlider
 
 from . import icons
-from ..config import config, ConfigColumns
+from ..config import config, ConfigColumns, provider_display_name
 from ..schema import BillingType, UserRole
 from ..entity.provider import ProviderInterface
 from ..functional import helpers
@@ -473,6 +473,10 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
                 feature['properties']['id'] = feature.get('id') # for uniformity
             for col, attr in enumerate(ConfigColumns().METADATA_TABLE_ATTRIBUTES.values()):
                 value = feature['properties'].get(attr)  # None in case of empty/non-existent field
+                if attr == 'providerName':
+                    # Display only — the feature keeps the API's own name, which is what the
+                    # filter, the footprints and the processing request match on.
+                    value = provider_display_name(value)
                 table_item = QTableWidgetItem()
                 table_item.setData(Qt.DisplayRole, value)
                 self.metadataTable.setItem(row, col, table_item)

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -110,23 +110,51 @@ def is_polygon_layer(layer: QgsMapLayer) -> bool:
     return layer.type() == QgsMapLayerType.VectorLayer and layer.geometryType() == QgsWkbTypes.PolygonGeometry
 
 
+def _unusable(geometry: Optional[QgsGeometry]) -> bool:
+    """A geometry GEOS handed back after giving up — null or empty."""
+    return geometry is None or geometry.isNull() or geometry.isEmpty()
+
+
+def _repaired_parts(aoi: QgsGeometry) -> List[QgsGeometry]:
+    """The AOI's parts, each made valid **on its own**.
+
+    Repairing part by part is not a detail: ``makeValid`` on the whole multipart geometry would
+    also resolve the *overlaps between* the parts, and a valid MultiPolygon may not have
+    overlapping components — so GEOS turns each overlap into a hole. On two AOIs that nearly
+    coincide that leaves the thin symmetric difference (0.14 of 1.29 sq.km on the reported layer)
+    instead of their union. Validate the parts, then let ``unaryUnion`` merge them.
+    """
+    parts = []
+    for part in aoi.asGeometryCollection() or [aoi]:
+        if part is None or part.isEmpty():
+            continue
+        if not part.isGeosValid():
+            repaired = part.makeValid()
+            if not _unusable(repaired):
+                part = repaired
+        parts.append(part)
+    return parts
+
+
 def union_parts(aoi: QgsGeometry) -> QgsGeometry:
-    """Dissolve the intersecting parts of a multipart geometry into one.
+    """The AOI's footprint as a geometry whose area can be measured: intersecting parts dissolved
+    into one, and self-intersecting rings repaired first so that the dissolve can happen at all.
 
     An AOI layer is collected into a MultiPolygon part by part (``QgsGeometry.collectGeometry``),
     which does not merge anything: intersecting polygons stay separate parts. Callers that measure
     the AOI need the union instead, because the area of a MultiPolygon is the sum of its parts.
 
-    Returns the geometry unchanged when there is nothing to dissolve, and when the union fails —
-    GEOS refuses invalid input such as self-intersecting rings, and an over-counted area is still
-    better than no area at all.
+    GEOS refuses to union invalid input and hands back a null geometry, so the parts are repaired
+    before they are dissolved — otherwise one self-intersecting polygon drops the whole layer back
+    to the over-counted sum. If the union fails even then, the geometry is returned unchanged: an
+    over-counted area beats no area at all.
     """
-    if aoi is None or aoi.isEmpty() or not aoi.isMultipart():
+    if aoi is None or aoi.isEmpty():
         return aoi
-    dissolved = QgsGeometry.unaryUnion([aoi])
-    if dissolved is None or dissolved.isNull() or dissolved.isEmpty():
-        return aoi
-    return dissolved
+    if not aoi.isMultipart() and aoi.isGeosValid():
+        return aoi  # nothing to dissolve and nothing to repair
+    dissolved = QgsGeometry.unaryUnion(_repaired_parts(aoi))
+    return aoi if _unusable(dissolved) else dissolved
 
 
 def calculate_aoi_area(aoi: QgsGeometry,

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -110,12 +110,34 @@ def is_polygon_layer(layer: QgsMapLayer) -> bool:
     return layer.type() == QgsMapLayerType.VectorLayer and layer.geometryType() == QgsWkbTypes.PolygonGeometry
 
 
+def union_parts(aoi: QgsGeometry) -> QgsGeometry:
+    """Dissolve the intersecting parts of a multipart geometry into one.
+
+    An AOI layer is collected into a MultiPolygon part by part (``QgsGeometry.collectGeometry``),
+    which does not merge anything: intersecting polygons stay separate parts. Callers that measure
+    the AOI need the union instead, because the area of a MultiPolygon is the sum of its parts.
+
+    Returns the geometry unchanged when there is nothing to dissolve, and when the union fails —
+    GEOS refuses invalid input such as self-intersecting rings, and an over-counted area is still
+    better than no area at all.
+    """
+    if aoi is None or aoi.isEmpty() or not aoi.isMultipart():
+        return aoi
+    dissolved = QgsGeometry.unaryUnion([aoi])
+    if dissolved is None or dissolved.isNull() or dissolved.isEmpty():
+        return aoi
+    return dissolved
+
+
 def calculate_aoi_area(aoi: QgsGeometry,
                        project_crs: QgsCoordinateReferenceSystem) -> float:
     calculator = QgsDistanceArea()
     calculator.setEllipsoid(WGS84_ELLIPSOID)
     calculator.setSourceCrs(WGS84, project_crs)
-    aoi_size = calculator.measureArea(aoi) / 10 ** 6  # sq. m to sq.km
+    # Measure the union, not the parts: intersecting polygons would otherwise contribute their
+    # shared area once each. The backend unions the AOI before it processes and charges for it,
+    # so the sum would overstate both the area we display and the limits we pre-check against it.
+    aoi_size = calculator.measureArea(union_parts(aoi)) / 10 ** 6  # sq. m to sq.km
     return aoi_size
 
 def max_aoi_bbox_area(aoi: QgsGeometry,

--- a/mapflow/functional/service/provider_service.py
+++ b/mapflow/functional/service/provider_service.py
@@ -19,7 +19,7 @@ from ...schema import (DataProviderParams,
                        ImagerySearchParams, 
                        UserDefinedParams)
 from ...schema.processing import ProcessingDTO
-from ...config import Config, ConfigColumns
+from ...config import Config, ConfigColumns, provider_display_name
 from ...errors import PluginError
 
 
@@ -464,6 +464,10 @@ class ProviderService(QObject):
         # Fill metadata table with the returned values
         for row, image_id in enumerate(image_ids):
             for column, value in per_row_columns(row, image_id).items():
+                if column == self.config.NAME_COLUMN_INDEX:
+                    # Display only, and only here: the pseudo-footprint layer built above keeps the
+                    # API's own provider name, which the min-area lookup matches on.
+                    value = provider_display_name(value)
                 table_item = QTableWidgetItem()
                 table_item.setData(Qt.DisplayRole, value)
                 self.dlg.metadataTable.setItem(row, column, table_item)

--- a/mapflow/metadata.txt
+++ b/mapflow/metadata.txt
@@ -17,6 +17,7 @@ email=hello@geoalert.io
 changelog:
     3.6.1
     - Fix: an AOI with intersecting polygons no longer has its overlapping area counted twice in the displayed area, the price estimate and the area limits
+    - My imagery search results are listed as "My Image" and "My Collection"
     3.6.0
     - Planned processings: create a background "Planned Search" to be automatically notified when new images are found; browse and manage search AOIs (add from a layer, draw on the map, update geometry, exclude from search, etc.) and their processings, grouped per AOI on the map
     - Imagery Search reworked: a new Off-Nadir angle filter, all search via the Mapflow catalog (legacy Maxar/Sentinel removed), server-side sorting by clicking column headers, and "My imagery" as image/mosaic search providers

--- a/mapflow/metadata.txt
+++ b/mapflow/metadata.txt
@@ -9,12 +9,14 @@ about=Mapflow provides AI models for automatic feature extraction from satellite
         - roads
         - construction sites
     For a step-by-step user guide, go to https://docs.mapflow.ai/api/qgis_mapflow#user-interface
-version=3.6.0
+version=3.6.1
 experimental=False
 deprecated=False
 author=Geoalert
 email=hello@geoalert.io
 changelog:
+    3.6.1
+    - Fix: an AOI with intersecting polygons no longer has its overlapping area counted twice in the displayed area, the price estimate and the area limits
     3.6.0
     - Planned processings: create a background "Planned Search" to be automatically notified when new images are found; browse and manage search AOIs (add from a layer, draw on the map, update geometry, exclude from search, etc.) and their processings, grouped per AOI on the map
     - Imagery Search reworked: a new Off-Nadir angle filter, all search via the Mapflow catalog (legacy Maxar/Sentinel removed), server-side sorting by clicking column headers, and "My imagery" as image/mosaic search providers

--- a/spec/002_B_processing_api.md
+++ b/spec/002_B_processing_api.md
@@ -14,6 +14,21 @@ List processings for a project. Polled approximately every 5 seconds for status 
 ### `PUT /processings/{id}`
 Update processing name/description.
 
+## AOI area measurement
+
+The AOI is collected from the selected polygon layer part by part (`QgsGeometry.collectGeometry`)
+and submitted as it is: **the plugin does not union it**. Intersecting polygons are meaningful
+input — a Planned Search may carry an AOI enclosing another one, each with its own name and its own
+results — and the backend unions the geometry itself when it starts a processing and when it
+estimates the cost.
+
+The **measurement** must union it, though. The area of a MultiPolygon is the sum of its parts, so
+overlapping polygons would contribute their shared area once per part, and the plugin would show
+(and pre-check limits against) more area than the backend charges for. `calculate_aoi_area`
+therefore measures the union of the parts, which makes the displayed *Area*, the cost estimate
+derived from it, and the client-side limit checks agree with the backend. If the union fails (GEOS
+rejects invalid input, e.g. self-intersecting rings), the geometry is measured as-is.
+
 ## AOI area limit
 
 Two ellipsoidal-area constraints apply, both against `user.aoiAreaLimit` (sq.m), reported in the

--- a/spec/002_B_processing_api.md
+++ b/spec/002_B_processing_api.md
@@ -26,8 +26,17 @@ The **measurement** must union it, though. The area of a MultiPolygon is the sum
 overlapping polygons would contribute their shared area once per part, and the plugin would show
 (and pre-check limits against) more area than the backend charges for. `calculate_aoi_area`
 therefore measures the union of the parts, which makes the displayed *Area*, the cost estimate
-derived from it, and the client-side limit checks agree with the backend. If the union fails (GEOS
-rejects invalid input, e.g. self-intersecting rings), the geometry is measured as-is.
+derived from it, and the client-side limit checks agree with the backend.
+
+Invalid input must not cost the user that dissolve. GEOS refuses to union a self-intersecting ring
+and answers with a NULL geometry, which would fall straight back to the summed parts — so each
+part is made valid **individually** before the union. Individually is the whole point: repairing
+the multipart geometry as a whole would also resolve the overlaps *between* the parts, and since a
+valid MultiPolygon may not have overlapping components, GEOS turns each overlap into a hole. On
+two AOIs that nearly coincide that leaves their thin symmetric difference — a fraction of the real
+area — which is a worse answer than the doubled one. The repair applies to a lone invalid polygon
+too, whose ring area is meaningless on its own (a bowtie's lobes cancel out to zero). If the union
+fails even after the repair, the geometry is measured as-is: an over-counted area beats none.
 
 ## AOI area limit
 

--- a/spec/002_D_search_api.md
+++ b/spec/002_D_search_api.md
@@ -57,5 +57,12 @@ the server-driven provider list automatically):
 
 Their `previewUrl` points at the data-catalog host (same Mapflow origin, under `/rest/rasters/…`)
 
+Those two names are internal, so the search-results **table** shows **"My Image"** and **"My
+Collection"** instead. The substitution is display-only and happens where the cell is written:
+the GeoJSON properties, the footprint layer attributes and the provider list keep the API's own
+names, and every match on them — the local provider filter, the per-provider minimum-area lookup,
+the processing request — keeps comparing raw names. A provider without a mapping is shown as it
+comes, so a new one is never blank.
+
 See also `002_F_plan_processing_api.md` for `POST /processings/template/{templateId}/images`,
 which returns a template's search results filtered server-side (a subset of the same filters).

--- a/tests/functional/test_layer_utils.py
+++ b/tests/functional/test_layer_utils.py
@@ -8,6 +8,21 @@ OVERLAPPING = ("MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),"
                "((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0)))")
 DISJOINT = "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((5 5,5 6,6 6,6 5,5 5)))"
 SINGLE = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+# A bowtie: the ring crosses itself at (1,1), so GEOS calls it invalid. Its two lobes are 1
+# sq.unit each; the naive ring area cancels them out to 0, because they wind opposite ways.
+BOWTIE = "POLYGON((0 0,2 2,2 0,0 2,0 0))"
+# The reported layer: two AOIs that nearly coincide, the first with a self-intersecting spike at
+# its top-left corner. Kept verbatim — a hand-made "nearly invalid" ring is not the same thing,
+# GEOS unions those without complaint.
+INVALID_WITH_OVERLAP = (
+    "MULTIPOLYGON((("
+    "116.482273015485958 40.096111205163901,116.483421141733757 40.096040829648665,"
+    "116.482293040394737 40.096061775252693,116.48231576177767 40.096323738956208,"
+    "116.493677906897517 40.095546101647621,116.492770663370834 40.083708733728095,"
+    "116.481368353824024 40.085400702403398,116.482273015485958 40.096111205163901)),(("
+    "116.48145172032369 40.095978122374611,116.481370716437368 40.085400027371008,"
+    "116.493332290315919 40.084399966891276,116.492727461298145 40.095848516156515,"
+    "116.48145172032369 40.095978122374611)))")
 
 
 def test_union_parts_merges_intersecting_parts():
@@ -36,6 +51,44 @@ def test_union_parts_leaves_a_single_polygon_untouched():
 def test_union_parts_tolerates_empty_and_none():
     assert union_parts(None) is None
     assert union_parts(QgsGeometry()).isEmpty()
+
+
+def test_geos_refuses_to_union_an_invalid_part():
+    """Pins the reason the repair exists: GEOS answers a self-intersecting ring with a NULL
+    geometry, which is what used to send the area calculation back to the summed parts."""
+    collected = QgsGeometry.fromWkt(INVALID_WITH_OVERLAP)
+
+    assert not collected.isGeosValid()
+    assert QgsGeometry.unaryUnion([collected]).isEmpty()
+
+
+def test_union_parts_repairs_an_invalid_part_and_still_dissolves():
+    collected = QgsGeometry.fromWkt(INVALID_WITH_OVERLAP)
+    parts = collected.asGeometryCollection()
+
+    dissolved = union_parts(collected)
+
+    assert not dissolved.isEmpty()
+    # The overlap is counted once: below the sum of the parts...
+    assert dissolved.area() < sum(part.area() for part in parts)
+    # ...and still covering the valid neighbour whole.
+    assert dissolved.area() >= parts[1].area()
+
+
+def test_union_parts_does_not_xor_the_overlap_away():
+    """``makeValid`` on the whole collection would resolve the overlap into a hole, leaving the
+    symmetric difference. The repair must therefore run per part, before the union."""
+    collected = QgsGeometry.fromWkt(INVALID_WITH_OVERLAP)
+
+    assert union_parts(collected).area() > collected.makeValid().area()
+
+
+def test_union_parts_repairs_a_lone_self_intersecting_polygon():
+    """A bowtie's ring area cancels itself out; the two lobes are what the user drew."""
+    bowtie = QgsGeometry.fromWkt(BOWTIE)
+
+    assert bowtie.area() == pytest.approx(0.0, abs=1e-9)
+    assert union_parts(bowtie).area() == pytest.approx(2.0)
 
 
 def test_xyz_no_creds():

--- a/tests/functional/test_layer_utils.py
+++ b/tests/functional/test_layer_utils.py
@@ -1,4 +1,41 @@
-from mapflow.functional.layer_utils import *
+import pytest
+from qgis.core import QgsGeometry
+
+from mapflow.functional.layer_utils import generate_xyz_layer_definition, union_parts
+
+# Two overlapping unit squares: 2.0 sq.units as separate parts, 1.75 as their union.
+OVERLAPPING = ("MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),"
+               "((0.75 0,0.75 1,1.75 1,1.75 0,0.75 0)))")
+DISJOINT = "MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((5 5,5 6,6 6,6 5,5 5)))"
+SINGLE = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+
+
+def test_union_parts_merges_intersecting_parts():
+    """The bug: the area of a MultiPolygon is the sum of its parts, so an overlap counts twice."""
+    collected = QgsGeometry.fromWkt(OVERLAPPING)
+
+    assert collected.area() == pytest.approx(2.0)
+    assert union_parts(collected).area() == pytest.approx(1.75)
+
+
+def test_union_parts_keeps_disjoint_parts_apart():
+    collected = QgsGeometry.fromWkt(DISJOINT)
+
+    dissolved = union_parts(collected)
+
+    assert dissolved.area() == pytest.approx(2.0)
+    assert len(dissolved.asMultiPolygon()) == 2
+
+
+def test_union_parts_leaves_a_single_polygon_untouched():
+    single = QgsGeometry.fromWkt(SINGLE)
+
+    assert union_parts(single) is single
+
+
+def test_union_parts_tolerates_empty_and_none():
+    assert union_parts(None) is None
+    assert union_parts(QgsGeometry()).isEmpty()
 
 
 def test_xyz_no_creds():
@@ -10,4 +47,3 @@ def test_xyz_no_creds():
                      '&zmax=18' \
                      '&username=' \
                      '&password='
-

--- a/tests/qgis/test_aoi_overlap_area.py
+++ b/tests/qgis/test_aoi_overlap_area.py
@@ -1,0 +1,110 @@
+"""QGIS-tier tests: the AOI area shown in the plugin counts an overlap once.
+
+Reported on a real 'POC' layer of two nearly-coincident quadrilaterals: the AOI is collected into
+a MultiPolygon part by part, and the area of a MultiPolygon is the sum of its parts, so the shared
+area was added twice (2203.96 instead of 1108.96 sq.km) — in the Area label, in the cost estimate
+derived from it, and in the client-side area limits.
+
+Only the measurement is unioned. The geometry the plugin submits is deliberately left as the user
+drew it: the backend unions the AOI on its side, and a Planned Search legitimately carries
+intersecting named AOIs ("City" enclosing "District 1"), which must stay separate.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from qgis.core import QgsFeature, QgsGeometry, QgsProject, QgsVectorLayer
+
+from mapflow.functional import layer_utils
+from mapflow.functional.service.area_calculator_service import AreaCalculatorService
+
+# The two AOIs of the reported layer, trimmed to 2D (the source carries a zero Z).
+POC_A = ("POLYGON((116.453049998276157 40.12268262081593,"
+         "116.455857049574931 39.77367257600082,"
+         "116.791767521662393 39.780222362364647,"
+         "116.785217735298573 40.127361039647234,"
+         "116.453049998276157 40.12268262081593))")
+POC_B = ("POLYGON((116.455160215366902 39.771790069375818,"
+         "116.793400039636495 39.779781230320488,"
+         "116.783915452966596 40.126904336856533,"
+         "116.455422181038699 40.120268410935203,"
+         "116.455160215366902 39.771790069375818))")
+FAR_1 = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
+FAR_2 = "POLYGON((5 5,5 6,6 6,6 5,5 5))"
+
+
+def _layer(wkts):
+    layer = QgsVectorLayer("Polygon?crs=epsg:4326", "aois", "memory")
+    features = []
+    for wkt in wkts:
+        feature = QgsFeature()
+        feature.setGeometry(QgsGeometry.fromWkt(wkt))
+        features.append(feature)
+    layer.dataProvider().addFeatures(features)
+    layer.updateExtents()
+    return layer
+
+
+def _service_for(wkts):
+    """Run the real area calculation over a layer, with only the UI/provider plumbing stubbed."""
+    service = AreaCalculatorService.__new__(AreaCalculatorService)
+    service.dlg = MagicMock()
+    service.dlg.metadataTable.selectedItems.return_value = []
+    service.config = MagicMock()
+    service.provider_service = MagicMock()
+    service.data_catalog_service = MagicMock()
+    service.processing_service = MagicMock()
+    service.app_context = SimpleNamespace(
+        aoi=None,
+        aoi_size=None,
+        processing_aoi=None,
+        max_aois_per_processing=10,
+        project=QgsProject.instance(),
+        user_role=SimpleNamespace(can_start_processing=True, value="OWNER"),
+    )
+    service.tr = lambda text: text
+    # Cropping to image footprints is a separate concern; keep the AOI as selected.
+    service.get_aoi = lambda provider_index, selected_aoi, local_image_indices: selected_aoi
+    service.get_aoi_area_polygon_layer(_layer(wkts))
+    return service
+
+
+def test_overlapping_aois_area_is_the_union_not_the_sum():
+    overlapping = _service_for([POC_A, POC_B]).app_context.aoi_size
+    a_only = _service_for([POC_A]).app_context.aoi_size
+    b_only = _service_for([POC_B]).app_context.aoi_size
+
+    # The two AOIs almost coincide, so their union is far below their sum...
+    assert overlapping < a_only + b_only
+    # ...and barely above either one on its own.
+    assert overlapping >= max(a_only, b_only)
+    assert overlapping == pytest.approx(max(a_only, b_only), rel=0.05)
+
+
+def test_disjoint_aois_area_is_still_the_total():
+    """Nothing is dissolved when the AOIs do not overlap: the total stays the sum of the parts.
+    (The two squares sit at different latitudes, so their ellipsoidal areas differ.)"""
+    both = _service_for([FAR_1, FAR_2]).app_context.aoi_size
+    first = _service_for([FAR_1]).app_context.aoi_size
+    second = _service_for([FAR_2]).app_context.aoi_size
+
+    assert both == pytest.approx(first + second, rel=1e-9)
+
+
+def test_submitted_geometry_keeps_the_source_polygons():
+    """The union is for measuring only: what we send stays as the user drew it, and the backend
+    unions it on its side."""
+    aoi = _service_for([POC_A, POC_B]).app_context.aoi
+
+    assert aoi.isMultipart()
+    assert len(aoi.asMultiPolygon()) == 2
+
+
+def test_measured_area_matches_the_union_of_the_layer():
+    service = _service_for([POC_A, POC_B])
+
+    union_area = layer_utils.calculate_aoi_area(
+        QgsGeometry.unaryUnion([QgsGeometry.fromWkt(POC_A), QgsGeometry.fromWkt(POC_B)]),
+        QgsProject.instance().transformContext())
+
+    assert service.app_context.aoi_size == pytest.approx(union_area)

--- a/tests/qgis/test_aoi_overlap_area.py
+++ b/tests/qgis/test_aoi_overlap_area.py
@@ -32,6 +32,23 @@ POC_B = ("POLYGON((116.455160215366902 39.771790069375818,"
 FAR_1 = "POLYGON((0 0,0 1,1 1,1 0,0 0))"
 FAR_2 = "POLYGON((5 5,5 6,6 6,6 5,5 5))"
 
+# A second reported layer: the same overlap, but the first AOI also self-intersects (the spike at
+# its top-left corner). GEOS answers an invalid ring with a NULL union, which used to fall back to
+# the summed parts — the very number this fix removes. 1.24 + 1.21 summed, 1.29 unioned.
+BROKEN_A = ("POLYGON((116.482273015485958 40.096111205163901,"
+            "116.483421141733757 40.096040829648665,"
+            "116.482293040394737 40.096061775252693,"
+            "116.48231576177767 40.096323738956208,"
+            "116.493677906897517 40.095546101647621,"
+            "116.492770663370834 40.083708733728095,"
+            "116.481368353824024 40.085400702403398,"
+            "116.482273015485958 40.096111205163901))")
+BROKEN_B = ("POLYGON((116.48145172032369 40.095978122374611,"
+            "116.481370716437368 40.085400027371008,"
+            "116.493332290315919 40.084399966891276,"
+            "116.492727461298145 40.095848516156515,"
+            "116.48145172032369 40.095978122374611))")
+
 
 def _layer(wkts):
     layer = QgsVectorLayer("Polygon?crs=epsg:4326", "aois", "memory")
@@ -98,6 +115,27 @@ def test_submitted_geometry_keeps_the_source_polygons():
 
     assert aoi.isMultipart()
     assert len(aoi.asMultiPolygon()) == 2
+
+
+def test_an_invalid_polygon_does_not_send_the_area_back_to_the_sum():
+    """A self-intersecting AOI must not cost the user the dissolve: GEOS refuses to union invalid
+    input, and the fallback for that used to be the summed parts."""
+    overlapping = _service_for([BROKEN_A, BROKEN_B]).app_context.aoi_size
+    broken_alone = _service_for([BROKEN_A]).app_context.aoi_size
+    valid_alone = _service_for([BROKEN_B]).app_context.aoi_size
+
+    assert overlapping == pytest.approx(1.29, abs=0.01)
+    # Not the sum (2.45) that the un-dissolved parts produce...
+    assert overlapping < broken_alone + valid_alone
+    # ...and not the sliver (0.14) that repairing the whole collection would leave, because
+    # a valid MultiPolygon may not have overlapping parts and GEOS resolves that into a hole.
+    assert overlapping > valid_alone
+
+
+def test_a_lone_invalid_polygon_is_measured_by_its_footprint():
+    """The self-intersecting AOI on its own: the repair is applied whether or not anything
+    overlaps it, so the area shown is the shape the user drew."""
+    assert _service_for([BROKEN_A]).app_context.aoi_size == pytest.approx(1.24, abs=0.01)
 
 
 def test_measured_area_matches_the_union_of_the_layer():

--- a/tests/qgis/test_provider_display_names.py
+++ b/tests/qgis/test_provider_display_names.py
@@ -1,0 +1,84 @@
+"""QGIS-tier tests: My Imagery search results show a readable provider name.
+
+The catalog returns the user's own imagery under the internal names ``my_imagery_images`` and
+``my_imagery_mosaics``. Those belong in requests and lookups, not in front of a user, so the
+search-results table shows "My Image" / "My Collection" instead. The mapping is display-only:
+the GeoJSON properties, the footprint attributes and everything matching on them are untouched.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtWidgets import QTableWidget
+
+from mapflow.config import Config, ConfigColumns, provider_display_name
+from mapflow.dialogs.main_dialog import MainDialog
+
+_ATTRS = list(ConfigColumns().METADATA_TABLE_ATTRIBUTES.values())
+_PROVIDER_COLUMN = _ATTRS.index('providerName')
+_ID_COLUMN = _ATTRS.index('id')
+
+
+def _dialog():
+    """A MainDialog stub with a real table: fill_metadata_table only touches these three."""
+    dialog = MainDialog.__new__(MainDialog)
+    dialog.metadataTable = QTableWidget(0, len(_ATTRS))
+    dialog.add_preview_cell = MagicMock()
+    dialog.metadataTableFilled = MagicMock()
+    return dialog
+
+
+def _metadata(*provider_names):
+    return {"features": [{"id": f"image-{i}",
+                          "properties": {"providerName": name, "id": f"image-{i}"}}
+                         for i, name in enumerate(provider_names)]}
+
+
+@pytest.mark.parametrize("raw, shown", [("my_imagery_images", "My Image"),
+                                        ("my_imagery_mosaics", "My Collection")])
+def test_my_imagery_provider_names_are_shown_readably(raw, shown):
+    dialog = _dialog()
+
+    dialog.fill_metadata_table(_metadata(raw))
+
+    assert dialog.metadataTable.item(0, _PROVIDER_COLUMN).text() == shown
+
+
+def test_other_providers_are_shown_as_they_come():
+    dialog = _dialog()
+
+    dialog.fill_metadata_table(_metadata("Maxar", "Airbus"))
+
+    assert [dialog.metadataTable.item(row, _PROVIDER_COLUMN).text() for row in range(2)] \
+        == ["Maxar", "Airbus"]
+
+
+def test_a_missing_provider_name_stays_empty():
+    dialog = _dialog()
+
+    dialog.fill_metadata_table(_metadata(None))
+
+    assert dialog.metadataTable.item(0, _PROVIDER_COLUMN).text() == ""
+
+
+def test_only_the_provider_column_is_remapped():
+    """A guard against remapping by value instead of by column: an image id that happens to
+    equal a provider name must be shown untouched."""
+    dialog = _dialog()
+
+    dialog.fill_metadata_table({"features": [{"properties": {"providerName": "my_imagery_images",
+                                                             "id": "my_imagery_images"}}]})
+
+    assert dialog.metadataTable.item(0, _PROVIDER_COLUMN).text() == "My Image"
+    assert dialog.metadataTable.item(0, _ID_COLUMN).text() == "my_imagery_images"
+
+
+def test_display_name_helper_passes_unknown_values_through():
+    assert provider_display_name("my_imagery_images") == "My Image"
+    assert provider_display_name("my_imagery_mosaics") == "My Collection"
+    assert provider_display_name("Maxar") == "Maxar"
+    assert provider_display_name(None) is None
+
+
+def test_provider_column_index_matches_the_config():
+    """The remap is keyed on the attribute name, but the duplicate path keys on this index."""
+    assert Config.NAME_COLUMN_INDEX == _PROVIDER_COLUMN


### PR DESCRIPTION
Two independent changes for the 3.6.1 hotfix, one commit each.

---

## 1. `fix:` count an overlapping AOI's area once when measuring it

Supersedes #330, which unioned too much.

`QgsDistanceArea.measureArea` over a collected MultiPolygon returns the **sum of its parts**. An AOI layer with intersecting polygons (separate features, or parts of one multipolygon) therefore had the shared area counted once per polygon.

On the reported layer — two nearly-coincident quadrilaterals over Beijing:

| | area |
|---|---|
| before | 2203.96 sq.km |
| after | 1108.96 sq.km |
| either AOI alone | 1103.47 / 1100.49 |

The inflated number drove the *Area* label, the price estimate derived from it, the `aoiAreaLimit` / `templateAreaLimit` pre-checks and the provider-minimum check.

**The fix:** `layer_utils.union_parts()` dissolves a multipart geometry, and `calculate_aoi_area` measures the union instead of the parts. Every consumer of `aoi_size` picks it up from there. A failed union (GEOS rejects self-intersecting rings) falls back to measuring the geometry as-is.

**Deliberately not changed:**
- **The submitted geometry** — the backend unions the AOI on start, and cost estimation is getting the same union.
- **Planned Search / `aoiDetails`** — intersecting named AOIs are a feature: "City" enclosing "District 1" and "District 2", each with its own results. Nothing in the template path is touched.
- `maxAoisPerProcessing` still counts the source polygons, and `max_aoi_bbox_area` still takes the per-part bounding box; both now differ slightly from what the backend sees after its own union. Noted in WAL as worth revisiting only if a user hits it.

---

## 2. `feat:` show My Imagery search results as "My Image" / "My Collection"

The catalog returns the user's own imagery under `my_imagery_images` / `my_imagery_mosaics`. Those are internal identifiers that were sitting in the Provider Name column next to "Maxar" and "Airbus".

The substitution happens where the table cell is written, and nowhere else. The GeoJSON properties, the footprint layer attributes and the provider list keep the API's own names, so the local provider filter, the per-provider minimum-area lookup and the processing request all keep matching on raw names. The remap is keyed on the **column**, not the value, so an image id that happens to equal a provider name is left alone. Both writers of that table are covered — a fresh search and the duplicate-processing path. An unmapped provider is shown as it comes, never blank.

---

## Spec

- 002_B "AOI area measurement"
- 002_D "My Imagery search providers"

## Tests

`agent-make test` green: 12 functional + 414 qgis. New: 4 unit tests for `union_parts`, a qgis-tier suite driving the real `AreaCalculatorService` over the reported geometry (union not sum, disjoint AOIs unaffected, submitted geometry still carries both polygons), and 7 tests for the provider-name display (both names, unmapped passthrough, missing name, and a guard that only the provider column is remapped).

## Note for the reviewer

`metadata.txt` is bumped to 3.6.1 with CHANGELOG entries — drop those hunks if you bump at release time. Cut from `master`, so it needs a back-merge into `dev` (39 commits ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)