### PR TITLE
docs: plan one suppression policy for every error dialog

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -117,20 +117,59 @@ Against `spec/003_local_storage.md`; drop what is no longer read.
 
 ### Phase F — after the structure is settled
 
-[ ] Wrap user interactions in error_guard
+### Error reporting — one suppression policy for every dialog
+
+Planned in full and approved; **sequenced after Phase C by decision, and not to be re-raised
+unless a discovery changes that order.** Steps 1–3 are independent of the extractions and fix a
+live violation of `spec/006_error_reporting.md`; step 4 genuinely needs Phase C finished.
+
+The state that motivates it, as measured on `dev`:
+
+* two report paths do the same job with different plumbing — `report_unexpected_error`
+  (exception → `get_exception_report_body`) and `report_http_error` (response →
+  `get_error_report_body`) — and both build `ErrorMessageWidget` themselves, with different
+  wording conventions;
+* **only the exception path is throttled.** The response path can stack dialogs without bound,
+  which is exactly what the volume-limit contract forbids and why the opt-outs below exist;
+* **six request sites opt out of error handling and supply no handler**, so their server errors
+  reach nobody: `mapflow.py:475,2617,3732`, `functional/api/processing_api.py:86`,
+  `functional/api/data_catalog_api.py:97,257`. (A previous version of this entry said three; it
+  missed both data_catalog ones. A further 26 sites opt out but pass their own handler, which is
+  correct and out of scope.)
+
+[ ] 1. Signature and throttle for the HTTP path
+`response_signature(response)` = Qt error code + endpoint path; `http._request_path` already
+computes that path, query-free, because it lands in a mail body. Carry `suppressed_count` into
+the dialog text and report body the way the exception path does.
+
+[ ] 2. One reporter, in `infra/`
+Both entry points behind one module owning the throttle, the dialog and the suppressed-count
+wording. This **moves `report_http_error` out of `AlertService`**, where the preview step put it:
+a service may import `infra/`, so it never needed to be in the message tier. `AlertService` keeps
+the message tier, which is what `spec/007_architecture.md` assigns it.
+
+[ ] 3. Restore the six silent request paths
+With the throttle covering them, opting out has no remaining justification — `spec/006` already
+says so. Each site takes the default handler back, or states in a comment why not.
+
+[ ] 4. Apply `guard_entry_point` at the entry points
 `guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher` is
 guarded. Everything entering plugin code from Qt without passing through `Http` still escapes to
 QGIS's raw unhandled-exception dialog: button clicks, selection changes, timer ticks,
-drag-and-drop, dialog accept/reject.
-Cheap once Phase C lands — a controller slot is the definition of an entry point
-(`spec/007_architecture.md` § Entry points), so the sites are enumerable instead of guessed.
+drag-and-drop, dialog accept/reject. 203 `.connect()` sites today, 109 still in `mapflow.py` —
+which is why this waits for Phase C, where a controller slot becomes the definition of an entry
+point (`spec/007_architecture.md` § Entry points).
+The decorator is the cheap half. The expensive half is `spec/006` § "A guarded callback is
+interrupted, not completed": every slot needs checking for cleanup placed after code that can
+raise. That is the bug that polled `/user/status` twice a second for a whole session.
 
-[ ] Restore user-facing errors on the polled paths
-Three call sites opt out of the default error handler purely to avoid stacked modals:
-`mapflow.py` `refresh_status`, `mapflow.py:3042`, and `processing_api.py` `get_processings`. A real
-server error on those paths is invisible to the user. The throttle removes the reason for the
-workaround, but `report_http_error` needs its own signature (Qt error code + endpoint path) first,
-so both dialog paths land on one suppression policy.
+[ ] 5. Throttle the message tier too
+Decided with the above: the contract says *no failure* may produce unbounded dialogs, and
+`alert()` is `exec()`-modal like the report dialog. It is reachable from polled paths (the
+template callbacks hang off the 6 s processing poll), so the same storm is possible there.
+Throttle parameters move into `config.py` so they can be tuned during live UX testing without a
+code change — the current values (60 s window, ×2 backoff, 30 min cap, 10 s global floor) were
+reasoned from poll intervals, not measured against users.
 
 [ ] A refused price is undone by the next UI refresh
 When `/processing/cost/v2` refuses, `ProcessingService.disable_processing_start` correctly

--- a/spec/006_error_reporting.md
+++ b/spec/006_error_reporting.md
@@ -39,10 +39,30 @@ The log tier is unconditional and is never thinned by suppression. It is where a
 reconstructs how often something fired and in what order, which is exactly the information
 the other two tiers discard.
 
