### PR TITLE
refactor/extract preview service

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -38,34 +38,24 @@ leaf-first so each extraction depends only on what already moved.
 
 Service and controller boundaries are tabulated in `spec/007_architecture.md`.
 
-[ready-for-review] Extract AOI editing and AOI layers → `AoiService` + `view/aoi_view.py` + `ProcessingController`
-Note on the split, decided when the step was planned: the AOI wiring spans two controller
-regions. The start-processing panel's AOI selection is `ProcessingController` (created by this
-step); the on-map edit sessions are template AOIs and belong to `TemplateController`, which the
-templates step below creates. The *logic* all moves now; the template-side connects stay in
-`mapflow.py` until that controller exists, which the spec permits — `mapflow.py` may hold
-wiring, not domain logic.
-`filter_search_by_selected_aoi` goes with `SearchService`, and the template AOI *display*
-layers (`_add_geojson_aoi_layer`, `on_template_aois_changed`) with `TemplateService`.
-[ ] Extract preview → `PreviewService`
+[ready-for-review] Extract preview → `PreviewService`
+Boundary: preview *layers on the map*. That includes the My Imagery map-layer previews
+(`mosaic_preview`, `get_image_preview_l`) but not `get_image_preview_s`, which paints a QImage
+into a panel widget — a thumbnail, not a layer, so it stays with the catalog.
+`ResultsLoader`'s preview helpers stay in `layer_utils` and are called from the service; Phase D
+moves that module wholesale, so moving them now would churn a file that step rewrites.
+Search-tab widget reads stay in `mapflow.py` until the next step creates `view/search_view.py`.
+Also splits `_template_group_target` into a pure `find` and an explicit `ensure` — see the
+templates step, which was carrying that decision until preview became its second caller.
 [ ] Extract imagery search → `SearchService` + `SearchController` + `view/search_view.py`
 [ ] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
 [ ] Extract templates → `TemplateService` + `TemplateController` (largest domain, ~55 methods
     in `mapflow.py` plus the template half of `processing_service.py`)
-Decide here: `_template_group_target` is find-**or-create**, and that conflation is already
-leaking. `AoiService.select_aois_as_processing_area` has to take the group as a *callable*
-(`group_factory`) purely so the group is not materialised on every AOI selection change — a
-lambda whose only job is to defer a side effect, which is a smell pointing at the callee.
-Two ways out, to choose when this step rewrites the code anyway:
-- split it into a pure `find_template_group` and an explicit `ensure_template_group`, and pass
-  the found group (or None) eagerly; or
-- have `AoiService` emit the layer it built and let the template owner place it in the tree,
-  on the grounds that *where a layer sits in the layer tree* is a template concern, not AOI
-  geometry.
-The second is probably right but is the bigger change. Note the create-if-missing looks
-defensive rather than load-bearing: the template group already exists by the time a multi-AOI
-selection is possible, because opening the template draws its AOI display layers through the
-same function. Confirm that before removing it.
+Still open here: whether placing a layer in the template's group belongs to the service that
+built the layer at all. `AoiService` and `PreviewService` both reach for the template group
+today; the alternative is that they emit the layer and the template owner places it, on the
+grounds that *where a layer sits in the layer tree* is a template concern. The find/ensure split
+(preview step) removed the pressure to decide, not the question.
 [ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
 [ ] Split auth from account status → `SessionService` + `AccountService`
 [ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction

--- a/mapflow/functional/controller/data_catalog_controller.py
+++ b/mapflow/functional/controller/data_catalog_controller.py
@@ -1,12 +1,19 @@
 from PyQt5.QtCore import QObject
 from ..service.data_catalog import DataCatalogService
+from ..service.preview_service import PreviewService
 from ...dialogs.main_dialog import MainDialog
 
 
 class DataCatalogController(QObject):
-    def __init__(self, dlg: MainDialog, data_catalog_service: DataCatalogService):
+    def __init__(self,
+                 dlg: MainDialog,
+                 data_catalog_service: DataCatalogService,
+                 preview_service: PreviewService):
         self.dlg = dlg
         self.service = data_catalog_service
+        # Which mosaic/image is selected is the catalog's; putting the raster on the map is
+        # PreviewService's, so the two preview buttons wire across.
+        self.preview_service = preview_service
         self.view = self.service.view
 
         # At first, when mosaic and image are not selected, make buttons unavailable or hidden
@@ -16,7 +23,8 @@ class DataCatalogController(QObject):
 
         # Mosaic
         self.dlg.editMosaicButton.clicked.connect(self.service.update_mosaic)
-        self.dlg.previewMosaicButton.clicked.connect(self.service.mosaic_preview)
+        self.dlg.previewMosaicButton.clicked.connect(
+            self.preview_service.preview_my_imagery_mosaic)
         self.dlg.mosaicTable.selectionModel().selectionChanged.connect(self.service.check_mosaic_selection)
         self.dlg.showImagesButton.clicked.connect(self.view.show_images_table)
         self.dlg.seeImagesButton.clicked.connect(self.view.show_images_table)
@@ -30,7 +38,8 @@ class DataCatalogController(QObject):
         self.view.choose_raster_layer.triggered.connect(self.service.choose_raster_layers)
         self.dlg.imageInfoButton.clicked.connect(self.service.image_info)
         self.dlg.renameImageButton.clicked.connect(self.service.show_rename_image_dialog)
-        self.dlg.previewImageButton.clicked.connect(self.service.get_image_preview_l)
+        self.dlg.previewImageButton.clicked.connect(
+            self.preview_service.preview_my_imagery_image)
         self.dlg.downloadImageButton.clicked.connect(self.service.download_image)
         self.dlg.imageTable.selectionModel().selectionChanged.connect(self.service.check_image_selection)
         self.dlg.seeMosaicsButton.clicked.connect(self.service.switch_to_mosaics_table)

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -106,6 +106,24 @@ def get_catalog_aoi(catalog_aoi: QgsGeometry,
     return clipped_aoi
 
 
+def find_template_group(project,
+                        mapflow_group_name: str,
+                        template_group_name: str,
+                        subgroup_name: Optional[str] = None):
+    """The ``<mapflow group> > <template> [> <subgroup>]`` layer-tree group, or None.
+
+    Creates nothing — that is `Mapflow._ensure_template_group`. Lives here because both the
+    plugin and the services that place an already-built layer need the lookup, and a service may
+    not reach back into `mapflow.py` for it.
+    """
+    root = project.layerTreeRoot()
+    parent_group = root.findGroup(mapflow_group_name) or root
+    template_group = parent_group.findGroup(template_group_name)
+    if template_group is None or not subgroup_name:
+        return template_group
+    return template_group.findGroup(subgroup_name)
+
+
 def is_polygon_layer(layer: QgsMapLayer) -> bool:
     """Determine if a layer is of vector type and has polygonal geometry.
     :param layer: A layer to test

--- a/mapflow/functional/service/alert_service.py
+++ b/mapflow/functional/service/alert_service.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 from PyQt5.QtWidgets import QApplication, QInputDialog, QMessageBox
 from PyQt5.QtCore import Qt, QObject
 
@@ -62,6 +62,35 @@ class AlertService(QObject):
         """Display a confirmation dialog. Returns True if user confirms."""
         return self.alert(message, QMessageBox.Question, blocking=True)
 
+    def report_http_error(self,
+                          response,
+                          plugin_version: str,
+                          title: str = None,
+                          error_message_parser: Optional[Callable] = None) -> None:
+        """The *report* tier of `spec/006_error_reporting.md`: the dialog that offers to mail us
+        the failure. Here for the same reason `alert` and `ask_text` are — a service that hits an
+        HTTP error should not have to import a dialog to say so.
+
+        `plugin_version` is passed in rather than read: this tier knows how to present a failure,
+        not where the session state lives.
+        """
+        # Imported here, not at module scope, for the reason `error_guard.report_unexpected_error`
+        # gives for the same import: the dialog pulls in the Qt widget tree, and keeping it lazy
+        # lets a headless context construct this service without one. Showing dialogs is this
+        # tier's job, so the dependency itself is not the thing being avoided.
+        from ...dialogs.error_message_widget import ErrorMessageWidget
+        from ...http import get_error_report_body
+        response_body = response.readAll().data().decode()
+        error_summary, email_body = get_error_report_body(
+            response=response,
+            response_body=response_body,
+            plugin_version=plugin_version,
+            error_message_parser=error_message_parser)
+        ErrorMessageWidget(parent=QApplication.activeWindow(),
+                           text=error_summary,
+                           title=title,
+                           email_body=email_body).show()
+
     def ask_text(self, title: str, label: str, default: str = "") -> Tuple[str, bool]:
         """Ask the user for a line of text. Returns (text, accepted).
 
@@ -92,3 +121,8 @@ def alert_confirm(message: str) -> bool:
 
 def ask_text(title: str, label: str, default: str = "") -> Tuple[str, bool]:
     return AlertService.instance().ask_text(title, label, default)
+
+def report_http_error(response, plugin_version: str, title: str = None,
+                      error_message_parser: Optional[Callable] = None) -> None:
+    return AlertService.instance().report_http_error(
+        response, plugin_version, title, error_message_parser)

--- a/mapflow/functional/service/aoi_service.py
+++ b/mapflow/functional/service/aoi_service.py
@@ -221,7 +221,7 @@ class AoiService(QObject):
 
     # ---------- the processing Area for a template AOI selection ----------
 
-    def select_aois_as_processing_area(self, aois, group_factory=None) -> None:
+    def select_aois_as_processing_area(self, aois, group=None) -> None:
         """Point the Area at the selected AOI(s), so the Area shown in the combo IS the one a
         processing will use — one place to look, no silent override.
 
@@ -229,23 +229,23 @@ class AoiService(QObject):
         gets a visible "Selected AOIs" layer holding one feature per AOI. No-op when no AOI is
         selected, keeping the current Area (e.g. while a processing row is selected).
 
-        ``group_factory`` is called — at most once, and only for a multi-selection — to get the
-        template's layer-tree group. It is a callable rather than a group because resolving that
-        group *creates* it when missing, and this runs on every selection change.
+        ``group`` is the template's layer-tree group, or None to leave the built layer at the
+        root. Looking it up is side-effect free (`Mapflow._find_template_group`), so it can be
+        resolved before the call rather than deferred into it.
         """
         aois = [aoi for aoi in aois if aoi and aoi.id]
         selected_ids = frozenset(str(aoi.id) for aoi in aois)
         # Selection signals fire often; only rebuild when the set actually changes.
         if selected_ids == (self._processing_area_filter or frozenset()):
             return
-        layer = self._layer_for_selected_aois(aois, group_factory)
+        layer = self._layer_for_selected_aois(aois, group)
         if layer is None:
             return
         self._processing_area_filter = selected_ids or None
         # The controller points the combo at it; layerChanged then recomputes Area and cost.
         self.currentAoiLayerChanged.emit(layer, True)
 
-    def _layer_for_selected_aois(self, aois, group_factory) -> Optional[QgsVectorLayer]:
+    def _layer_for_selected_aois(self, aois, group) -> Optional[QgsVectorLayer]:
         """The layer the Area combo should show for the current AOI selection."""
         if not aois:
             return None
@@ -256,10 +256,10 @@ class AoiService(QObject):
                       if geom is not None]
         if not geometries:
             return None
-        return self.rebuild_selected_aois_layer(geometries, group_factory)
+        return self.rebuild_selected_aois_layer(geometries, group)
 
     def rebuild_selected_aois_layer(self, geometries: List[QgsGeometry],
-                                    group_factory=None) -> QgsVectorLayer:
+                                    group=None) -> QgsVectorLayer:
         """(Re)build the visible "Selected AOIs" layer in the template group — one feature per
         selected AOI, so a processing covers exactly them and the per-processing AOI limit still
         applies. Visible on the map and in the tree (unlike the old hidden 'Selected AOI')."""
@@ -273,7 +273,6 @@ class AoiService(QObject):
         layer.dataProvider().addFeatures(features)
         layer.updateExtents()
         layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'aoi.qml'))
-        group = group_factory() if group_factory is not None else None
         if group is not None:
             self.app_context.project.addMapLayer(layer, addToLegend=False)
             group.insertLayer(0, layer)

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import QObject, QUrl, pyqtSignal, Qt
 from PyQt5.QtGui import QImage
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog, QAbstractItemView
-from qgis.core import QgsCoordinateReferenceSystem, QgsGeometry, QgsRasterLayer
+from qgis.core import QgsRasterLayer
 
 from ...dialogs.main_dialog import MainDialog
 from ...dialogs.mosaic_dialog import CreateMosaicDialog, UpdateMosaicDialog
@@ -19,7 +19,7 @@ from ...schema import MyImageryParams
 from ..api.data_catalog_api import DataCatalogApi
 from ..view.data_catalog_view import DataCatalogView
 from ...http import Http
-from ...functional import layer_utils, helpers
+from ...functional import helpers
 from ...functional.app_context import AppContext
 from ...config import Config
 from ...model.provider import MyImageryProvider
@@ -228,19 +228,6 @@ class DataCatalogService(QObject):
         self.view.add_mosaic_cell_buttons()
         self.view.show_mosaic_info(mosaic.name)
 
-    def mosaic_preview(self):
-        try:
-            mosaic = self.selected_mosaic()
-            url = mosaic.rasterLayer.tileUrl
-            url_json = mosaic.rasterLayer.tileJsonUrl
-            name = mosaic.name
-            layer = layer_utils.generate_raster_layer(url, name)
-            self.api.request_mosaic_extent(url_json, layer)
-        except AttributeError:
-            message = 'Please, select imagery collection'
-            info_box = QMessageBox(QMessageBox.Information, "Mapflow", message, parent=QApplication.activeWindow())
-            return info_box.exec()
-
 
     # Images CRUD
     def upload_images_to_mosaic(self):
@@ -445,38 +432,6 @@ class DataCatalogService(QObject):
         self.view.show_preview_s(image)
         if self.view.mosaic_table_visible:
             self.view.enable_mosaic_images_preview(len(self.images), self.preview_idx)