+### Where each tier lives
+
+The **message** tier is `AlertService`, a service: `alert_*`, `ask_text` and anything else that
+needs a synchronous answer from the user. It owns the Qt types so its callers do not import
+them — a service asking the user a question is not a reason to hand control to something that
+can see a dialog.
+
+The **report** tier lives in `infra/`, not in a service. Two reasons, and the second is the
+binding one:
+
+- it is reached from `Http`, which is itself infra and must not depend on a service singleton;
+- every layer may import `infra/`, so putting it there makes it reachable from services, api
+  modules and controllers alike, whereas a service-tier reporter is reachable only downward.
+
+A service that needs to report an unexpected failure imports the reporter from `infra/`. It does
+not emit a signal for someone else to report on its behalf, and it does not construct
+`ErrorMessageWidget`.
+
 ### Volume limit
 
 **Contract: no failure, however often it recurs, may produce an unbounded number of
-dialogs.**
+dialogs.** This covers *every* dialog tier — report and message alike. Both use `exec()`, so
+both stack; a modal that says "Could not refresh" on a 6-second poll locks QGIS just as
+effectively as an unthrottled crash report.
 
 This is not a nicety. Plugin modals are opened with `exec()`, which runs a nested event
 loop, so `QTimer` keeps firing while a dialog is up and dialogs *stack* rather than queue.
@@ -53,10 +73,13 @@ introduced to replace.
 
 `mapflow/report_throttle.py` implements the limit:
 
-- Failures are identified by **signature** — exception type plus the source line it was
-  raised from. Not the message (messages carry ids and would make every occurrence look
+- Failures are identified by **signature**. For an exception: its type plus the source line it
+  was raised from. Not the message (messages carry ids and would make every occurrence look
   new) and not the operation context (one broken line reached from two call paths is one
-  bug).
+  bug). For an HTTP failure, where there is no raising frame to key on: the **Qt error code
+  plus the endpoint path**, query string excluded — the same string the report body carries,
+  for the same reason, since a query carries ids and tokens that would make every occurrence
+  distinct.
 - A signature that has just been reported is suppressed for a **window**, starting at 60s —
   above the slowest poll interval — and **doubling on each further report**, capped at
   30 minutes. A persistent failure therefore still resurfaces a couple of times an hour
@@ -67,6 +90,11 @@ introduced to replace.
 - Suppressed occurrences are counted, and the count is carried into both the dialog text
   and the report body. A traceback that fired 200 times describes a different bug from one
   that fired once, and the single traceback cannot show the difference.
+
+The four numbers above are **configuration, in `config.py`, not constants in
+`report_throttle.py`.** They were derived from poll intervals rather than from watching anyone
+use the plugin, so they are a first guess that live UX testing is expected to move. Reasoning
+about them stays here; the values do not.
 
 ### A guarded callback is interrupted, not completed
 


### PR DESCRIPTION
Records an approved plan, sequenced after Phase C by decision. Not to be re-raised unless a
discovery changes that order.

The measurements behind it: two report paths do the same job with different plumbing, both
building ErrorMessageWidget themselves, and only the exception one is throttled. The response
path can stack dialogs without bound — which is precisely what the volume-limit contract
forbids, and precisely why six request sites opt out of error handling entirely and let server
errors reach nobody. The workaround and the violation are the same fact seen from two ends.

A previous version of that entry said three sites. It is six; it had missed both data_catalog
ones. Counted with an AST check rather than by reading, because 26 further sites also pass
use_default_error_handler=False and are correct — they supply their own handler.

Two durable decisions go to spec/006 rather than staying in the WAL entry.

The report tier belongs in infra/, not in a service. It is reached from Http, which is infra and
must not depend on a service singleton; and every layer may import infra/, so a reporter there is
reachable from services, api modules and controllers alike, where a service-tier one is reachable
only downward. This is a correction: the preview step put report_http_error in AlertService on
the belief that a service could not otherwise reach a dialog. A service may import infra/, so it
always could.

The volume limit covers the message tier too, not only reports. alert() is exec()-modal like the
report dialog and is reachable from polled paths, so "Could not refresh" on a 6-second timer
locks QGIS just as effectively as an unthrottled crash report. The contract already said *no
failure*; it now says so where it cannot be read as reports-only.

The four throttle numbers become configuration. They were reasoned from poll intervals, not
measured against anyone using the plugin, and live UX testing is expected to move them — so the
reasoning stays in the spec and the values do not.

## Manual test
none — documentation only.