-
-    def get_image_preview_l(self):
-        try:
-            image = self.selected_image()
-            footprint = QgsGeometry.fromWkt(image.footprint)  # already in WGS84
-            self.api.get_image_preview_l(image=image,
-                                         footprint=footprint,
-                                         callback=self.display_image_preview,
-                                         image_name=image.filename)
-        except AttributeError:
-            return
-
-    def display_image_preview(self,
-                              response: QNetworkReply,
-                              footprint: QgsGeometry,
-                              crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:4326"),
-                              image_name: str = ""):
-        """Display image preview using GCP-based georeferencing.
-
-        Uses ResultsLoader.display_preview_with_gcp() which handles rotated/skewed footprints correctly.
-        QGIS will reproject on-the-fly to match the project CRS.
-        """
-        layer = self.result_loader.display_preview_with_gcp(
-            response=response,
-            footprint=footprint,
-            crs=crs,
-            image_name=image_name,
-            add_aoi=False
-        )
-        if layer:
-            self.iface.setActiveLayer(layer)
-            self.iface.zoomToActiveLayer()
 
     def rename_image_callback(self, response: QNetworkReply):
         new_image = ImageReturnSchema.from_dict(json.loads(response.readAll().data()))

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -1,0 +1,399 @@
+import os
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtNetwork import QNetworkReply
+from osgeo import gdal, ogr
+from qgis.core import (QgsCoordinateReferenceSystem, QgsFeature, QgsGeometry, QgsLayerTreeLayer,
+                       QgsRasterLayer, QgsRectangle, QgsVectorLayer)
+
+from .. import helpers
+from .. import layer_utils
+from ..app_context import AppContext
+from .alert_service import alert, alert_info, alert_warning, report_http_error
+from ...config import OSM
+from ...errors import ImageIdRequired
+from ...schema.catalog import MultiPreviewList, PreviewType
+
+
+class PreviewService(QObject):
+    """Preview *layers on the map*: XYZ tiles, PNG/JPG stills, mosaic tiles, catalog images.
+
+    The boundary is the layer. The My Imagery thumbnail (`get_image_preview_s`) paints a QImage
+    into a panel widget and stays with the catalog; anything that puts a raster on the map is
+    here, together with the two guards that keep a second copy off it.
+
+    Holds no widget and no dialog (`spec/007_architecture.md` § Layer rules). The search-table
+    reads that decide *which* image to preview stay with the caller until
+    `view/search_view.py` exists; what arrives here is an image id or a feature.
+    """
+
+    def __init__(self,
+                 iface,
+                 app_context: AppContext,
+                 http,
+                 plugin_dir: str,
+                 config,
+                 result_loader,
+                 processing_service):
+        super().__init__()
+        self.iface = iface
+        self.app_context = app_context
+        self.http = http
+        self.plugin_dir = plugin_dir
+        self.config = config
+        self.result_loader = result_loader
+        #: Consulted for the in-template placement rules only. Becomes `TemplateService` when the
+        #: templates step splits it out.
+        self.processing_service = processing_service
+        #: Image ids whose preview is being downloaded. The layer is only added in the HTTP
+        #: callback, so the on-map duplicate check cannot see an in-flight one — a rapid second
+        #: click would start a second download without this.
+        self._pending_preview_ids = set()
+        #: The mosaic-preview boundary layer currently shown. Its name varies by acquisition
+        #: date, so a name match alone leaves the previous boundary on the map.
+        self._mosaic_preview_footprint_id = None
+
+    # ---------- reading the search-metadata layer ----------
+
+    def metadata_feature(self, image_id):
+        if not image_id:
+            return None
+        try:  # Get the image extent to set the correct extent on the raster layer
+            return next(self.app_context.metadata_layer.getFeatures(f"id = '{image_id}'"))
+        except (RuntimeError, AttributeError, StopIteration):  # layer gone, deleted, or empty
+            return None
+
+    def metadata_footprint(self,
+                           image_id=None,
+                           feature=None,
+                           crs: QgsCoordinateReferenceSystem = helpers.WEB_MERCATOR):
+        if not feature:
+            feature = self.metadata_feature(image_id)
+        if not feature:
+            return None
+        return helpers.from_wgs84(feature.geometry(), crs)
+
+    @staticmethod
+    def _feature_attribute(feature, name):
+        """``feature.attribute(name)``, or ``None`` when that field does not exist on the layer.
+
+        The OGR GeoJSON reader omits a property that is null in every feature, so My Imagery
+        results (all-null ``acquisitionDate`` etc.) lack those columns and a plain
+        ``feature.attribute(name)`` would raise ``KeyError``. A NULL value on an existing field
+        already comes back as Python ``None``."""
+        try:
+            return feature.attribute(name)
+        except KeyError:
+            return None
+
+    # ---------- placement ----------
+
+    def _add_aoi_to_preview_if_needed(self) -> None:
+        """Overlay the search AOI on a preview — but not inside a template, where the AOI is
+        already drawn as its own layer, so the clone would just duplicate it (feedback 1)."""
+        if self.processing_service.in_template_mode:
+            return
+        self.result_loader.add_aoi_to_preview()
+
+    def _relocate_to_template_group(self, layer) -> None:
+        """In the in-template view, move a freshly added preview layer into the template's
+        map group, above the search-results footprints and below the AOI subgroups, so the
+        precedence is AOIs (top) > previews > search results (bottom)."""
+        service = self.processing_service
+        if not layer or not service.in_template_mode or not service.active_template:
+            return
+        settings = self.app_context.settings
+        mapflow_group_name = settings.value('layerGroup') or self.app_context.plugin_name
+        try:
+            template_group = layer_utils.find_template_group(
+                self.app_context.project, mapflow_group_name, str(service.active_template.name))
+            root = self.app_context.project.layerTreeRoot()
+            node = root.findLayer(layer.id())
+            if node is None or template_group is None:
+                return
+            footprints_layer = getattr(self.app_context, 'metadata_layer', None)
+            footprints_id = footprints_layer.id() if footprints_layer else None
+            children = template_group.children()
+            # Default to the bottom; otherwise insert directly above the footprints layer
+            # (which itself sits below the AOI/processing subgroups).
+            insert_index = len(children)
+            for i, child in enumerate(children):
+                if isinstance(child, QgsLayerTreeLayer) and child.layerId() == footprints_id:
+                    insert_index = i
+                    break
+            template_group.insertChildNode(insert_index, node.clone())
+            (node.parent() or root).removeChildNode(node)
+        except (AttributeError, RuntimeError):
+            return
+
+    def _move_layer_to_top(self, layer_id: str) -> bool:
+        """Move an existing layer's tree node to the top of its parent group."""
+        root = self.app_context.project.layerTreeRoot()
+        node = root.findLayer(layer_id)
+        if not node:
+            return False
+        parent = node.parent() or root
+        parent.insertChildNode(0, node.clone())
+        parent.removeChildNode(node)
+        return True
+
+    # ---------- entry points ----------
+
+    def preview_catalog(self, image_id):
+        feature = self.metadata_feature(image_id)
+        if not feature:
+            alert(self.tr("Preview is unavailable when metadata layer is removed"))
+            return
+        # If this image's preview is already on the map (layers are named "<image_id> preview"),
+        # just bring it to the top instead of downloading and adding a duplicate.
+        existing_preview = self.app_context.project.mapLayersByName(f"{image_id} preview")
+        if existing_preview:
+            self._move_layer_to_top(existing_preview[0].id())
+            self.iface.setActiveLayer(existing_preview[0])
+            self.iface.mapCanvas().refresh()
+            return
+        # A preview for this image is already being downloaded (async): a rapid second click /
+        # double-click must not start another download. The preview layer is only added in the
+        # HTTP callback, so the on-map guard above cannot catch these — hence this in-flight set.
+        if image_id in self._pending_preview_ids:
+            return
+        footprint = self.metadata_footprint(feature=feature)
+        self.iface.mapCanvas().zoomToSelected(self.app_context.metadata_layer)
+        self.iface.mapCanvas().refresh()
+        # Get multi-image preview (e.g. Roscosmos)
+        try:
+            previews_list = MultiPreviewList.from_dict_or_string(feature['previews'])
+        except KeyError:  # duplicated processings don't have this field
+            previews_list = MultiPreviewList([])
+        if len(previews_list.previews) != 0:
+            previews = []
+            for p in previews_list.previews:
+                # Create QgsGeometry from GeoJSON through ogr and wkt
+                ogr_geom = ogr.CreateGeometryFromJson(str(p.geometry))
+                wkt_geom = ogr_geom.ExportToWkt()
+                geom = QgsGeometry.fromWkt(wkt_geom)
+                previews.append((p.url, geom))
+            self._pending_preview_ids.add(image_id)  # in-flight until the VRT is added / errors
+            self.preview_multiple_png(response=None,
+                                      previews=previews,
+                                      footprint=previews[0][1],
+                                      image_id=image_id,
+                                      georeferenced_previews_list=[])
+            return
+        # Get single image preview. Read each attribute independently: a My Imagery result may
+        # lack whole metadata columns — an all-null acquisitionDate is dropped by the OGR GeoJSON
+        # reader, so feature.attribute('acquisitionDate') raises KeyError. A single missing field
+        # must not blank out the others (a shared try/except previously reset preview_type to '',
+        # so even mosaics with a valid xyz preview reported "no preview"). Duplicated processings
+        # likewise lack these fields, and get '' the same way.
+        url = self._feature_attribute(feature, 'previewUrl') or ''
+        preview_type = self._feature_attribute(feature, 'previewType') or ''
+        provider_name = self._feature_attribute(feature, 'providerName') or ''
+        raw_date = self._feature_attribute(feature, 'acquisitionDate')
+        image_date = raw_date.toString("dd.MM.yyyy") if raw_date else ''
+        if not preview_type:
+            alert(self.tr("Selected imagery has no preview"))
+            return
+        # Display image preview
+        if preview_type in (PreviewType.png, PreviewType.jpg):
+            if not url:
+                alert(self.tr("Preview with such URL is unavailable"))
+                return
+            self._pending_preview_ids.add(image_id)  # in-flight until added / errors
+            self.preview_png(url, footprint, image_id)
+        # Display mosaic preview
+        elif preview_type in (PreviewType.xyz, PreviewType.tms, PreviewType.wms):
+            self.preview_mosaic(feature, url, preview_type, provider_name, image_date)
+        else:
+            alert(self.tr("Preview for '{iid}' is unavailable").format(iid=image_id))
+            return
+
+    def preview_xyz(self, provider, image_id):
+        max_zoom = self.config.MAX_ZOOM
+        layer_name = provider.name
+        try:
+            url = provider.preview_url(image_id=image_id)
+            preview_max_zoom = provider.preview_max_zoom
+        except ImageIdRequired:
+            alert_warning(self.tr("Provider {name} requires image id for preview!")
+                          .format(name=provider.name))
+            return
+        except NotImplementedError:
+            alert_info(self.tr("Preview is unavailable for the provider {}. \n"
+                               "OSM layer will be added instead.").format(provider.name))
+            # Add OSM instead of preview, if it is unavailable (for Mapbox)
+            layer = QgsRasterLayer(OSM, 'OpenStreetMap', 'wms')
+            self.result_loader.add_preview_layer(preview_layer=layer)
+            return
+        except Exception as e:
+            # provider.preview_url is provider-supplied and may fail in ways only it knows;
+            # the message is the only thing the user can act on, so it is shown rather than
+            # narrowed away.
+            alert_warning(str(e))
+            return
+        uri = layer_utils.generate_xyz_layer_definition(url,
+                                                        provider.source_type,
+                                                        preview_max_zoom or max_zoom,
+                                                        provider.credentials.login,
+                                                        provider.credentials.password)
+        layer = QgsRasterLayer(uri, layer_name, 'wms')
+        layer.setCrs(QgsCoordinateReferenceSystem(provider.crs))
+        if layer.isValid():
+            self.result_loader.add_preview_layer(preview_layer=layer)
+        else:
+            alert(self.tr("We couldn't load a preview for this image"))
+
+    # ---------- PNG / JPG ----------
+
+    def preview_png(self,
+                    url: str,
+                    footprint: QgsGeometry,
+                    image_id: str = ""):
+        # previewUrl is always a self-authenticating (pre-signed) URL — for every provider,
+        # including My Imagery — so we send a dummy Authorization header and never leak the
+        # Mapflow credentials to the (often third-party) preview host.
+        self.http.get(url=url,
+                      timeout=30,
+                      auth='null'.encode(),
+                      callback=self.display_png_preview_gcp,
+                      use_default_error_handler=False,
+                      error_handler=self.preview_png_error_handler,
+                      error_handler_kwargs={"image_id": image_id},
+                      callback_kwargs={"footprint": footprint,
+                                       "image_id": image_id})
+
+    def display_png_preview(self,
+                            response: QNetworkReply,
+                            extent: QgsRectangle,
+                            crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:3857"),
+                            image_id: str = ""):
+        """
+        We assume that png preview is not internally georeferenced,
+        but the footprint specified in the metadata has the same extent, so we generate georef
+        for the image
+        """
+        with open(self.app_context.temp_dir/os.urandom(32).hex(), mode='wb') as f:
+            f.write(response.readAll().data())
+        preview = gdal.Open(f.name)
+        pixel_xsize = extent.width() / preview.RasterXSize
+        pixel_ysize = extent.height() / preview.RasterYSize
+        preview.SetProjection(crs.toWkt())
+        preview.SetGeoTransform([
+            extent.xMinimum(),  # north-west corner x
+            pixel_xsize,  # pixel horizontal resolution (m)
+            0,  # x-axis rotation
+            extent.yMaximum(),  # north-west corner y
+            0,  # y-axis rotation
+            -pixel_ysize  # pixel vertical resolution (m)
+        ])
+        preview.FlushCache()
+        layer = QgsRasterLayer(f.name, f"{image_id} preview", 'gdal')
+        layer.setExtent(extent)
+        self.app_context.project.addMapLayer(layer)
+
+    def display_png_preview_gcp(self,
+                                response: QNetworkReply,
+                                footprint: QgsGeometry,
+                                crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:3857"),
+                                image_id: str = ""):
+        """
+        Display image preview using Ground Control Points from footprint corners.
+        Delegates to ResultsLoader.display_preview_with_gcp().
+        """
+        layer = self.result_loader.display_preview_with_gcp(
+            response=response,
+            footprint=footprint,
+            crs=crs,
+            image_name=image_id,
+            # Don't clone the AOI over the preview inside a template: the AOI is already drawn
+            # as its own layer there, so the "Search area" clone just duplicates it (feedback 1).
+            add_aoi=not self.processing_service.in_template_mode,
+        )
+        self._pending_preview_ids.discard(image_id)  # download finished
+        self._relocate_to_template_group(layer)
+
+    def preview_multiple_png(self,
+                             response: QNetworkReply,
+                             previews: List[Tuple[str, QgsGeometry]],
+                             footprint: QgsGeometry,
+                             image_id: str = "",
+                             georeferenced_previews_list: Optional[List[str]] = None):
+        " Add preview for multi-part images (e.g. Roscosmos). "
+        if georeferenced_previews_list is None:
+            georeferenced_previews_list = []
+        # Callback part: collect response images into a list
+        if response:
+            georeferenced_preview = self.result_loader.georeference_preview_part(
+                response=response, footprint=footprint, crs=helpers.WGS84)
+            georeferenced_previews_list.append(georeferenced_preview)
+        # Final part: merge all collected images into one VRT
+        if len(previews) == 0:
+            vrt_path = os.path.join(self.app_context.temp_dir, os.urandom(32).hex())
+            vrt = gdal.BuildVRT(vrt_path, georeferenced_previews_list)
+            vrt.FlushCache()
+            vrt = None
+            vrt_layer = QgsRasterLayer(vrt_path, f"{image_id} preview", 'gdal')
+            self._pending_preview_ids.discard(image_id)  # multi-part download finished
+            self.result_loader.add_layer(vrt_layer)
+            self._add_aoi_to_preview_if_needed()
+            self._relocate_to_template_group(vrt_layer)
+            return
+        # Request part: remove first image from the list and get its preview
+        image_to_preview = previews.pop(0)
+        self.http.get(url=image_to_preview[0],
+                      timeout=30,
+                      auth='null'.encode(),
+                      callback=self.preview_multiple_png,
+                      use_default_error_handler=False,
+                      error_handler=self.preview_png_error_handler,
+                      error_handler_kwargs={"image_id": image_id},
+                      callback_kwargs={"previews": previews,
+                                       "footprint": image_to_preview[1],
+                                       "image_id": image_id,
+                                       "georeferenced_previews_list": georeferenced_previews_list})
+
+    def preview_png_error_handler(self, response: QNetworkReply, image_id: str = ""):
+        # Clear the in-flight flag so the user can retry this image's preview after a failure.
+        self._pending_preview_ids.discard(image_id)
+        report_http_error(response,
+                          plugin_version=self.app_context.plugin_version,
+                          title=self.tr("Could not display preview"))
+
+    # ---------- mosaic tiles ----------
+
+    def preview_mosaic(self,
+                       feature: QgsFeature,
+                       url: str,
+                       preview_type: str,
+                       provider_name: str,
+                       image_date: str):
+        uri = layer_utils.generate_xyz_layer_definition(url=url, source_type=preview_type)
+        tile_layer = QgsRasterLayer(uri, provider_name, "wms")
+        tiles_to_delete = [
+            layer.id() for layer in self.app_context.project.mapLayers().values()
+            if layer.dataProvider().dataSourceUri() == tile_layer.dataProvider().dataSourceUri()]
+        self.app_context.project.removeMapLayers(tiles_to_delete)
+        self.result_loader.add_layer(layer=tile_layer, order=0)
+        self._relocate_to_template_group(tile_layer)
+        # Add footprint layer
+        if feature:
+            footprint_layer = QgsVectorLayer("Polygon?crs=EPSG:4326",
+                                             f"{provider_name}_{image_date}",
+                                             "memory")
+            footprint_layer.dataProvider().addFeatures([feature])
+            footprint_layer.updateExtents()
+            footprint_layer.loadNamedStyle(
+                os.path.join(self.plugin_dir, 'static', 'styles', 'metadata_footprint.qml'))
+            # Remove same-named boundaries AND the previously shown one (its name varies by
+            # acquisition date, so a name match alone leaves the old boundary on the map).
+            footprints_to_delete = [
+                layer.id() for layer in self.app_context.project.mapLayers().values()
+                if layer.name() == footprint_layer.name()]
+            if self._mosaic_preview_footprint_id:
+                footprints_to_delete.append(self._mosaic_preview_footprint_id)
+            self.app_context.project.removeMapLayers(footprints_to_delete)
+            self.result_loader.add_layer(layer=footprint_layer, order=0)
+            self._mosaic_preview_footprint_id = footprint_layer.id()
+            self._relocate_to_template_group(footprint_layer)
+        self._add_aoi_to_preview_if_needed()

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -35,7 +35,8 @@ class PreviewService(QObject):
                  plugin_dir: str,
                  config,
                  result_loader,
-                 processing_service):
+                 processing_service,
+                 data_catalog_service=None):
         super().__init__()
         self.iface = iface
         self.app_context = app_context
@@ -43,6 +44,10 @@ class PreviewService(QObject):
         self.plugin_dir = plugin_dir
         self.config = config
         self.result_loader = result_loader
+        #: Consulted for *which* mosaic or image is selected in My Imagery. Which one is
+        #: selected is the catalog's business; putting the resulting raster on the map is this
+        #: service's.
+        self.data_catalog_service = data_catalog_service
         #: Consulted for the in-template placement rules only. Becomes `TemplateService` when the
         #: templates step splits it out.
         self.processing_service = processing_service
@@ -397,3 +402,57 @@ class PreviewService(QObject):
             self._mosaic_preview_footprint_id = footprint_layer.id()
             self._relocate_to_template_group(footprint_layer)
         self._add_aoi_to_preview_if_needed()
+
+    # ---------- My Imagery ----------
+    #
+    # The catalog's own previews. Separate entry points from the search ones above because they
+    # start from a selected mosaic/image rather than a metadata feature — but they end the same
+    # way, as a raster on the map, which is why they live here and the panel *thumbnail*
+    # (`DataCatalogService.get_image_preview_s`) does not.
+
+    def preview_my_imagery_mosaic(self):
+        """Add the selected mosaic's tile layer, then fit it to the extent from its tile JSON."""
+        try:
+            mosaic = self.data_catalog_service.selected_mosaic()
+            url = mosaic.rasterLayer.tileUrl
+            url_json = mosaic.rasterLayer.tileJsonUrl
+            name = mosaic.name
+        except AttributeError:
+            # Nothing selected, or a mosaic with no raster layer yet.
+            alert_info(self.tr('Please, select imagery collection'))
+            return
+        layer = layer_utils.generate_raster_layer(url, name)
+        self.data_catalog_service.api.request_mosaic_extent(url_json, layer)
+
+    def preview_my_imagery_image(self):
+        """Request the full-size preview of the selected image."""
+        try:
+            image = self.data_catalog_service.selected_image()
+            footprint = QgsGeometry.fromWkt(image.footprint)  # already in WGS84
+        except AttributeError:
+            return
+        self.data_catalog_service.api.get_image_preview_l(image=image,
+                                                          footprint=footprint,
+                                                          callback=self.display_my_imagery_image,
+                                                          image_name=image.filename)
+
+    def display_my_imagery_image(self,
+                                 response: QNetworkReply,
+                                 footprint: QgsGeometry,
+                                 crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:4326"),
+                                 image_name: str = ""):
+        """Display image preview using GCP-based georeferencing.
+
+        Uses ResultsLoader.display_preview_with_gcp() which handles rotated/skewed footprints
+        correctly. QGIS will reproject on-the-fly to match the project CRS.
+        """
+        layer = self.result_loader.display_preview_with_gcp(
+            response=response,
+            footprint=footprint,
+            crs=crs,
+            image_name=image_name,
+            add_aoi=False
+        )
+        if layer:
+            self.iface.setActiveLayer(layer)
+            self.iface.zoomToActiveLayer()

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -6,8 +6,8 @@ from base64 import b64decode
 from configparser import ConfigParser  # parse metadata.txt -> QGIS version check (compatibility)
 from datetime import datetime, timedelta  # processing creation datetime formatting
 from pathlib import Path
-from typing import List, Optional, Callable, Tuple
-from osgeo import gdal, ogr
+from typing import List, Optional, Callable
+from osgeo import ogr
 
 from PyQt5.QtCore import (
     QCoreApplication, QDate, QDateTime, QObject, Qt,
@@ -20,15 +20,14 @@ from PyQt5.QtWidgets import (
     QMenu, QMessageBox, QPushButton, QWidget, QToolButton
 )
 from qgis.core import (
-    QgsCoordinateReferenceSystem, QgsDistanceArea, QgsFeature, QgsGeometry,
-    QgsLayerTreeGroup, QgsLayerTreeLayer, QgsMapLayer, QgsMapLayerType,
-    QgsProject, QgsRasterLayer, QgsRectangle, QgsVectorLayer
+    QgsDistanceArea, QgsFeature, QgsGeometry,
+    QgsLayerTreeGroup, QgsMapLayer, QgsMapLayerType,
+    QgsProject, QgsVectorLayer
 )
 
-from .config import OSM, Config, ConfigColumns
+from .config import Config, ConfigColumns
 from .errors import (BadProcessingInput,
                      ErrorMessage,
-                     ImageIdRequired,
                      PluginError,
                      ProcessingInputDataMissing,
                      ProxyIsAlreadySet)
@@ -41,6 +40,7 @@ from .functional.controller.data_catalog_controller import DataCatalogController
 from .functional.controller.project_processing_controller import ProjectProcessingController
 from .functional.controller.processing_controller import ProcessingController
 from .functional.service.aoi_service import AoiService
+from .functional.service.preview_service import PreviewService
 from .functional.view.aoi_view import AoiView
 from .functional.service import (DataCatalogService,
                                  ProcessingService,
@@ -60,9 +60,7 @@ from .schema import (BillingType,
                      MyImageryParams,
                      ProviderReturnSchema,
                      UserDefinedParams)
-from .schema.catalog import (MultiPreviewList,
-                             PreviewType,
-                             ProductType)
+from .schema.catalog import ProductType
 from .schema.project import MapflowProject, UserRole
 from .schema.template import (CreateProcessingTemplateSchema,
                               DeleteAoisSchema,
@@ -294,6 +292,13 @@ class Mapflow(QObject):
                                       result_loader=self.result_loader,
                                       data_catalog_service=self.data_catalog_service,
                                       processing_service=self.processing_service)
+        self.preview_service = PreviewService(iface=self.iface,
+                                              app_context=self.app_context,
+                                              http=self.http,
+                                              plugin_dir=self.plugin_dir,
+                                              config=self.config,
+                                              result_loader=self.result_loader,
+                                              processing_service=self.processing_service)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
@@ -967,41 +972,6 @@ class Mapflow(QObject):
         return any(layer.customProperty('mapflow/no_aoi_processing_id') == str(pid)
                    for layer in self.app_context.project.mapLayers().values())
 
-    def _add_aoi_to_preview_if_needed(self) -> None:
-        """Overlay the search AOI on a preview — but not inside a template, where the AOI is
-        already drawn as its own layer, so the clone would just duplicate it (feedback 1)."""
-        if self.processing_service.in_template_mode:
-            return
-        self.result_loader.add_aoi_to_preview()
-
-    def _relocate_preview_to_template_group(self, layer) -> None:
-        """In the in-template view, move a freshly added preview layer into the template's
-        map group, above the search-results footprints and below the AOI subgroups, so the
-        precedence is AOIs (top) > previews > search results (bottom)."""
-        service = self.processing_service
-        if not layer or not service.in_template_mode or not service.active_template:
-            return
-        try:
-            template_group = self._find_template_group(str(service.active_template.name))
-            root = self.app_context.project.layerTreeRoot()
-            node = root.findLayer(layer.id())
-            if node is None or template_group is None:
-                return
-            footprints_layer = getattr(self.app_context, 'metadata_layer', None)
-            footprints_id = footprints_layer.id() if footprints_layer else None
-            children = template_group.children()
-            # Default to the bottom; otherwise insert directly above the footprints layer
-            # (which itself sits below the AOI/processing subgroups).
-            insert_index = len(children)
-            for i, child in enumerate(children):
-                if isinstance(child, QgsLayerTreeLayer) and child.layerId() == footprints_id:
-                    insert_index = i
-                    break
-            template_group.insertChildNode(insert_index, node.clone())
-            (node.parent() or root).removeChildNode(node)
-        except (AttributeError, RuntimeError):
-            return
-
     def _add_geojson_aoi_layer(self,
                                features: list,
                                layer_name: str,
@@ -1074,13 +1044,9 @@ class Mapflow(QObject):
         materialises a group as a side effect cannot be called on a path like that without a
         lambda to defer it.
         """
-        root = self.app_context.project.layerTreeRoot()
         mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
-        parent_group = root.findGroup(mapflow_group_name) or root
-        template_group = parent_group.findGroup(template_group_name)
-        if template_group is None or not subgroup_name:
-            return template_group
-        return template_group.findGroup(subgroup_name)
+        return layer_utils.find_template_group(self.app_context.project, mapflow_group_name,
+                                               template_group_name, subgroup_name)
 
     def _ensure_template_group(self,
                                template_group_name: str,
@@ -2742,293 +2708,6 @@ class Mapflow(QObject):
             self.dlg.searchProvidersCombo.addItemWithCheckState(pr.name, Qt.Unchecked, pr.api_name)
         self.dlg.searchProvidersCombo.setDefaultText(self.tr("Show all"))
 
-    def _move_layer_to_top(self, layer_id: str) -> bool:
-        """Move an existing layer's tree node to the top of its parent group."""
-        root = self.app_context.project.layerTreeRoot()
-        node = root.findLayer(layer_id)
-        if not node:
-            return False
-        parent = node.parent() or root
-        parent.insertChildNode(0, node.clone())
-        parent.removeChildNode(node)
-        return True
-
-    def preview_catalog(self, image_id):
-        feature = self.metadata_feature(image_id)
-        if not feature:
-            self.alert(self.tr("Preview is unavailable when metadata layer is removed"))
-            return
-        # If this image's preview is already on the map (layers are named "<image_id> preview"),
-        # just bring it to the top instead of downloading and adding a duplicate.
-        existing_preview = self.app_context.project.mapLayersByName(f"{image_id} preview")
-        if existing_preview:
-            self._move_layer_to_top(existing_preview[0].id())
-            self.iface.setActiveLayer(existing_preview[0])
-            self.iface.mapCanvas().refresh()
-            return
-        # A preview for this image is already being downloaded (async): a rapid second click /
-        # double-click must not start another download. The preview layer is only added in the
-        # HTTP callback, so the on-map guard above cannot catch these — hence this in-flight set.
-        if image_id in self._pending_preview_ids:
-            return
-        footprint = self.metadata_footprint(feature=feature)
-        url = feature.attribute('previewUrl')
-        preview_type = feature.attribute('previewType')
-        self.iface.mapCanvas().zoomToSelected(self.app_context.metadata_layer)
-        self.iface.mapCanvas().refresh()
-        # Get multi-image preview (e.g. Roscosmos)
-        try:
-            previews_list = MultiPreviewList.from_dict_or_string(feature['previews'])
-        except KeyError: # duplicated processings don't have this field
-            previews_list = MultiPreviewList([])
-        if len(previews_list.previews) != 0:
-            previews = []
-            for p in previews_list.previews:
-                # Create QgsGeometry from GeoJSON through ogr and wkt
-                ogr_geom = ogr.CreateGeometryFromJson(str(p.geometry))
-                wkt_geom = ogr_geom.ExportToWkt()
-                geom = QgsGeometry.fromWkt(wkt_geom)
-                previews.append((p.url, geom))
-            self._pending_preview_ids.add(image_id)  # in-flight until the VRT is added / errors
-            self.preview_multiple_png(response=None,
-                                      previews=previews,
-                                      footprint=previews[0][1],
-                                      image_id=image_id,
-                                      georeferenced_previews_list=[])
-            return
-        # Get single image preview. Read each attribute independently: a My Imagery result may
-        # lack whole metadata columns — an all-null acquisitionDate is dropped by the OGR GeoJSON
-        # reader, so feature.attribute('acquisitionDate') raises KeyError. A single missing field
-        # must not blank out the others (a shared try/except previously reset preview_type to '',
-        # so even mosaics with a valid xyz preview reported "no preview"). Duplicated processings
-        # likewise lack these fields, and get '' the same way.
-        url = self._feature_attribute(feature, 'previewUrl') or ''
-        preview_type = self._feature_attribute(feature, 'previewType') or ''
-        provider_name = self._feature_attribute(feature, 'providerName') or ''
-        raw_date = self._feature_attribute(feature, 'acquisitionDate')
-        image_date = raw_date.toString("dd.MM.yyyy") if raw_date else ''
-        if not preview_type:
-            self.alert(self.tr("Selected imagery has no preview"))
-            return
-        # Display image preview
-        if preview_type in (PreviewType.png, PreviewType.jpg):
-            if not url:
-                self.alert(self.tr("Preview with such URL is unavailable"))
-                return
-            self._pending_preview_ids.add(image_id)  # in-flight until the preview is added / errors
-            self.preview_png(url, footprint, image_id)
-        # Display mosaic preview
-        elif preview_type in (PreviewType.xyz, PreviewType.tms, PreviewType.wms):
-            self.preview_mosaic(feature, url, preview_type, provider_name, image_date)
-        else:
-            self.alert(self.tr("Preview for '{iid}' is unavailable").format(iid=image_id))
-            return
-
-    def preview_png(self,
-                    url: str,
-                    footprint: QgsGeometry,
-                    image_id: str = ""):
-        # previewUrl is always a self-authenticating (pre-signed) URL — for every provider,
-        # including My Imagery — so we send a dummy Authorization header and never leak the
-        # Mapflow credentials to the (often third-party) preview host.
-        self.http.get(url=url,
-                      timeout=30,
-                      auth='null'.encode(),
-                      callback=self.display_png_preview_gcp,
-                      use_default_error_handler=False,
-                      error_handler=self.preview_png_error_handler,
-                      error_handler_kwargs={"image_id": image_id},
-                      callback_kwargs={"footprint": footprint,
-                                       "image_id": image_id})
-
-    def display_png_preview(self,
-                            response: QNetworkReply,
-                            extent: QgsRectangle,
-                            crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:3857"),
-                            image_id: str = ""):
-        """
-        We assume that png preview is not internally georeferenced,
-        but the footprint specified in the metadata has the same extent, so we generate georef for the image
-        """
-        with open(self.app_context.temp_dir/os.urandom(32).hex(), mode='wb') as f:
-            f.write(response.readAll().data())
-        preview = gdal.Open(f.name)
-        pixel_xsize = extent.width() / preview.RasterXSize
-        pixel_ysize = extent.height() / preview.RasterYSize
-        preview.SetProjection(crs.toWkt())
-        preview.SetGeoTransform([
-            extent.xMinimum(),  # north-west corner x
-            pixel_xsize,  # pixel horizontal resolution (m)
-            0,  # x-axis rotation
-            extent.yMaximum(),  # north-west corner y
-            0,  # y-axis rotation
-            -pixel_ysize  # pixel vertical resolution (m)
-        ])
-        preview.FlushCache()
-        layer = QgsRasterLayer(f.name, f"{image_id} preview", 'gdal')
-        layer.setExtent(extent)
-        self.app_context.project.addMapLayer(layer)
-
-    def display_png_preview_gcp(self,
-                                response: QNetworkReply,
-                                footprint: QgsGeometry,
-                                crs: QgsCoordinateReferenceSystem = QgsCoordinateReferenceSystem("EPSG:3857"),
-                                image_id: str = ""):
-        """
-        Display image preview using Ground Control Points from footprint corners.
-        Delegates to ResultsLoader.display_preview_with_gcp().
-        """
-        layer = self.result_loader.display_preview_with_gcp(
-            response=response,
-            footprint=footprint,
-            crs=crs,
-            image_name=image_id,
-            # Don't clone the AOI over the preview inside a template: the AOI is already drawn
-            # as its own layer there, so the "Search area" clone just duplicates it (feedback 1).
-            add_aoi=not self.processing_service.in_template_mode,
-        )
-        self._pending_preview_ids.discard(image_id)  # download finished
-        self._relocate_preview_to_template_group(layer)
-
-    def preview_multiple_png(self,
-                             response: QNetworkReply,
-                             previews: List[Tuple[str, QgsGeometry]],
-                             footprint: QgsGeometry,
-                             image_id: str = "",
-                             georeferenced_previews_list: List[str] = []):
-        " Add preview for multi-part images (e.g. Roscosmos). "
-        # Callback part: collect response images into a list
-        if response:
-            georeferenced_preview = self.result_loader.georeference_preview_part(response=response,
-                                                                                 footprint=footprint,
-                                                                                 crs=helpers.WGS84)
-            georeferenced_previews_list.append(georeferenced_preview)
-        # Final part: merge all coolected images into one VRT
-        if len(previews) == 0:
-            vrt_path = os.path.join(self.app_context.temp_dir, os.urandom(32).hex())
-            vrt = gdal.BuildVRT(vrt_path, georeferenced_previews_list)
-            vrt.FlushCache()
-            vrt = None
-            vrt_layer = QgsRasterLayer(vrt_path, "{image_id} preview".format(image_id=image_id), 'gdal')
-            self._pending_preview_ids.discard(image_id)  # multi-part download finished
-            self.result_loader.add_layer(vrt_layer)
-            self._add_aoi_to_preview_if_needed()
-            self._relocate_preview_to_template_group(vrt_layer)
-            return
-        # Requset part: remove first image from the list and get its preview
-        image_to_preview = previews.pop(0)
-        self.http.get(url=image_to_preview[0],
-                      timeout=30,
-                      auth='null'.encode(),
-                      callback=self.preview_multiple_png,
-                      use_default_error_handler=False,
-                      error_handler=self.preview_png_error_handler,
-                      error_handler_kwargs={"image_id": image_id},
-                      callback_kwargs={"previews": previews,
-                                       "footprint": image_to_preview[1],
-                                       "image_id": image_id,
-                                       "georeferenced_previews_list":georeferenced_previews_list})
-
-    def preview_png_error_handler(self, response: QNetworkReply, image_id: str = ""):
-        # Clear the in-flight flag so the user can retry this image's preview after a failure.
-        self._pending_preview_ids.discard(image_id)
-        self.report_http_error(response, self.tr("Could not display preview"))
-    
-    def preview_mosaic(self,
-                       feature: QgsFeature,
-                       url: str,
-                       preview_type: str,
-                       provider_name: str,
-                       image_date: str):
-        uri = layer_utils.generate_xyz_layer_definition(url=url, source_type=preview_type)
-        tile_layer = QgsRasterLayer(uri, provider_name, "wms")
-        tiles_to_delete = [layer.id() for layer in self.app_context.project.mapLayers().values()
-                            if layer.dataProvider().dataSourceUri() == tile_layer.dataProvider().dataSourceUri()]
-        self.app_context.project.removeMapLayers(tiles_to_delete)
-        self.result_loader.add_layer(layer=tile_layer, order=0)
-        self._relocate_preview_to_template_group(tile_layer)
-        # Add footprint layer
-        if feature:
-            footprint_layer = QgsVectorLayer("Polygon?crs=EPSG:4326",
-                                                f"{provider_name}_{image_date}",
-                                                "memory")
-            footprint_layer.dataProvider().addFeatures([feature])
-            footprint_layer.updateExtents()
-            footprint_layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata_footprint.qml'))
-            # Remove same-named boundaries AND the previously shown one (its name varies by
-            # acquisition date, so a name match alone leaves the old boundary on the map).
-            footprints_to_delete = [layer.id() for layer in self.app_context.project.mapLayers().values()
-                                    if layer.name() == footprint_layer.name()]
-            if self._mosaic_preview_footprint_id:
-                footprints_to_delete.append(self._mosaic_preview_footprint_id)
-            self.app_context.project.removeMapLayers(footprints_to_delete)
-            self.result_loader.add_layer(layer=footprint_layer, order=0)
-            self._mosaic_preview_footprint_id = footprint_layer.id()
-            self._relocate_preview_to_template_group(footprint_layer)
-        self._add_aoi_to_preview_if_needed()
-
-    def metadata_footprint(self,
-                           image_id=None,
-                           feature=None,
-                           crs: QgsCoordinateReferenceSystem = helpers.WEB_MERCATOR):
-        if not feature:
-            feature = self.metadata_feature(image_id)
-        if not feature:
-            return None
-        return helpers.from_wgs84(feature.geometry(), crs)
-
-    @staticmethod
-    def _feature_attribute(feature, name):
-        """``feature.attribute(name)``, or ``None`` when that field does not exist on the layer.
-
-        The OGR GeoJSON reader omits a property that is null in every feature, so My Imagery
-        results (all-null ``acquisitionDate`` etc.) lack those columns and a plain
-        ``feature.attribute(name)`` would raise ``KeyError``. A NULL value on an existing field
-        already comes back as Python ``None``."""
-        try:
-            return feature.attribute(name)
-        except KeyError:
-            return None
-
-    def metadata_feature(self, image_id):
-        if not image_id:
-            return None
-        try:  # Get the image extent to set the correct extent on the raster layer
-            return next(self.app_context.metadata_layer.getFeatures(f"id = '{image_id}'"))
-        except (RuntimeError, AttributeError, StopIteration):  # layer doesn't exist or has been deleted, or empty
-            return None
-
-    def preview_xyz(self, provider, image_id):
-        max_zoom = self.config.MAX_ZOOM
-        layer_name = provider.name
-        try:
-            url = provider.preview_url(image_id=image_id)
-            preview_max_zoom = provider.preview_max_zoom
-        except ImageIdRequired:
-            self.alert(self.tr("Provider {name} requires image id for preview!").format(name=provider.name),
-                       QMessageBox.Warning)
-            return
-        except NotImplementedError:            
-            self.alert(self.tr("Preview is unavailable for the provider {}. \nOSM layer will be added instead.").format(provider.name), QMessageBox.Information)
-            # Add OSM instaed of preview, if it is unavailable (for Mapbox)
-            layer = QgsRasterLayer(OSM, 'OpenStreetMap', 'wms')
-            self.result_loader.add_preview_layer(preview_layer=layer)
-            return
-        except Exception as e:
-            self.alert(str(e), QMessageBox.Warning)
-            return         
-        uri = layer_utils.generate_xyz_layer_definition(url,
-                                                        provider.source_type,
-                                                        preview_max_zoom or max_zoom,
-                                                        provider.credentials.login,
-                                                        provider.credentials.password)
-        layer = QgsRasterLayer(uri, layer_name, 'wms')
-        layer.setCrs(QgsCoordinateReferenceSystem(provider.crs))
-        if layer.isValid():
-            self.result_loader.add_preview_layer(preview_layer=layer)
-        else:
-            self.alert(self.tr("We couldn't load a preview for this image"))
-
     def preview(self) -> None:
         """Display raster tiles served over the Web."""
         selected_cells = self.dlg.metadataTable.selectedItems()
@@ -3042,9 +2721,9 @@ class Mapflow(QObject):
             self.alert(self.tr("This provider requires image ID!"), QMessageBox.Warning)
             return
         if isinstance(provider, ImagerySearchProvider):
-            self.preview_catalog(image_id=image_id)
+            self.preview_service.preview_catalog(image_id=image_id)
         else:  # XYZ providers
-            self.preview_xyz(provider=provider, image_id=image_id)
+            self.preview_service.preview_xyz(provider=provider, image_id=image_id)
     
     def on_metadata_table_cell_clicked(self, row: int, column: int):
         """Keep click behavior passive; marking seen is handled by Seen actions only."""
@@ -3202,7 +2881,7 @@ class Mapflow(QObject):
         if column == self.config.PPRVIEW_INDEX_COLUMN:
             id_column_index = self.config.SEARCH_ID_COLUMN_INDEX
             image_id = self.dlg.metadataTable.item(row, id_column_index).text()
-            self.preview_catalog(image_id)
+            self.preview_service.preview_catalog(image_id)
 
     def preview_or_search(self, provider) -> None:
         provider_index = self.dlg.providerIndex()

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -106,9 +106,6 @@ class Mapflow(QObject):
     _search_sort_order = "DESC"
     # Cached widen-warning messages backing the (!) indicator's click handler.
     _widen_details = None
-    # Id of the currently shown mosaic-preview boundary layer, so it can be removed when the
-    # next preview is shown (its name varies by acquisition date, so name-match alone misses it).
-    _mosaic_preview_footprint_id = None
 
     def __init__(self, iface) -> None:
         """Initialize the plugin.
@@ -233,7 +230,9 @@ class Mapflow(QObject):
                                                     self.result_loader,
                                                     self.app_context.plugin_version,
                                                     app_context=self.app_context)
-        self.data_catalog_controller = DataCatalogController(self.dlg, self.data_catalog_service)
+        # DataCatalogController is built after PreviewService (below): its two preview buttons
+        # wire to that service, which in turn needs processing_service for the in-template
+        # placement rules.
 
         # ========== 7. INITIALIZE PROJECT AND PROCESSING SERVICES ==========
         self.project_service = ProjectService(http=self.http,
@@ -298,7 +297,11 @@ class Mapflow(QObject):
                                               plugin_dir=self.plugin_dir,
                                               config=self.config,
                                               result_loader=self.result_loader,
-                                              processing_service=self.processing_service)
+                                              processing_service=self.processing_service,
+                                              data_catalog_service=self.data_catalog_service)
+        self.data_catalog_controller = DataCatalogController(self.dlg,
+                                                             self.data_catalog_service,
+                                                             self.preview_service)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -787,7 +787,7 @@ class Mapflow(QObject):
         # the AOI-area monitor (which reacts to layersAdded) recognizes and skips it.
         self.app_context.metadata_layer = layer
         if template_group_name:
-            target_group = self._template_group_target(template_group_name)
+            target_group = self._ensure_template_group(template_group_name)
             self.app_context.project.addMapLayer(layer, addToLegend=False)
             # Append (bottom) so the search-results footprints sit below the AOI/processing
             # subgroups rather than on top of them.
@@ -904,7 +904,7 @@ class Mapflow(QObject):
         single-clicks its row (see on_no_aoi_processing_clicked) — no bulk requests on open."""
         if not template or not self.processing_service.no_aoi_processing_ids():
             return
-        self._template_group_target(str(template.name), self._no_aoi_subgroup_name())
+        self._ensure_template_group(str(template.name), self._no_aoi_subgroup_name())
 
     def on_no_aoi_processing_clicked(self, *args) -> None:
         """Single-click on a 'No AOI' processing row: fetch that processing's AOI and add it to the
@@ -982,7 +982,7 @@ class Mapflow(QObject):
         if not layer or not service.in_template_mode or not service.active_template:
             return
         try:
-            template_group = self._template_group_target(str(service.active_template.name))
+            template_group = self._find_template_group(str(service.active_template.name))
             root = self.app_context.project.layerTreeRoot()
             node = root.findLayer(layer.id())
             if node is None or template_group is None:
@@ -1043,7 +1043,7 @@ class Mapflow(QObject):
 
         root = self.app_context.project.layerTreeRoot()
         if template_group_name:
-            target_group = self._template_group_target(template_group_name, subgroup_name)
+            target_group = self._ensure_template_group(template_group_name, subgroup_name)
             self.app_context.project.addMapLayer(aoi_layer, addToLegend=False)
             target_group.insertLayer(0, aoi_layer)
         elif reference_layer_id:
@@ -1064,11 +1064,32 @@ class Mapflow(QObject):
         self.aoi_service.register_layer(aoi_layer, recompute_cost=False, set_current=False)
         return aoi_layer
 
-    def _template_group_target(self,
+    def _find_template_group(self,
+                             template_group_name: str,
+                             subgroup_name: Optional[str] = None):
+        """The ``Mapflow > <template name> [> <subgroup>]`` layer-tree group, or None.
+
+        Creates nothing. Callers that only need to *place* a layer next to the template's other
+        layers use this: they run on selection changes and preview clicks, and a lookup that
+        materialises a group as a side effect cannot be called on a path like that without a
+        lambda to defer it.
+        """
+        root = self.app_context.project.layerTreeRoot()
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        parent_group = root.findGroup(mapflow_group_name) or root
+        template_group = parent_group.findGroup(template_group_name)
+        if template_group is None or not subgroup_name:
+            return template_group
+        return template_group.findGroup(subgroup_name)
+
+    def _ensure_template_group(self,
                                template_group_name: str,
                                subgroup_name: Optional[str] = None):
-        """Find or create the ``Mapflow > <template name> [> <subgroup>]`` layer-tree group
-        and return the node new layers should be inserted into.
+        """Find or create that group, and return the node new layers should be inserted into.
+
+        For the callers that are *adding* the template's layers, and so legitimately bring the
+        group into being. Everything that merely places an already-built layer wants
+        ``_find_template_group`` instead.
 
         The Mapflow group is created here when missing so the template group is nested under it
         from the very first (template-open) call. Previously the open path fell back to the root
@@ -1191,10 +1212,7 @@ class Mapflow(QObject):
         template = self.processing_service.active_template
         self.aoi_service.select_aois_as_processing_area(
             self.processing_service.selected_aois(),
-            # Lazy: resolving the group creates it when missing, and this runs on every
-            # selection change. Only a multi-AOI selection actually needs it.
-            group_factory=(lambda: self._template_group_target(str(template.name))
-                           if template else None))
+            self._find_template_group(str(template.name)) if template else None)
 
     def select_processing_in_table(self, processing_id: str):
         """Select processing row by ID and open processing details."""

--- a/tests/qgis/test_my_imagery_preview.py
+++ b/tests/qgis/test_my_imagery_preview.py
@@ -1,0 +1,130 @@
+"""QGIS-tier tests for the My Imagery previews that put a raster on the map.
+
+These moved from `DataCatalogService` to `PreviewService` with the preview extraction, and the
+move found them untested: nothing failed when they changed owner, which is exactly the state
+`spec/007_architecture.md` forbids leaving a behaviour in. Written here because the boundary
+they sit on is the one worth pinning — *which* mosaic or image is selected is the catalog's
+business, putting the resulting raster on the map is this service's.
+
+The panel thumbnail (`DataCatalogService.get_image_preview_s`) deliberately stayed behind: it
+paints a QImage into a widget and never touches the map.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from qgis.core import QgsGeometry
+
+from mapflow.functional.service.preview_service import PreviewService
+
+
+@pytest.fixture
+def catalog():
+    catalog = MagicMock()
+    catalog.selected_mosaic.return_value = None
+    catalog.selected_image.return_value = None
+    return catalog
+
+
+@pytest.fixture
+def service(catalog):
+    return PreviewService(iface=MagicMock(),
+                          app_context=SimpleNamespace(project=MagicMock()),
+                          http=MagicMock(),
+                          plugin_dir="",
+                          config=MagicMock(),
+                          result_loader=MagicMock(),
+                          processing_service=SimpleNamespace(in_template_mode=False,
+                                                             active_template=None),
+                          data_catalog_service=catalog)
+
+
+@pytest.fixture
+def alerts(monkeypatch):
+    shown = []
+    monkeypatch.setattr("mapflow.functional.service.preview_service.alert_info",
+                        lambda message, *a, **kw: shown.append(message))
+    return shown
+
+
+# ---------- mosaics ----------
+
+def test_previewing_a_mosaic_requests_the_extent_for_its_tile_layer(service, catalog):
+    catalog.selected_mosaic.return_value = SimpleNamespace(
+        name="My collection",
+        rasterLayer=SimpleNamespace(tileUrl="https://host/tiles/{z}/{x}/{y}.png",
+                                    tileJsonUrl="https://host/tiles/tile.json"))
+
+    service.preview_my_imagery_mosaic()
+
+    args = catalog.api.request_mosaic_extent.call_args.args
+    # The tile JSON URL is what carries the bounds; the layer is built from the tile URL.
+    assert args[0] == "https://host/tiles/tile.json"
+    assert args[1].name() == "My collection"
+
+
+def test_previewing_no_mosaic_says_so_and_requests_nothing(service, catalog, alerts):
+    catalog.selected_mosaic.return_value = None
+
+    service.preview_my_imagery_mosaic()
+
+    catalog.api.request_mosaic_extent.assert_not_called()
+    assert len(alerts) == 1
+
+
+def test_a_mosaic_without_a_raster_layer_is_not_a_crash(service, catalog, alerts):
+    """A collection that has no imagery yet has no rasterLayer, so reading tileUrl raises."""
+    catalog.selected_mosaic.return_value = SimpleNamespace(name="Empty", rasterLayer=None)
+
+    service.preview_my_imagery_mosaic()
+
+    catalog.api.request_mosaic_extent.assert_not_called()
+    assert len(alerts) == 1
+
+
+# ---------- images ----------
+
+def test_previewing_an_image_sends_its_footprint(service, catalog):
+    catalog.selected_image.return_value = SimpleNamespace(
+        footprint="POLYGON((0 0,0 1,1 1,1 0,0 0))", filename="scene.tif")
+
+    service.preview_my_imagery_image()
+
+    kwargs = catalog.api.get_image_preview_l.call_args.kwargs
+    assert kwargs["image_name"] == "scene.tif"
+    assert kwargs["footprint"].asWkt().startswith("Polygon")
+    # The reply is georeferenced by this service, not by the catalog.
+    assert kwargs["callback"] == service.display_my_imagery_image
+
+
+def test_previewing_no_image_requests_nothing(service, catalog):
+    catalog.selected_image.return_value = None
+
+    service.preview_my_imagery_image()
+
+    catalog.api.get_image_preview_l.assert_not_called()
+
+
+def test_displaying_an_image_preview_activates_and_zooms_to_it(service):
+    layer = MagicMock()
+    service.result_loader.display_preview_with_gcp.return_value = layer
+
+    service.display_my_imagery_image(response=MagicMock(),
+                                     footprint=QgsGeometry.fromWkt("POLYGON((0 0,0 1,1 1,1 0,0 0))"),
+                                     image_name="scene.tif")
+
+    service.iface.setActiveLayer.assert_called_once_with(layer)
+    service.iface.zoomToActiveLayer.assert_called_once()
+
+
+def test_a_preview_that_failed_to_georeference_is_not_zoomed_to(service):
+    """display_preview_with_gcp returns None when it cannot build the layer; zooming to that
+    would raise inside a QGIS call rather than simply doing nothing."""
+    service.result_loader.display_preview_with_gcp.return_value = None
+
+    service.display_my_imagery_image(response=MagicMock(),
+                                     footprint=QgsGeometry.fromWkt("POLYGON((0 0,0 1,1 1,1 0,0 0))"),
+                                     image_name="scene.tif")
+
+    service.iface.setActiveLayer.assert_not_called()
+    service.iface.zoomToActiveLayer.assert_not_called()

--- a/tests/qgis/test_no_aoi_processings.py
+++ b/tests/qgis/test_no_aoi_processings.py
@@ -108,13 +108,13 @@ def test_processings_loaded_creates_no_aoi_group_only_when_unbound_exist():
     plugin = Mapflow.__new__(Mapflow)
     plugin.tr = lambda text: text
     plugin.processing_service = MagicMock()
-    plugin._template_group_target = MagicMock()
+    plugin._ensure_template_group = MagicMock()
 
     plugin.processing_service.no_aoi_processing_ids.return_value = {"p2"}
     plugin.on_template_processings_loaded(SimpleNamespace(name="T"))
-    plugin._template_group_target.assert_called_once_with("T", "No AOI")
+    plugin._ensure_template_group.assert_called_once_with("T", "No AOI")
 
-    plugin._template_group_target.reset_mock()
+    plugin._ensure_template_group.reset_mock()
     plugin.processing_service.no_aoi_processing_ids.return_value = set()
     plugin.on_template_processings_loaded(SimpleNamespace(name="T"))
-    plugin._template_group_target.assert_not_called()
+    plugin._ensure_template_group.assert_not_called()

--- a/tests/qgis/test_preview_dedup.py
+++ b/tests/qgis/test_preview_dedup.py
@@ -4,52 +4,61 @@ A preview layer is added only in the async HTTP callback, so a rapid second clic
 on the Preview cell used to start several downloads (the on-map dedupe guard saw nothing yet) and
 add several duplicate preview layers. An in-flight guard (``_pending_preview_ids``) prevents a
 second download for an image whose preview is already being fetched; it is cleared on success and
-on error so the image can be previewed again afterwards."""
+on error so the image can be previewed again afterwards.
+
+Owned by `PreviewService` since the preview extraction. The error path reports through the
+message tier (`report_http_error`), which the service calls directly — `AlertService` owns the
+report tier of `spec/006_error_reporting.md`, so a service does not need a dialog to reach it.
+"""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.mapflow import Mapflow
+import pytest
+
+from mapflow.functional.service.preview_service import PreviewService
 
 
-def _plugin():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.app_context = SimpleNamespace(project=MagicMock())
-    plugin.app_context.project.mapLayersByName.return_value = []  # nothing on the map yet
-    plugin.metadata_feature = MagicMock(return_value=MagicMock())  # feature exists
-    plugin.preview_png = MagicMock()
-    plugin._pending_preview_ids = set()
-    return plugin
+@pytest.fixture
+def service():
+    app_context = SimpleNamespace(project=MagicMock(), plugin_version="1.2.3")
+    app_context.project.mapLayersByName.return_value = []  # nothing on the map yet
+    service = PreviewService(iface=MagicMock(),
+                             app_context=app_context,
+                             http=MagicMock(),
+                             plugin_dir="",
+                             config=MagicMock(),
+                             result_loader=MagicMock(),
+                             processing_service=SimpleNamespace(in_template_mode=False,
+                                                                active_template=None))
+    service.metadata_feature = MagicMock(return_value=MagicMock())  # feature exists
+    service.preview_png = MagicMock()
+    return service
 
 
-def test_preview_catalog_skips_when_download_in_flight():
-    plugin = _plugin()
-    plugin._pending_preview_ids = {"IMG-1"}  # a download for this image is already running
+def test_preview_catalog_skips_when_download_in_flight(service):
+    service._pending_preview_ids = {"IMG-1"}  # a download for this image is already running
 
-    plugin.preview_catalog("IMG-1")
+    service.preview_catalog("IMG-1")
 
-    plugin.preview_png.assert_not_called()  # no second download started
-
-
-def test_display_png_preview_gcp_clears_in_flight_flag():
-    plugin = _plugin()
-    plugin._pending_preview_ids = {"IMG-1"}
-    plugin.result_loader = MagicMock()
-    plugin.result_loader.display_preview_with_gcp.return_value = None
-    plugin.processing_service = SimpleNamespace(in_template_mode=False)
-    plugin._relocate_preview_to_template_group = MagicMock()
-
-    plugin.display_png_preview_gcp(response=MagicMock(), footprint=MagicMock(), image_id="IMG-1")
-
-    assert "IMG-1" not in plugin._pending_preview_ids  # cleared -> image can be previewed again
+    service.preview_png.assert_not_called()  # no second download started
 
 
-def test_error_handler_clears_in_flight_flag():
-    plugin = _plugin()
-    plugin._pending_preview_ids = {"IMG-1"}
-    plugin.report_http_error = MagicMock()
+def test_display_png_preview_gcp_clears_in_flight_flag(service):
+    service._pending_preview_ids = {"IMG-1"}
+    service.result_loader.display_preview_with_gcp.return_value = None
 
-    plugin.preview_png_error_handler(MagicMock(), image_id="IMG-1")
+    service.display_png_preview_gcp(response=MagicMock(), footprint=MagicMock(),
+                                    image_id="IMG-1")
 
-    assert "IMG-1" not in plugin._pending_preview_ids
-    plugin.report_http_error.assert_called_once()
+    assert "IMG-1" not in service._pending_preview_ids  # cleared -> previewable again
+
+
+def test_error_handler_clears_in_flight_flag(service, monkeypatch):
+    reported = MagicMock()
+    monkeypatch.setattr("mapflow.functional.service.preview_service.report_http_error", reported)
+    service._pending_preview_ids = {"IMG-1"}
+
+    service.preview_png_error_handler(MagicMock(), image_id="IMG-1")
+
+    assert "IMG-1" not in service._pending_preview_ids
+    reported.assert_called_once()

--- a/tests/qgis/test_preview_null_metadata.py
+++ b/tests/qgis/test_preview_null_metadata.py
@@ -3,13 +3,18 @@
 A NULL ``acquisitionDate`` attribute comes back as Python ``None``, so the historic
 ``feature.attribute('acquisitionDate').toString(...)`` raised ``AttributeError`` — which the
 surrounding ``except KeyError`` (there for duplicated processings) did not catch.
+
+Owned by `PreviewService` since the preview extraction. `alert` is patched rather than mocked
+on the object: the service reaches the message tier through a module-level function, the way
+every other service does.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 from qgis.core import QgsVectorLayer, QgsFeature
 
-from mapflow.mapflow import Mapflow
+from mapflow.functional.service.preview_service import PreviewService
 
 
 def _null_date_feature():
@@ -27,20 +32,12 @@ def _null_date_feature():
 
 
 def test_preview_catalog_handles_null_acquisition_date():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.iface = MagicMock()
-    plugin.metadata_feature = MagicMock(return_value=_null_date_feature())
-    plugin.metadata_footprint = MagicMock(return_value=MagicMock())
-    plugin.preview_png = MagicMock()
-    plugin._pending_preview_ids = set()
-    plugin.app_context = SimpleNamespace(project=MagicMock(), metadata_layer=MagicMock())
-    plugin.app_context.project.mapLayersByName.return_value = []
+    service = _preview_service(_null_date_feature())
 
-    plugin.preview_catalog("img-1")  # must not raise
+    service.preview_catalog("img-1")  # must not raise
 
     # The PNG branch is reached (no exception aborted it before dispatch).
-    plugin.preview_png.assert_called_once()
+    service.preview_png.assert_called_once()
 
 
 def _feature_without_acquisition_date_field(preview_type, preview_url, provider_name):
@@ -60,44 +57,56 @@ def _feature_without_acquisition_date_field(preview_type, preview_url, provider_
     return next(layer.getFeatures())
 
 
-def _preview_plugin(feature):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.iface = MagicMock()
-    plugin.alert = MagicMock()
-    plugin.metadata_feature = MagicMock(return_value=feature)
-    plugin.metadata_footprint = MagicMock(return_value=MagicMock())
-    plugin.preview_png = MagicMock()
-    plugin.preview_mosaic = MagicMock()
-    plugin._pending_preview_ids = set()
-    plugin.app_context = SimpleNamespace(project=MagicMock(), metadata_layer=MagicMock())
-    plugin.app_context.project.mapLayersByName.return_value = []
-    return plugin
+def _preview_service(feature):
+    app_context = SimpleNamespace(project=MagicMock(), metadata_layer=MagicMock())
+    app_context.project.mapLayersByName.return_value = []
+    service = PreviewService(iface=MagicMock(),
+                             app_context=app_context,
+                             http=MagicMock(),
+                             plugin_dir="",
+                             config=MagicMock(),
+                             result_loader=MagicMock(),
+                             processing_service=SimpleNamespace(in_template_mode=False,
+                                                                active_template=None))
+    service.metadata_feature = MagicMock(return_value=feature)
+    service.metadata_footprint = MagicMock(return_value=MagicMock())
+    service.preview_png = MagicMock()
+    service.preview_mosaic = MagicMock()
+    return service
 
 
-def test_mosaic_previews_when_acquisition_date_field_is_absent():
+@pytest.fixture
+def alerts(monkeypatch):
+    """What the service told the user. Empty is the assertion in both tests below."""
+    shown = []
+    monkeypatch.setattr("mapflow.functional.service.preview_service.alert",
+                        lambda *args, **kwargs: shown.append(args[0] if args else ""))
+    return shown
+
+
+def test_mosaic_previews_when_acquisition_date_field_is_absent(alerts):
     # The reported bug: a mosaic (valid xyz preview) reported "Selected imagery has no preview"
     # because a KeyError on the missing acquisitionDate column blanked out preview_type.
     feature = _feature_without_acquisition_date_field(
         "xyz", "https://host/api/v0/cogs/tiles/{z}/{x}/{y}.png?uri=s3://bucket/cog",
         "my_imagery_mosaics")
-    plugin = _preview_plugin(feature)
+    service = _preview_service(feature)
 
-    plugin.preview_catalog("mosaic-1")
+    service.preview_catalog("mosaic-1")
 
-    plugin.preview_mosaic.assert_called_once()
-    plugin.preview_png.assert_not_called()
-    plugin.alert.assert_not_called()  # no "Selected imagery has no preview"
+    service.preview_mosaic.assert_called_once()
+    service.preview_png.assert_not_called()
+    assert alerts == []  # no "Selected imagery has no preview"
 
 
-def test_image_dispatches_to_png_when_acquisition_date_field_is_absent():
+def test_image_dispatches_to_png_when_acquisition_date_field_is_absent(alerts):
     # An image reaches the PNG branch too (its own failure, if any, is the broken URL download —
     # not the false "no preview").
     feature = _feature_without_acquisition_date_field(
         "png", "https://host/rest/rasters/image/x/preview/l", "my_imagery_images")
-    plugin = _preview_plugin(feature)
+    service = _preview_service(feature)
 
-    plugin.preview_catalog("img-1")
+    service.preview_catalog("img-1")
 
-    plugin.preview_png.assert_called_once()
-    plugin.alert.assert_not_called()
+    service.preview_png.assert_called_once()
+    assert alerts == []

--- a/tests/qgis/test_template_group_and_preview.py
+++ b/tests/qgis/test_template_group_and_preview.py
@@ -28,7 +28,7 @@ def test_template_group_created_under_mapflow_group_when_absent():
     root = project.layerTreeRoot()
     plugin = _plugin_for_group(project)
 
-    group = plugin._template_group_target("T1")
+    group = plugin._ensure_template_group("T1")
 
     mapflow_group = root.findGroup("Mapflow")
     assert mapflow_group is not None
@@ -42,8 +42,8 @@ def test_open_then_preview_reuse_the_same_single_group():
     root = project.layerTreeRoot()
     plugin = _plugin_for_group(project)
 
-    open_group = plugin._template_group_target("T1", subgroup_name="AOI: North")
-    preview_group = plugin._template_group_target("T1")  # later preview call
+    open_group = plugin._ensure_template_group("T1", subgroup_name="AOI: North")
+    preview_group = plugin._ensure_template_group("T1")  # later preview call
 
     mapflow_group = root.findGroup("Mapflow")
     # Exactly one "T1" group exists, under the Mapflow group.
@@ -58,10 +58,36 @@ def test_template_group_falls_back_to_root_when_user_deleted_mapflow_group():
     root = project.layerTreeRoot()
     plugin = _plugin_for_group(project, add_layers_to_group=False)
 
-    group = plugin._template_group_target("T1")
+    group = plugin._ensure_template_group("T1")
 
     assert root.findGroup("Mapflow") is None
     assert root.findGroup("T1") is group
+
+
+def test_finding_a_template_group_creates_nothing():
+    """The whole point of the find/ensure split. `_find_template_group` is called from paths
+    that fire on every AOI selection and every preview click; if it created the group as a
+    side effect, opening a template and clicking around would conjure groups the user never
+    asked for — which is why those callers previously had to defer it behind a lambda."""
+    project = QgsProject()
+    root = project.layerTreeRoot()
+    plugin = _plugin_for_group(project)
+
+    assert plugin._find_template_group("T1") is None
+    assert plugin._find_template_group("T1", subgroup_name="AOI: North") is None
+
+    assert root.findGroup("Mapflow") is None
+    assert not any(child.name() == "T1" for child in root.children())
+
+
+def test_finding_a_template_group_returns_the_one_ensure_made():
+    project = QgsProject()
+    plugin = _plugin_for_group(project)
+
+    created = plugin._ensure_template_group("T1", subgroup_name="AOI: North")
+
+    assert plugin._find_template_group("T1") is created.parent()
+    assert plugin._find_template_group("T1", subgroup_name="AOI: North") is created
 
 
 def _plugin_for_preview(in_template_mode):

--- a/tests/qgis/test_template_group_and_preview.py
+++ b/tests/qgis/test_template_group_and_preview.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 from qgis.core import QgsProject
 
+from mapflow.functional.service.preview_service import PreviewService
 from mapflow.mapflow import Mapflow
 
 
@@ -119,17 +120,31 @@ def test_reconnect_cell_preview_first_time_no_disconnect_error():
     plugin.dlg.metadataTable.cellClicked.connect.assert_called_once()
 
 
+def _preview_service(in_template_mode):
+    """T1 moved to `PreviewService` with the rest of the preview code; the reconnect above is
+    still `mapflow.py`, because it manages a search-table signal."""
+    return PreviewService(
+        iface=MagicMock(),
+        app_context=SimpleNamespace(project=MagicMock()),
+        http=MagicMock(),
+        plugin_dir="",
+        config=MagicMock(),
+        result_loader=MagicMock(),
+        processing_service=SimpleNamespace(in_template_mode=in_template_mode,
+                                           active_template=None))
+
+
 def test_add_aoi_to_preview_skipped_in_template_mode():
-    plugin = _plugin_for_preview(in_template_mode=True)
+    service = _preview_service(in_template_mode=True)
 
-    plugin._add_aoi_to_preview_if_needed()
+    service._add_aoi_to_preview_if_needed()
 
-    plugin.result_loader.add_aoi_to_preview.assert_not_called()
+    service.result_loader.add_aoi_to_preview.assert_not_called()
 
 
 def test_add_aoi_to_preview_runs_outside_template_mode():
-    plugin = _plugin_for_preview(in_template_mode=False)
+    service = _preview_service(in_template_mode=False)
 
-    plugin._add_aoi_to_preview_if_needed()
+    service._add_aoi_to_preview_if_needed()
 
-    plugin.result_loader.add_aoi_to_preview.assert_called_once()
+    service.result_loader.add_aoi_to_preview.assert_called_once()

--- a/tests/qgis/test_template_preview_layers.py
+++ b/tests/qgis/test_template_preview_layers.py
@@ -1,11 +1,15 @@
 """QGIS-tier tests for preview-layer handling: de-duplicating by moving to top, and the
-in-template precedence (AOIs > previews > search-results footprints)."""
+in-template precedence (AOIs > previews > search-results footprints).
+
+Owned by `PreviewService` since the preview extraction. The group lookup it uses is
+`layer_utils.find_template_group`, which creates nothing — so relocating a preview can never
+conjure the template group it was looking for."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from qgis.core import QgsProject, QgsVectorLayer
 
-from mapflow.mapflow import Mapflow
+from mapflow.functional.service.preview_service import PreviewService
 
 
 def _mem_layer(name):
@@ -18,16 +22,27 @@ def _add(project, group, layer):
     return layer
 
 
+def _service(app_context, processing_service=None):
+    return PreviewService(
+        iface=MagicMock(),
+        app_context=app_context,
+        http=MagicMock(),
+        plugin_dir="",
+        config=MagicMock(),
+        result_loader=MagicMock(),
+        processing_service=processing_service or SimpleNamespace(in_template_mode=False,
+                                                                 active_template=None))
+
+
 def test_move_layer_to_top_brings_node_first():
     project = QgsProject()
     root = project.layerTreeRoot()
     _add(project, root, _mem_layer("first"))
     second = _add(project, root, _mem_layer("second"))
 
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(project=project)
+    service = _service(SimpleNamespace(project=project))
 
-    plugin._move_layer_to_top(second.id())
+    service._move_layer_to_top(second.id())
 
     assert root.children()[0].layerId() == second.id()
 
@@ -43,17 +58,15 @@ def test_relocate_preview_places_it_above_footprints_inside_template_group():
     # A preview added to the root (as the regular preview flow does).
     preview = _add(project, root, _mem_layer("img-1 preview"))
 
-    plugin = Mapflow.__new__(Mapflow)
     settings = MagicMock()
     settings.value.return_value = "Mapflow"
-    plugin.app_context = SimpleNamespace(
-        project=project, settings=settings, plugin_name="Mapflow", metadata_layer=footprints,
-    )
-    plugin.processing_service = SimpleNamespace(
-        in_template_mode=True, active_template=SimpleNamespace(name="T1"),
-    )
+    service = _service(
+        SimpleNamespace(project=project, settings=settings, plugin_name="Mapflow",
+                        metadata_layer=footprints),
+        processing_service=SimpleNamespace(in_template_mode=True,
+                                           active_template=SimpleNamespace(name="T1")))
 
-    plugin._relocate_preview_to_template_group(preview)
+    service._relocate_to_template_group(preview)
 
     names = [c.name() for c in template_group.children()]
     # Order within the template group: AOI subgroup, preview, footprints.
@@ -67,10 +80,8 @@ def test_relocate_preview_noop_outside_template_mode():
     root = project.layerTreeRoot()
     preview = _add(project, root, _mem_layer("img-1 preview"))
 
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(project=project)
-    plugin.processing_service = SimpleNamespace(in_template_mode=False, active_template=None)
+    service = _service(SimpleNamespace(project=project))
 
-    plugin._relocate_preview_to_template_group(preview)
+    service._relocate_to_template_group(preview)
 
     assert root.children()[-1].layerId() == preview.id()

--- a/tests/qgis/test_template_processing_area.py
+++ b/tests/qgis/test_template_processing_area.py
@@ -106,14 +106,14 @@ def test_missing_aoi_layer_leaves_the_area_untouched(service, area_layers):
     assert service._processing_area_filter is None
 
 
-def test_the_group_is_only_resolved_for_a_multi_selection(service):
-    """Resolving the template group *creates* it when missing, and this runs on every selection
-    change — so a single-AOI selection must not touch it."""
-    group_factory = MagicMock(return_value=None)
+def test_a_single_selection_does_not_touch_the_template_group(service, area_layers):
+    """A single AOI uses its own layer, so nothing is built and nothing is placed. The group is
+    resolved by the caller now (`Mapflow._find_template_group`, which creates nothing), so this
+    no longer needs to assert on how it was passed — only that no layer is built for it."""
+    service.select_aois_as_processing_area([_aoi("a1", _square(0, 0))], group=None)
 
-    service.select_aois_as_processing_area([_aoi("a1", _square(0, 0))], group_factory)
-
-    group_factory.assert_not_called()
+    service.rebuild_selected_aois_layer.assert_not_called()
+    assert area_layers == [service.find_layer_for_aoi.return_value]
 
 
 def test_removing_the_selected_aois_layer_drops_it_from_the_project_and_the_registry(service):


### PR DESCRIPTION
- **docs: retire the merged AOI step and pull the group-target split forward**
- **refactor: split the template group lookup into find and ensure**
- **refactor: move the search previews into a PreviewService**
- **refactor: move the My Imagery map previews to PreviewService**
