### PR TITLE
refactor/extract search service

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -38,19 +38,32 @@ leaf-first so each extraction depends only on what already moved.
 
 Service and controller boundaries are tabulated in `spec/007_architecture.md`.
 
-[ready-for-review] Extract preview → `PreviewService`
-Boundary: preview *layers on the map*. That includes the My Imagery map-layer previews
-(`mosaic_preview`, `get_image_preview_l`) but not `get_image_preview_s`, which paints a QImage
-into a panel widget — a thumbnail, not a layer, so it stays with the catalog.
-`ResultsLoader`'s preview helpers stay in `layer_utils` and are called from the service; Phase D
-moves that module wholesale, so moving them now would churn a file that step rewrites.
-Search-tab widget reads stay in `mapflow.py` until the next step creates `view/search_view.py`.
-Also splits `_template_group_target` into a pure `find` and an explicit `ensure` — see the
-templates step, which was carrying that decision until preview became its second caller.
-[ ] Extract imagery search → `SearchService` + `SearchController` + `view/search_view.py`
+[ready-for-review] Extract imagery search → `SearchService` + `SearchController` + `view/search_view.py`
+Boundary drawn at the gate, because most search-*named* code is not imagery search:
+in scope are the request and its results (`get_metadata`, `request_mapflow_metadata` + callback
++ error handler, `display_metadata_geojson_layer`, `clear_metadata`, `_is_search_metadata_layer`),
+the footprints layer, pagination, sort, the search-provider selection, the search-tab mode
+controls, and the four preview slots the preview step deliberately left behind
+(`preview`, `preview_search_from_cell`, `preview_or_search`, `_reconnect_cell_preview`).
+Out of scope and deferred to the two steps below: the local filter, and everything that operates
+on a *template's* search.
+`_build_search_params` turns out to be called only from template creation and template update,
+never from `get_metadata` — so it is template code despite the name. That single fact is what
+keeps this step from swallowing the two after it.
+First step with a real `view/` rather than deferring widget reads, so larger than AOI or preview.
 [ ] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
+Bigger than it looks: `apply_local_filter` alone has 10 widget connections and
+`tests/qgis/test_local_filter.py` has 39 tests.
 [ ] Extract templates → `TemplateService` + `TemplateController` (largest domain, ~55 methods
     in `mapflow.py` plus the template half of `processing_service.py`)
+Takes `filter_search_by_selected_aoi` with it. The AOI step assigned that to `SearchService`;
+reading it while scoping the search step showed both its collaborators are template code — it
+reads `processing_service.selected_aois()` and calls `_load_template_search`. It filters a
+*template's* results by AOI selection, so it belongs here, not with imagery search.
+Also takes `_build_search_params`, `_load_template_search(_page)`, `show_template_search_results`,
+`create_search_template*`, `update_template_search_params`, `exclude_processing_from_search`,
+`_template_filter_baseline`, `apply_search_params_to_ui`, `_store_template_search_footprints`
+and `_prompt_plan_search`.
 Still open here: whether placing a layer in the template's group belongs to the service that
 built the layer at all. `AoiService` and `PreviewService` both reach for the template group
 today; the alternative is that they emit the layer and the template owner places it, on the

--- a/WAL.md
+++ b/WAL.md
@@ -51,6 +51,11 @@ on a *template's* search.
 never from `get_metadata` — so it is template code despite the name. That single fact is what
 keeps this step from swallowing the two after it.
 First step with a real `view/` rather than deferring widget reads, so larger than AOI or preview.
+`SearchController` starts small on purpose — the three preview-dispatch handlers and their
+wiring. A controller owns a connection only when it owns the handler, and the run/sort/pagination
+handlers still call unextracted collaborators (provider selection, template loader, local
+filter); their connections stay in `mapflow.py` and the controller grows as those handlers move,
+the same way `ProcessingController` began with AOI selection alone.
 [ ] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
 Bigger than it looks: `apply_local_filter` alone has 10 widget connections and
 `tests/qgis/test_local_filter.py` has 39 tests.

--- a/mapflow/functional/controller/search_controller.py
+++ b/mapflow/functional/controller/search_controller.py
@@ -1,0 +1,71 @@
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QMessageBox
+
+from ..service.alert_service import alert
+from ..service.preview_service import PreviewService
+from ..service.provider_service import ProviderService
+from ..service.search_service import SearchService
+from ..view.search_view import SearchView
+from ...model.provider import ImagerySearchProvider
+
+
+class SearchController(QObject):
+    """The imagery-search tab's preview dispatch: which image to preview, and from where.
+
+    Scope today is deliberately small — the three preview-dispatch handlers and their wiring.
+    A controller may own a signal connection only when it owns the *handler*; the run, sort and
+    pagination handlers still call collaborators that have not been extracted (provider
+    selection, the template search loader, the local filter), so their connections stay in
+    `mapflow.py` until those handlers can move here. This grows as they do, the same way
+    `ProcessingController` started with AOI selection alone.
+    """
+
+    def __init__(self,
+                 search_service: SearchService,
+                 search_view: SearchView,
+                 preview_service: PreviewService,
+                 provider_service: ProviderService,
+                 search_button,
+                 metadata_table):
+        super().__init__()
+        self.search_service = search_service
+        self.search_view = search_view
+        self.preview_service = preview_service
+        self.provider_service = provider_service
+
+        # Owned handlers, so the connections are owned here too.
+        search_button.clicked.connect(self.preview_or_search)
+        metadata_table.cellDoubleClicked.connect(self.preview)
+        # cellClicked -> preview is rewired on every table refill (see reconnect_cell_preview).
+        self.reconnect_cell_preview()
+
+    def preview(self, *args) -> None:
+        """Double-click / Preview: show tiles for the selected image."""
+        image_id = self.search_view.selected_image_id()
+        provider = self.provider_service.providers[self.search_view.provider_index()]
+        if provider.requires_image_id and not image_id:
+            alert(self.tr("This provider requires image ID!"), QMessageBox.Warning)
+            return
+        if isinstance(provider, ImagerySearchProvider):
+            self.preview_service.preview_catalog(image_id=image_id)
+        else:  # XYZ providers
+            self.preview_service.preview_xyz(provider=provider, image_id=image_id)
+
+    def preview_or_search(self, *args) -> None:
+        """The Search button: providers that need an image id send the user to the search tab to
+        pick one; the rest can preview straight away."""
+        provider = self.provider_service.providers[self.search_view.provider_index()]
+        if provider.requires_image_id:
+            self.search_view.switch_to_search_tab()
+        else:
+            self.preview()
+
+    def preview_search_from_cell(self, row: int, column: int) -> None:
+        """A click in the results table's Preview column previews that row's image."""
+        if self.search_view.is_preview_column(column):
+            self.preview_service.preview_catalog(self.search_view.image_id_at(row))
+
+    def reconnect_cell_preview(self) -> None:
+        """Rewire the Preview-cell click after a table refill. Public because `apply_local_filter`
+        (still in `mapflow.py`) drives it — it moves here with the local filter."""
+        self.search_view.connect_cell_preview(self.preview_search_from_cell)

--- a/mapflow/functional/service/search_service.py
+++ b/mapflow/functional/service/search_service.py
@@ -1,0 +1,283 @@
+import json
+import logging
+import os
+from typing import List, Optional
+
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
+from qgis.core import QgsGeometry, QgsVectorLayer
+
+from ..app_context import AppContext
+from .alert_service import alert, alert_info
+from ...http import api_message_parser
+from ...model.provider import ImagerySearchProvider, ProviderInterface
+from ...schema import ImageCatalogRequestSchema, ImageCatalogResponseSchema
+from ...schema.catalog import ProductType
+from .alert_service import report_http_error
+
+logger = logging.getLogger(__name__)
+
+
+class SearchService(QObject):
+    """The imagery-search request, its results, and the footprints layer they are drawn on.
+
+    Holds no widget (`spec/007_architecture.md` § Layer rules). Anything the UI must do in
+    response leaves as a signal and `SearchController` drives the view.
+
+    Two things are deliberately *not* here:
+
+    * choosing between a regular search and a template's search. Both paging and header-sort
+      pick one or the other from `in_template_mode`, which is coordination between two regions
+      — the controller's job, not this service's.
+    * the filter widget reads. They arrive as arguments, gathered by `SearchView` in one call at
+      the moment Search is pressed.
+    """
+
+    #: A page of results arrived: the GeoJSON to render, ready for the table.
+    resultsReceived = pyqtSignal(object)
+    #: The footprints layer was (re)built. The controller wires its selection to the table.
+    metadataLayerReady = pyqtSignal(object)
+    #: Pagination for the page just received: 1-based page number and total pages.
+    pagerChanged = pyqtSignal(int, int)
+    #: There is only one page; the pager should go away.
+    pagerHidden = pyqtSignal()
+
+    def __init__(self,
+                 iface,
+                 app_context: AppContext,
+                 http,
+                 plugin_dir: str,
+                 config,
+                 config_search_columns,
+                 result_loader,
+                 provider_service):
+        super().__init__()
+        self.iface = iface
+        self.app_context = app_context
+        self.http = http
+        self.plugin_dir = plugin_dir
+        self.config = config
+        self.config_search_columns = config_search_columns
+        self.result_loader = result_loader
+        self.provider_service = provider_service
+        self.page_offset = 0
+        self.page_limit = config.SEARCH_RESULTS_PAGE_LIMIT
+        #: Server-side sort. Held here rather than in the view because a template's search sends
+        #: the same two parameters to a different endpoint.
+        self.sort_by = "ACQUISITION_DATE"
+        self.sort_order = "DESC"
+
+    # ---------- the provider that can search ----------
+
+    @property
+    def imagery_search_provider(self):
+        for provider in self.provider_service.providers:
+            if isinstance(provider, ImagerySearchProvider):
+                return provider
+        return None
+
+    def is_search_metadata_layer(self, layer) -> bool:
+        """True if `layer` is the current imagery-search footprints layer.
+
+        Metadata-layer creators assign ``app_context.metadata_layer`` before adding the
+        layer to the project, so this is reliable at ``layersAdded`` time.
+        """
+        metadata_layer = self.app_context.metadata_layer
+        if metadata_layer is None:
+            return False
+        try:
+            return layer.id() == metadata_layer.id()
+        except RuntimeError:  # metadata layer was deleted
+            return False
+
+    # ---------- the request ----------
+
+    def search(self,
+               aoi: QgsGeometry,
+               provider: ProviderInterface,
+               aoi_layer,
+               baseline_filters: dict,
+               from_: Optional[str] = None,
+               to: Optional[str] = None,
+               min_resolution: Optional[float] = None,
+               max_resolution: Optional[float] = None,
+               max_cloud_cover: Optional[float] = None,
+               min_off_nadir_angle: Optional[float] = None,
+               max_off_nadir_angle: Optional[float] = None,
+               min_intersection: Optional[float] = None,
+               offset: Optional[int] = 0,
+               hide_unavailable: Optional[bool] = False,
+               product_types: Optional[List[ProductType]] = None,
+               search_providers: Optional[List[str]] = None) -> None:
+        """Ask the Mapflow catalog for imagery over ``aoi``. Filtering is server-side.
+
+        ``aoi_layer`` is where the footprints layer will be placed relative to, resolved now
+        rather than in the callback: the request is the moment the user expressed the intent, and
+        the combo may have moved on by the time the response lands.
+        """
+        self.app_context.metadata_aoi = aoi
+        # Remember what this search actually asks the server for, so the widen (!) indicator can
+        # flag later widget edits that ask for MORE than was fetched (which local filtering can't
+        # surface without a fresh Search).
+        self.app_context.search_baseline_filters = baseline_filters
+        request_payload = ImageCatalogRequestSchema(aoi=json.loads(aoi.asJson()),
+                                                    acquisitionDateFrom=from_,
+                                                    acquisitionDateTo=to,
+                                                    minResolution=min_resolution,
+                                                    maxResolution=max_resolution,
+                                                    maxCloudCover=max_cloud_cover,
+                                                    minOffNadirAngle=min_off_nadir_angle,
+                                                    maxOffNadirAngle=max_off_nadir_angle,
+                                                    minAoiIntersectionPercent=min_intersection,
+                                                    limit=self.page_limit,
+                                                    offset=offset,
+                                                    hideUnavailable=hide_unavailable,
+                                                    productTypes=product_types,
+                                                    dataProviders=search_providers,
+                                                    sortBy=self.sort_by,
+                                                    sortOrder=self.sort_order)
+        self.http.post(url=provider.meta_url,
+                       body=request_payload.as_json().encode(),
+                       headers={},
+                       callback=self.search_callback,
+                       callback_kwargs={"aoi_layer": aoi_layer},
+                       error_handler=self.search_error_handler,
+                       use_default_error_handler=False,
+                       timeout=60)
+
+    def search_error_handler(self, response: QNetworkReply):
+        title = self.tr("We couldn't get metadata from the Mapflow Imagery Catalog")
+        error = response.attribute(QNetworkRequest.HttpStatusCodeAttribute)
+        if error is not None:
+            title += self.tr(". Error {error}").format(error=error)
+        report_http_error(response,
+                          plugin_version=self.app_context.plugin_version,
+                          title=title,
+                          error_message_parser=api_message_parser)
+
+    def search_callback(self, response: QNetworkReply, aoi_layer=None):
+        response_json = json.loads(response.readAll().data())
+        if not response_json.get("images"):
+            alert_info(self.tr('No images match your criteria. Try relaxing the filters.'))
+            return
+        response_data = ImageCatalogResponseSchema(**response_json)
+        geoms = response_data.as_geojson()
+        # Add index to map table and layer
+        for position, feature in enumerate(geoms.get("features", ())):
+            feature['properties']['local_index'] = position
+
+        # Save the current search results to load later
+        provider = self.imagery_search_provider
+        save_failed_message = self.tr(
+            "<b>Results could not be loaded </b><br>Please, make sure you chose the right output "
+            "folder in the Settings tab and you have access rights to this folder")
+        try:
+            filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
+        except OSError:
+            # The case the message describes: missing/unwritable output folder.
+            alert(save_failed_message)
+            return
+        except Exception:
+            logger.exception("Unexpected error saving the search layer")
+            alert(save_failed_message)
+            return
+        self.display_metadata_geojson_layer(filename, f"{provider.name} metadata", aoi_layer)
+        # Retain the raw results so the instant local filter can reorder/re-render them without
+        # a new request.
+        self.app_context.search_result_geojson = geoms
+        self.resultsReceived.emit(geoms)
+        self.update_pager(response_data.total, response_data.limit, response_data.offset)
+
+    # ---------- the footprints layer ----------
+
+    def display_metadata_geojson_layer(self, filename, layer_name, aoi_layer=None):
+        self.remove_metadata_layer()
+        # Assigned (before add_layer) so the AOI-area monitor recognizes and skips it.
+        self.app_context.metadata_layer = QgsVectorLayer(filename, layer_name, 'ogr')
+        self.app_context.metadata_layer.loadNamedStyle(
+            os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
+        # Place search results just under the AOI layer, if that layer has a legend node.
+        # (A layer added with addToLegend=False has no tree node -> findLayer returns None;
+        # fall back to a plain add instead of dereferencing a missing parent.)
+        aoi_layer_tree = (self.app_context.project.layerTreeRoot().findLayer(aoi_layer.id())
+                          if aoi_layer else None)
+        if aoi_layer_tree is not None and aoi_layer_tree.parent() is not None:
+            index = aoi_layer_tree.parent().children().index(aoi_layer_tree)
+            self.result_loader.add_layer(layer=self.app_context.metadata_layer, order=index + 1)
+        else:
+            self.result_loader.add_layer(layer=self.app_context.metadata_layer)
+        self.app_context.search_footprints = {
+            feature['local_index']: feature
+            for feature in self.app_context.metadata_layer.getFeatures()
+        }
+        self.metadataLayerReady.emit(self.app_context.metadata_layer)
+
+    def remove_metadata_layer(self) -> None:
+        try:
+            self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
+        except (AttributeError, RuntimeError):  # metadata layer has been deleted
+            pass
+
+    def clear(self) -> None:
+        """Drop the results, the layer and the retained baseline. The widen (!) indicator is the
+        controller's to hide — this only makes it meaningless."""
+        self.remove_metadata_layer()
+        self.app_context.open_template_results_id = None
+        self.app_context.search_result_geojson = None
+        self.app_context.search_baseline_filters = None
+        if self.app_context.search_provider:
+            self.app_context.search_provider.clear_saved_search(self.app_context.temp_dir)
+
+    # ---------- pagination ----------
+
+    def update_pager(self, total: int, limit: int, offset: int) -> None:
+        """Recompute paging from a response's ``total``/``limit``/``offset``. Shared by regular
+        search and template search (T6): template results used to fill the table but never toggle
+        the pager."""
+        if limit and total > limit:
+            self.page_offset = offset
+            self.page_limit = limit
+            quotient, remainder = divmod(total, limit)
+            total_pages = quotient + (remainder > 0)
+            page_number = int(offset / limit) + 1
+            self.pagerChanged.emit(page_number, total_pages)
+        else:
+            self.pagerHidden.emit()
+
+    def next_page_offset(self) -> int:
+        return self.page_offset + self.page_limit
+
+    def previous_page_offset(self) -> int:
+        return self.page_offset - self.page_limit
+
+    # ---------- sort ----------
+
+    def sort_column_field(self, column: int) -> Optional[str]:
+        """The API sort token for a table column, or None when that column is not sortable.
+
+        Only the columns the API can sort on (``config.SEARCH_SORT_FIELDS``) react; the rest
+        (preview, product type, band order, image id) do nothing.
+        """
+        attributes = tuple(self.config_search_columns.METADATA_TABLE_ATTRIBUTES.values())
+        if not 0 <= column < len(attributes):
+            return None
+        return self.config.SEARCH_SORT_FIELDS.get(attributes[column])
+
+    def toggle_sort(self, sort_field: str) -> None:
+        """Apply ``sort_field``, flipping ASC/DESC when it is already the active one."""
+        if self.sort_by == sort_field:
+            self.sort_order = "ASC" if self.sort_order == "DESC" else "DESC"
+        else:
+            self.sort_by = sort_field
+            self.sort_order = "DESC"
+
+    def active_sort_column(self) -> Optional[int]:
+        """The table column the active sort corresponds to, for redrawing the indicator."""
+        if not self.sort_by:
+            return None
+        attribute = next((attr for attr, token in self.config.SEARCH_SORT_FIELDS.items()
+                          if token == self.sort_by), None)
+        attributes = tuple(self.config_search_columns.METADATA_TABLE_ATTRIBUTES.values())
+        if attribute in attributes:
+            return attributes.index(attribute)
+        return None

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple
 
 from PyQt5.QtCore import QObject, Qt
-from PyQt5.QtWidgets import QPushButton
+from PyQt5.QtWidgets import QPushButton, QWidget
 
 from ...dialogs.main_dialog import MainDialog
 from ...schema.catalog import ProductType
@@ -23,6 +23,8 @@ class SearchView(QObject):
         super().__init__()
         self.dlg = dlg
         self.config = config
+        #: The current cellClicked->preview connection, so it can be dropped before rewiring.
+        self._cell_preview_connection = None
 
     # ---------- what the user is asking for ----------
 
@@ -79,7 +81,43 @@ class SearchView(QObject):
     def provider_index(self) -> int:
         return self.dlg.providerIndex()
 
+    def switch_to_search_tab(self) -> None:
+        """Bring the imagery-search tab to front (its objectName is historically 'providersTab')."""
+        tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
+        if tab is not None:
+            self.dlg.tabWidget.setCurrentWidget(tab)
+
     # ---------- the results table ----------
+
+    def selected_image_id(self) -> Optional[str]:
+        """Image id of the first selected results row, or None when nothing is selected."""
+        selected = self.dlg.metadataTable.selectedItems()
+        if not selected:
+            return None
+        return self.image_id_at(selected[0].row())
+
+    def image_id_at(self, row: int) -> str:
+        return self.dlg.metadataTable.item(row, self.config.SEARCH_ID_COLUMN_INDEX).text()
+
+    def is_preview_column(self, column: int) -> bool:
+        return column == self.config.PPRVIEW_INDEX_COLUMN
+
+    def connect_cell_preview(self, handler) -> None:
+        """(Re)wire the results table's 'Preview' cell click to ``handler``.
+
+        The table is refilled on every local-filter change; connecting without disconnecting
+        first stacks the connections, so one click would fire the preview several times and add
+        several preview layers (feedback 4.2). The prior connection is dropped first.
+        """
+        self.disconnect_cell_preview()
+        self._cell_preview_connection = self.dlg.metadataTable.cellClicked.connect(handler)
+
+    def disconnect_cell_preview(self) -> None:
+        try:
+            self.dlg.metadataTable.disconnect(self._cell_preview_connection)
+        except (AttributeError, TypeError, RuntimeError):
+            # no previous connection, or its underlying C++ object is gone
+            pass
 
     def clear_table(self) -> None:
         self.dlg.metadataTable.clearContents()

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -1,0 +1,114 @@
+from typing import List, Optional, Tuple
+
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtWidgets import QPushButton
+
+from ...dialogs.main_dialog import MainDialog
+from ...schema.catalog import ProductType
+
+
+class SearchView(QObject):
+    """Every widget read and write for the imagery-search tab.
+
+    Holds no service (`spec/007_architecture.md` § Layer rules): the controller reads the
+    search parameters from here, hands them to `SearchService`, and pushes results back.
+
+    The reads are grouped as `search_parameters()` rather than exposed one property per widget,
+    because they are only ever wanted together — at the moment the user presses Search — and a
+    single call is what makes "the request is built from what the widgets said *then*" true by
+    construction instead of by convention.
+    """
+
+    def __init__(self, dlg: MainDialog, config):
+        super().__init__()
+        self.dlg = dlg
+        self.config = config
+
+    # ---------- what the user is asking for ----------
+
+    def search_parameters(self) -> dict:
+        """The filter widgets, as the keyword arguments a search request takes."""
+        min_off_nadir, max_off_nadir = self.off_nadir_bounds()
+        return {
+            "from_": self.dlg.metadataFrom.dateTime().toTimeSpec(Qt.UTC).toString(Qt.ISODate),
+            "to": self.dlg.metadataTo.dateTime().toTimeSpec(Qt.UTC).toString(Qt.ISODate),
+            "max_cloud_cover": self.dlg.maxCloudCover.value(),
+            "min_intersection": self.dlg.minIntersection.value(),
+            "hide_unavailable": self.dlg.hideUnavailableResults.isChecked(),
+            "product_types": self.product_types(),
+            "search_providers": self.search_providers(),
+            "min_off_nadir_angle": min_off_nadir,
+            "max_off_nadir_angle": max_off_nadir,
+        }
+
+    def off_nadir_bounds(self) -> Tuple[Optional[float], Optional[float]]:
+        """(min, max) off-nadir angle to send, or (None, None) at the full 0-30 range.
+
+        Leaving it out at full range is not the same as sending 0-30: the bounds exclude images
+        whose angle is unknown, so sending them would drop results the user did not filter out.
+        """
+        if self.dlg.off_nadir_is_full_range():
+            return None, None
+        return self.dlg.off_nadir_range()
+
+    def product_types(self) -> List[str]:
+        """Neither box ticked means *both*, not neither — the backend reads an empty list
+        literally."""
+        product_types = []
+        if self.dlg.searchMosaicCheckBox.isChecked():
+            product_types.append(ProductType.mosaic.upper())
+        if self.dlg.searchImageCheckBox.isChecked():
+            product_types.append(ProductType.image.upper())
+        if not product_types:
+            product_types = [ProductType.mosaic.upper(), ProductType.image.upper()]
+        return product_types
+
+    def search_providers(self) -> Optional[List[str]]:
+        """Provider filter to send with a search/template request.
+
+        Only meaningful while the search is limited to available providers; when
+        "Search only through available providers" is off, the (hidden) provider selection
+        must NOT be sent — the search runs across all providers. An empty selection is
+        also omitted (None), since the backend reads ``[]`` as "search no providers".
+        """
+        if not self.dlg.hideUnavailableResults.isChecked():
+            return None
+        selected = self.dlg.searchProvidersCombo.checkedItemsData()
+        return selected or None
+
+    def provider_index(self) -> int:
+        return self.dlg.providerIndex()
+
+    # ---------- the results table ----------
+
+    def clear_table(self) -> None:
+        self.dlg.metadataTable.clearContents()
+        self.dlg.metadataTable.setRowCount(0)
+
+    def remove_more_button(self) -> None:
+        """Drop the "load more" button left by a previous search, if any."""
+        more_button = self.dlg.findChild(QPushButton,
+                                         self.config.METADATA_MORE_BUTTON_OBJECT_NAME)
+        if more_button:
+            self.dlg.layoutMetadataTable.removeWidget(more_button)
+            more_button.deleteLater()
+
+    def fill_table(self, geoms, sort: bool = False) -> None:
+        """Built-in Qt sorting stays OFF by default: results already arrive in the server's sort
+        order, and a header click re-requests with sortBy/sortOrder rather than sorting locally."""
+        self.dlg.fill_metadata_table(geoms, sort=sort)
+
+    # ---------- pagination ----------
+
+    def show_pages(self, page_number: int, total_pages: int) -> None:
+        self.dlg.enable_search_pages(True, page_number, total_pages)
+        self.dlg.searchRightButton.setEnabled(page_number != total_pages)
+        self.dlg.searchLeftButton.setEnabled(page_number != 1)
+
+    def hide_pages(self) -> None:
+        self.dlg.enable_search_pages(False)
+
+    # ---------- the widen (!) indicator ----------
+
+    def set_widen_warning_visible(self, visible: bool) -> None:
+        self.dlg.searchWidenWarning.setVisible(visible)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -39,6 +39,7 @@ from .functional.auth import get_auth_id
 from .functional.controller.data_catalog_controller import DataCatalogController
 from .functional.controller.project_processing_controller import ProjectProcessingController
 from .functional.controller.processing_controller import ProcessingController
+from .functional.controller.search_controller import SearchController
 from .functional.service.aoi_service import AoiService
 from .functional.service.preview_service import PreviewService
 from .functional.service.search_service import SearchService
@@ -308,11 +309,19 @@ class Mapflow(QObject):
                                             config_search_columns=self.config_search_columns,
                                             result_loader=self.result_loader,
                                             provider_service=self.provider_service)
-        # Search wiring. Moves to SearchController with the rest of the search-tab connects.
+        # Search wiring. Results/pager signals stay here for now — the run and pagination
+        # handlers they end at are still mapflow.py slots (see SearchController's docstring).
         self.search_service.resultsReceived.connect(self._on_search_results)
         self.search_service.metadataLayerReady.connect(self._on_metadata_layer_ready)
         self.search_service.pagerChanged.connect(self.search_view.show_pages)
         self.search_service.pagerHidden.connect(self.search_view.hide_pages)
+        # Owns the preview-dispatch handlers (search button, cell/double click) and their wiring.
+        self.search_controller = SearchController(search_service=self.search_service,
+                                                  search_view=self.search_view,
+                                                  preview_service=self.preview_service,
+                                                  provider_service=self.provider_service,
+                                                  search_button=self.dlg.searchImageryButton,
+                                                  metadata_table=self.dlg.metadataTable)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
@@ -409,19 +418,12 @@ class Mapflow(QObject):
         self.review_dialog.accepted.connect(self.submit_review)
 
         # ========== 13. PROVIDERS ==========
-        # Search filters (intersection, cloud, dates) are applied server-side on the next
-        # Search; there is no offline re-filtering on widget change anymore.
-        self.dlg.searchImageryButton.clicked.connect(self.preview_or_search)
-
+        # searchImageryButton and the metadata table's double/cell-click previews are wired by
+        # SearchController (constructed above).
         self.dlg.addProvider.clicked.connect(self.add_provider)
         self.dlg.editProvider.clicked.connect(self.edit_provider)
         self.dlg.removeProvider.clicked.connect(self.remove_provider)
 
-        # Image ids whose preview is currently being downloaded (async). Guards against the
-        # dedupe-on-map check missing duplicates, since the preview layer is only added in the
-        # HTTP callback — a second click/double-click fired several downloads before the first
-        # landed, producing duplicate preview layers.
-        self._pending_preview_ids = set()
         # Processing ids whose 'No AOI' AOI request is in flight (guards rapid re-clicks).
         self._pending_no_aoi_ids = set()
         self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
@@ -429,7 +431,6 @@ class Mapflow(QObject):
         self.dlg.metadataTable.itemSelectionChanged.connect(self.update_start_processing_button_state)
         self.app_context.meta_layer_table_connection = None
         self.dlg.getMetadata.clicked.connect(self.handle_metadata_button_click)
-        self.dlg.metadataTable.cellDoubleClicked.connect(self.preview)
         self.dlg.metadataTable.cellClicked.connect(self.on_metadata_table_cell_clicked)
         self.dlg.metadataTable.horizontalHeader().sectionClicked.connect(self.on_metadata_header_clicked)
         self.dlg.rasterSourceChanged.connect(self.on_provider_change)
@@ -1268,7 +1269,7 @@ class Mapflow(QObject):
             return
         geoms = self.app_context.search_result_geojson
         if not geoms or not geoms.get("features"):
-            self._reconnect_cell_preview()
+            self.search_controller.reconnect_cell_preview()
             self._update_widen_indicator()
             return
         features = geoms["features"]
@@ -1307,7 +1308,7 @@ class Mapflow(QObject):
             self._apply_new_image_markers()
         self._mark_unfit_rows(unfit)
         self._hide_unfit_footprints(getattr(self.app_context, "metadata_layer", None), unfit)
-        self._reconnect_cell_preview()
+        self.search_controller.reconnect_cell_preview()
         self._update_widen_indicator()
         # The fill above hid the sort arrow (setSortingEnabled(False)); put it back so it persists.
         self._restore_search_sort_indicator()
@@ -1619,19 +1620,6 @@ class Mapflow(QObject):
         # Re-filter once against the restored widgets (some setters above may not have changed a
         # value, so their change-signal would not have fired the filter).
         self.apply_local_filter()
-
-    def _reconnect_cell_preview(self):
-        """Rewire the search table's 'Preview' cell click to a single handler.
-        ``apply_local_filter`` runs on every table refill; connecting without disconnecting
-        first stacks the connections, so one click fires the preview several times and adds
-        several preview layers at once (feedback 4.2). Disconnect the previous connection first."""
-        try:
-            self.dlg.metadataTable.disconnect(self.cell_preview_connection)
-        except (AttributeError, TypeError, RuntimeError):
-            # no previous connection, or its underlying C++ object is gone
-            pass
-        self.cell_preview_connection = self.dlg.metadataTable.cellClicked.connect(
-            self.preview_search_from_cell)
 
     def set_up_login_dialog(self) -> MapflowLoginDialog:
         """Create a login dialog, set its title and signal-slot connections."""
@@ -2267,10 +2255,9 @@ class Mapflow(QObject):
 
     def get_metadata(self, _: Optional[bool] = False, offset: Optional[int] = 0) -> None:
         """Metadata is image footprints with attributes like acquisition date or cloud cover."""
-        try: # disconnect to prevent adding mutliple previews if table was refilled (multiple searches)
-            self.dlg.metadataTable.disconnect(self.cell_preview_connection)
-        except AttributeError: # if no previous connection (first search after start)
-            pass
+        # Drop the previous Preview-cell connection so a refill does not stack it (multiple
+        # searches would otherwise fire the preview several times per click).
+        self.search_view.disconnect_cell_preview()
         # If current provider does not support search, we should select ImagerySearchProvider to be able to search
         self.replace_search_provider_index()
         # A regular search replaces any template results, so a "Start" is no longer planned.
@@ -2547,23 +2534,6 @@ class Mapflow(QObject):
             self.dlg.searchProvidersCombo.addItemWithCheckState(pr.name, Qt.Unchecked, pr.api_name)
         self.dlg.searchProvidersCombo.setDefaultText(self.tr("Show all"))
 
-    def preview(self) -> None:
-        """Display raster tiles served over the Web."""
-        selected_cells = self.dlg.metadataTable.selectedItems()
-        if not selected_cells:
-            image_id = None
-        else:
-            id_column_index = self.config.SEARCH_ID_COLUMN_INDEX
-            image_id = self.dlg.metadataTable.item(selected_cells[0].row(), id_column_index).text()
-        provider = self.provider_service.providers[self.dlg.providerIndex()]
-        if provider.requires_image_id and not image_id:
-            self.alert(self.tr("This provider requires image ID!"), QMessageBox.Warning)
-            return
-        if isinstance(provider, ImagerySearchProvider):
-            self.preview_service.preview_catalog(image_id=image_id)
-        else:  # XYZ providers
-            self.preview_service.preview_xyz(provider=provider, image_id=image_id)
-    
     def on_metadata_table_cell_clicked(self, row: int, column: int):
         """Keep click behavior passive; marking seen is handled by Seen actions only."""
         return
@@ -2715,21 +2685,6 @@ class Mapflow(QObject):
                         )
                     status_item.setToolTip(tip)
                 break
-
-    def preview_search_from_cell (self, row, column):
-        if column == self.config.PPRVIEW_INDEX_COLUMN:
-            id_column_index = self.config.SEARCH_ID_COLUMN_INDEX
-            image_id = self.dlg.metadataTable.item(row, id_column_index).text()
-            self.preview_service.preview_catalog(image_id)
-
-    def preview_or_search(self, provider) -> None:
-        provider_index = self.dlg.providerIndex()
-        provider = self.provider_service.providers[provider_index]
-        if provider.requires_image_id:
-            imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
-            self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
-        else:
-            self.preview()
 
     def update_processing_current_rating(self) -> None:
         # reset labels:

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -17,7 +17,7 @@ from PyQt5.QtGui import QBrush, QColor, QIcon
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 from PyQt5.QtWidgets import (
     QAbstractItemView, QAction, QApplication, QFileDialog,
-    QMenu, QMessageBox, QPushButton, QWidget, QToolButton
+    QMenu, QMessageBox, QWidget, QToolButton
 )
 from qgis.core import (
     QgsDistanceArea, QgsFeature, QgsGeometry,
@@ -42,6 +42,7 @@ from .functional.controller.processing_controller import ProcessingController
 from .functional.service.aoi_service import AoiService
 from .functional.service.preview_service import PreviewService
 from .functional.view.aoi_view import AoiView
+from .functional.view.search_view import SearchView
 from .functional.service import (DataCatalogService,
                                  ProcessingService,
                                  ProjectService,
@@ -302,6 +303,7 @@ class Mapflow(QObject):
         self.data_catalog_controller = DataCatalogController(self.dlg,
                                                              self.data_catalog_service,
                                                              self.preview_service)
+        self.search_view = SearchView(dlg=self.dlg, config=self.config)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
@@ -2123,7 +2125,7 @@ class Mapflow(QObject):
         ``aoi_details`` is ``None`` the geometry is omitted — used to update a template's
         non-geometry search params (which the backend merges); geometry updates go through
         the per-AOI endpoints instead (the PUT template endpoint rejects geometry)."""
-        off_nadir_min, off_nadir_max = self._off_nadir_request_bounds()
+        off_nadir_min, off_nadir_max = self.search_view.off_nadir_bounds()
         return SearchParams(
             aoiDetails=aoi_details,
             acquisitionDateFrom=self.dlg.metadataFrom.dateTime().toUTC().toString("yyyy-MM-ddTHH:mm:ss.zzz'Z'"),
@@ -2291,13 +2293,9 @@ class Mapflow(QObject):
         # A regular search replaces any template results, so a "Start" is no longer planned.
         self.app_context.open_template_results_id = None
 
-        self.dlg.metadataTable.clearContents()
-        self.dlg.metadataTable.setRowCount(0)
-        more_button = self.dlg.findChild(QPushButton, self.config.METADATA_MORE_BUTTON_OBJECT_NAME)
-        if more_button:
-            self.dlg.layoutMetadataTable.removeWidget(more_button)
-            more_button.deleteLater()
-        provider = self.provider_service.providers[self.dlg.providerIndex()]
+        self.search_view.clear_table()
+        self.search_view.remove_more_button()
+        provider = self.provider_service.providers[self.search_view.provider_index()]
         # Check if the AOI is defined
         if self.app_context.aoi:
             aoi = self.app_context.aoi
@@ -2305,39 +2303,15 @@ class Mapflow(QObject):
             self.alert(self.tr('Please, select a valid area of interest'))
             return
 
-        from_time = self.dlg.metadataFrom.dateTime().toTimeSpec(Qt.UTC).toString(Qt.ISODate)
-        to_time = self.dlg.metadataTo.dateTime().toTimeSpec(Qt.UTC).toString(Qt.ISODate)
-
-        max_cloud_cover = self.dlg.maxCloudCover.value()
-        min_intersection = self.dlg.minIntersection.value()
-
-        hide_unavailable = self.dlg.hideUnavailableResults.isChecked()
-        product_types = self.selected_search_product_types()
-        search_providers = self.selected_search_providers()
-        min_off_nadir, max_off_nadir = self._off_nadir_request_bounds()
-
         # All imagery search goes through the Mapflow catalog API, which filters server-side.
+        # Every filter widget is read once, here, so the request is built from what the widgets
+        # said when Search was pressed rather than from whatever they say by the time it is sent.
         self.request_mapflow_metadata(aoi=aoi,
                                       provider=provider,
-                                      from_=from_time,
-                                      to=to_time,
                                       offset=offset,
-                                      max_cloud_cover=max_cloud_cover,
-                                      min_intersection=min_intersection,
-                                      min_off_nadir_angle=min_off_nadir,
-                                      max_off_nadir_angle=max_off_nadir,
-                                      hide_unavailable=hide_unavailable,
-                                      product_types=product_types,
-                                      search_providers=search_providers,
                                       sort_by=self._search_sort_by,
-                                      sort_order=self._search_sort_order)
-
-    def _off_nadir_request_bounds(self):
-        """(min, max) off-nadir angle to send to the API, or (None, None) at the full 0-30 range
-        (no off-nadir filtering — leaving it out avoids excluding images beyond the slider)."""
-        if self.dlg.off_nadir_is_full_range():
-            return None, None
-        return self.dlg.off_nadir_range()
+                                      sort_order=self._search_sort_order,
+                                      **self.search_view.search_parameters())
 
     def clear_metadata(self):
         try:
@@ -2346,12 +2320,11 @@ class Mapflow(QObject):
             pass
 
         self.app_context.open_template_results_id = None
-        self.dlg.metadataTable.clearContents()
-        self.dlg.metadataTable.setRowCount(0)
+        self.search_view.clear_table()
         # Drop the retained results/baseline so a stale widen (!) indicator does not linger.
         self.app_context.search_result_geojson = None
         self.app_context.search_baseline_filters = None
-        self.dlg.searchWidenWarning.setVisible(False)
+        self.search_view.set_widen_warning_visible(False)
         #provider = self.provider_service.providers[self.dlg.providerIndex()]
         self.app_context.search_provider.clear_saved_search(self.app_context.temp_dir)
 
@@ -3642,11 +3615,9 @@ class Mapflow(QObject):
             quotient, remainder = divmod(total, limit)
             total_pages = quotient + (remainder > 0)
             page_number = int(offset / limit) + 1
-            self.dlg.enable_search_pages(True, page_number, total_pages)
-            self.dlg.searchRightButton.setEnabled(page_number != total_pages)
-            self.dlg.searchLeftButton.setEnabled(page_number != 1)
+            self.search_view.show_pages(page_number, total_pages)
         else:
-            self.dlg.enable_search_pages(False)
+            self.search_view.hide_pages()
 
     def show_search_next_page(self):
         offset = self.search_page_offset + self.search_page_limit
@@ -3663,26 +3634,12 @@ class Mapflow(QObject):
             self.get_metadata(offset=offset)
     
     def selected_search_product_types(self):
-        product_types = []
-        if self.dlg.searchMosaicCheckBox.isChecked():
-            product_types.append(ProductType.mosaic.upper())
-        if self.dlg.searchImageCheckBox.isChecked():
-            product_types.append(ProductType.image.upper())
-        if len(product_types) == 0:
-            product_types = [ProductType.mosaic.upper(), ProductType.image.upper()]
-        return product_types
+        """Kept as a forwarder: template creation reads the same widgets, and that code moves in
+        the templates step."""
+        return self.search_view.product_types()
 
     def selected_search_providers(self):
-        """Provider filter to send with a search/template request.
-
-        Only meaningful while the search is limited to available providers; when
-        "Search only through available providers" is off, the (hidden) provider selection
-        must NOT be sent — the search runs across all providers. An empty selection is
-        also omitted (None), since the backend reads ``[]`` as "search no providers".
-        """
-        if not self.dlg.hideUnavailableResults.isChecked():
-            return None
-        return self.dlg.searchProvidersCombo.checkedItemsData() or None
+        return self.search_view.search_providers()
 
     def setup_tempdir(self) -> Optional[str]:
         """Create the working ``Temp`` directory under the configured output directory.

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -14,7 +14,7 @@ from PyQt5.QtCore import (
     QTimer, QTranslator
 )
 from PyQt5.QtGui import QBrush, QColor, QIcon
-from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
+from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
     QAbstractItemView, QAction, QApplication, QFileDialog,
     QMenu, QMessageBox, QWidget, QToolButton
@@ -41,6 +41,7 @@ from .functional.controller.project_processing_controller import ProjectProcessi
 from .functional.controller.processing_controller import ProcessingController
 from .functional.service.aoi_service import AoiService
 from .functional.service.preview_service import PreviewService
+from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
 from .functional.view.search_view import SearchView
 from .functional.service import (DataCatalogService,
@@ -55,7 +56,6 @@ from .http import (Http,
                    get_error_report_body)
 # Schema
 from .schema import (BillingType,
-                     ImageCatalogRequestSchema,
                      ImageCatalogResponseSchema,
                      ImagerySearchParams,
                      MyImageryParams,
@@ -101,10 +101,6 @@ class Mapflow(QObject):
     # Last local-filter outcome, so a slider drag that doesn't flip any image skips the re-fill.
     _last_unfit_set = None
     _last_filtered_geoms = None
-    # Server-side sort of the search results (regular search AND template results). Default:
-    # newest first by acquisition date; a header click changes/flips it and re-runs the search.
-    _search_sort_by = "ACQUISITION_DATE"
-    _search_sort_order = "DESC"
     # Cached widen-warning messages backing the (!) indicator's click handler.
     _widen_details = None
 
@@ -158,9 +154,6 @@ class Mapflow(QObject):
             self.app_context.settings.setValue('processings', {})
         # Set projects from settings if it was opened before
         self.app_context.project_id = self.app_context.settings.value("project_id")
-        # Imagery search pagination
-        self.search_page_offset = 0
-        self.search_page_limit = self.config.SEARCH_RESULTS_PAGE_LIMIT
 
         # ========== 3. INIT DIALOGS ==========
         # Init dialogs before creating timers that need them as parent
@@ -303,7 +296,23 @@ class Mapflow(QObject):
         self.data_catalog_controller = DataCatalogController(self.dlg,
                                                              self.data_catalog_service,
                                                              self.preview_service)
+        # Before SearchService, which resolves sortable columns through it. Was created further
+        # down with the provider-dialog wiring; construction order is load-bearing here.
+        self.config_search_columns = ConfigColumns()
         self.search_view = SearchView(dlg=self.dlg, config=self.config)
+        self.search_service = SearchService(iface=self.iface,
+                                            app_context=self.app_context,
+                                            http=self.http,
+                                            plugin_dir=self.plugin_dir,
+                                            config=self.config,
+                                            config_search_columns=self.config_search_columns,
+                                            result_loader=self.result_loader,
+                                            provider_service=self.provider_service)
+        # Search wiring. Moves to SearchController with the rest of the search-tab connects.
+        self.search_service.resultsReceived.connect(self._on_search_results)
+        self.search_service.metadataLayerReady.connect(self._on_metadata_layer_ready)
+        self.search_service.pagerChanged.connect(self.search_view.show_pages)
+        self.search_service.pagerHidden.connect(self.search_view.hide_pages)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
@@ -408,7 +417,6 @@ class Mapflow(QObject):
         self.dlg.editProvider.clicked.connect(self.edit_provider)
         self.dlg.removeProvider.clicked.connect(self.remove_provider)
 
-        self.config_search_columns = ConfigColumns()
         # Image ids whose preview is currently being downloaded (async). Guards against the
         # dedupe-on-map check missing duplicates, since the preview layer is only added in the
         # HTTP callback — a second click/double-click fired several downloads before the first
@@ -760,7 +768,7 @@ class Mapflow(QObject):
         # New images are flagged with an icon in the leftmost column (not by editing text).
         self._apply_new_image_markers()
         # Toggle/wire the search pager for the template results (T6).
-        self._update_search_pager(response_data.total, response_data.limit, response_data.offset)
+        self.search_service.update_pager(response_data.total, response_data.limit, response_data.offset)
 
     def _store_template_search_footprints(self,
                                           geoms: dict,
@@ -776,7 +784,7 @@ class Mapflow(QObject):
           user can preview image footprints and request imagery previews.
         """
         self.app_context.search_footprints = {}
-        provider = self.imagery_search_provider
+        provider = self.search_service.imagery_search_provider
         if not provider:
             return
         filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
@@ -1110,7 +1118,7 @@ class Mapflow(QObject):
             if imagery_search_tab:
                 self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
 
-        self.search_page_offset = max(0, offset)
+        self.search_service.page_offset = max(0, offset)
         if aoi_ids is None:
             aoi_ids = self._aoi_ids_from_template(template)
         # Template results are fetched WITHOUT date/cloud server-side filters: those (and the
@@ -1120,11 +1128,11 @@ class Mapflow(QObject):
         self.processing_service.api.get_template_images(
             template_id=template.id,
             callback=lambda response: self.get_selected_template_callback(response, template),
-            limit=self.search_page_limit,
-            offset=self.search_page_offset,
+            limit=self.search_service.page_limit,
+            offset=self.search_service.page_offset,
             aoi_ids=aoi_ids or None,
-            sort_by=self._search_sort_by,
-            sort_order=self._search_sort_order,
+            sort_by=self.search_service.sort_by,
+            sort_order=self.search_service.sort_order,
         )
 
     def _load_template_search_page(self, offset: int):
@@ -1774,26 +1782,12 @@ class Mapflow(QObject):
             # The current search-results footprint layer is a polygon too, but it is NOT an
             # AOI. Wiring its selection to the area calc would recompute (and re-request) the
             # processing cost a second time on every image click — skip it.
-            if self._is_search_metadata_layer(layer):
+            if self.search_service.is_search_metadata_layer(layer):
                 continue
             layer.selectionChanged.connect(self.area_calculator_service.calculate_aoi_area_selection)
             layer.geometryChanged.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
             layer.featureAdded.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
             layer.featuresDeleted.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
-
-    def _is_search_metadata_layer(self, layer) -> bool:
-        """True if `layer` is the current imagery-search footprints layer.
-
-        Metadata-layer creators assign ``app_context.metadata_layer`` before adding the
-        layer to the project, so this is reliable at ``layersAdded`` time.
-        """
-        metadata_layer = self.app_context.metadata_layer
-        if metadata_layer is None:
-            return False
-        try:
-            return layer.id() == metadata_layer.id()
-        except RuntimeError:  # metadata layer was deleted
-            return False
 
     def toggle_imagery_search(self,
                               provider):
@@ -1820,7 +1814,7 @@ class Mapflow(QObject):
         # We store the results in a temp folder, separate file for each provider
         geoms = self.app_context.search_provider.load_search_layer(self.app_context.temp_dir)
         if geoms:
-            self.display_metadata_geojson_layer(
+            self.search_service.display_metadata_geojson_layer(
                 os.path.join(self.app_context.temp_dir, self.app_context.search_provider.metadata_layer_name),
                 f"{self.app_context.search_provider.name} metadata")
             # Keep the restored results available to the instant local filter (fill below emits
@@ -1908,7 +1902,7 @@ class Mapflow(QObject):
         except (NotImplementedError, AttributeError):
             provider_supports_search = False
         if not provider_supports_search:
-            provider = self.imagery_search_provider
+            provider = self.search_service.imagery_search_provider
             # we need to deselect table to be able to use the non-search provider
         if provider != self.app_context.search_provider:
             self.app_context.search_provider = provider
@@ -2245,17 +2239,10 @@ class Mapflow(QObject):
         template-images endpoint accepts the same sortBy/sortOrder)."""
         if self.dlg.metadataTable.rowCount() == 0:
             return  # nothing searched yet
-        attributes = tuple(self.config_search_columns.METADATA_TABLE_ATTRIBUTES.values())
-        if not 0 <= column < len(attributes):
-            return
-        sort_field = self.config.SEARCH_SORT_FIELDS.get(attributes[column])
+        sort_field = self.search_service.sort_column_field(column)
         if not sort_field:
             return  # column is not server-sortable
-        if self._search_sort_by == sort_field:
-            self._search_sort_order = "ASC" if self._search_sort_order == "DESC" else "DESC"
-        else:
-            self._search_sort_by = sort_field
-            self._search_sort_order = "DESC"
+        self.search_service.toggle_sort(sort_field)
         self._update_search_sort_indicator(column)
         # Re-request the first page with the new sort — the template-images endpoint and
         # /catalog/meta take the same sort params, so both re-sort server-side.
@@ -2267,20 +2254,16 @@ class Mapflow(QObject):
     def _update_search_sort_indicator(self, column: int) -> None:
         header = self.dlg.metadataTable.horizontalHeader()
         header.setSortIndicatorShown(True)
-        order = Qt.DescendingOrder if self._search_sort_order == "DESC" else Qt.AscendingOrder
+        order = Qt.DescendingOrder if self.search_service.sort_order == "DESC" else Qt.AscendingOrder
         header.setSortIndicator(column, order)
 
     def _restore_search_sort_indicator(self) -> None:
         """Re-show the sort arrow on the active sort column. Every table (re)fill calls
         setSortingEnabled(False), which Qt implements as hiding the sort indicator, so it must be
         restored after each fill (otherwise the arrow flashes on click and immediately vanishes)."""
-        if not self._search_sort_by:
-            return
-        attribute = next((attr for attr, token in self.config.SEARCH_SORT_FIELDS.items()
-                          if token == self._search_sort_by), None)
-        attributes = tuple(self.config_search_columns.METADATA_TABLE_ATTRIBUTES.values())
-        if attribute in attributes:
-            self._update_search_sort_indicator(attributes.index(attribute))
+        column = self.search_service.active_sort_column()
+        if column is not None:
+            self._update_search_sort_indicator(column)
 
     def get_metadata(self, _: Optional[bool] = False, offset: Optional[int] = 0) -> None:
         """Metadata is image footprints with attributes like acquisition date or cloud cover."""
@@ -2303,154 +2286,34 @@ class Mapflow(QObject):
             self.alert(self.tr('Please, select a valid area of interest'))
             return
 
+        if not self.check_if_output_directory_is_selected():
+            return  # only when outputDirectory is empty AND user closed selection dialog
         # All imagery search goes through the Mapflow catalog API, which filters server-side.
         # Every filter widget is read once, here, so the request is built from what the widgets
         # said when Search was pressed rather than from whatever they say by the time it is sent.
-        self.request_mapflow_metadata(aoi=aoi,
-                                      provider=provider,
-                                      offset=offset,
-                                      sort_by=self._search_sort_by,
-                                      sort_order=self._search_sort_order,
-                                      **self.search_view.search_parameters())
+        self.search_service.search(aoi=aoi,
+                                   provider=provider,
+                                   aoi_layer=self.aoi_view.current_layer(),
+                                   baseline_filters=self._current_filter_baseline(),
+                                   offset=offset,
+                                   **self.search_view.search_parameters())
 
     def clear_metadata(self):
-        try:
-            self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
-        except (AttributeError, RuntimeError):  # metadata layer has been deleted
-            pass
-
-        self.app_context.open_template_results_id = None
+        """Drop the search results. The service owns the results and the layer; the table and the
+        widen (!) indicator are widgets, so they are cleared here until `SearchController` lands."""
+        self.search_service.clear()
         self.search_view.clear_table()
-        # Drop the retained results/baseline so a stale widen (!) indicator does not linger.
-        self.app_context.search_result_geojson = None
-        self.app_context.search_baseline_filters = None
         self.search_view.set_widen_warning_visible(False)
-        #provider = self.provider_service.providers[self.dlg.providerIndex()]
-        self.app_context.search_provider.clear_saved_search(self.app_context.temp_dir)
 
-    def request_mapflow_metadata(self,
-                                 aoi: QgsGeometry,
-                                 provider: ProviderInterface,
-                                 from_: Optional[str] = None,
-                                 to: Optional[str] = None,
-                                 min_resolution: Optional[float] = None,
-                                 max_resolution: Optional[float] = None,
-                                 max_cloud_cover: Optional[float] = None,
-                                 min_off_nadir_angle: Optional[float] = None,
-                                 max_off_nadir_angle: Optional[float] = None,
-                                 min_intersection: Optional[float] = None,
-                                 offset: Optional[int] = 0,
-                                 hide_unavailable: Optional[bool] = False,
-                                 product_types: Optional[List[ProductType]] = None,
-                                 search_providers: Optional[List[str]] = None,
-                                 sort_by: Optional[str] = None,
-                                 sort_order: Optional[str] = None):
-        if not self.check_if_output_directory_is_selected():
-            return # only when outputDirectory is empty AND user closed selection dialog
-        self.app_context.metadata_aoi = aoi
-        # Remember what this search actually asks the server for, so the widen (!) indicator can
-        # flag later widget edits that ask for MORE than was fetched (which local filtering can't
-        # surface without a fresh Search).
-        self.app_context.search_baseline_filters = self._current_filter_baseline()
-        request_payload = ImageCatalogRequestSchema(aoi=json.loads(aoi.asJson()),
-                                                    acquisitionDateFrom=from_,
-                                                    acquisitionDateTo=to,
-                                                    minResolution=min_resolution,
-                                                    maxResolution=max_resolution,
-                                                    maxCloudCover=max_cloud_cover,
-                                                    minOffNadirAngle=min_off_nadir_angle,
-                                                    maxOffNadirAngle=max_off_nadir_angle,
-                                                    minAoiIntersectionPercent=min_intersection,
-                                                    limit=self.search_page_limit,
-                                                    offset=offset,
-                                                    hideUnavailable=hide_unavailable,
-                                                    productTypes=product_types,
-                                                    dataProviders=search_providers,
-                                                    sortBy=sort_by,
-                                                    sortOrder=sort_order)
-        self.http.post(url=provider.meta_url,
-                       body=request_payload.as_json().encode(),
-                       headers={},
-                       callback=self.request_mapflow_metadata_callback,
-                       callback_kwargs={"min_intersection": min_intersection,
-                                        "max_cloud_cover": max_cloud_cover},
-                       error_handler=self.request_mapflow_metadata_error_handler,
-                       use_default_error_handler=False,
-                       timeout=60)
+    def _on_search_results(self, geoms) -> None:
+        """Built-in Qt sorting stays OFF: results already arrive in the server's sort order, and
+        a header click re-requests rather than sorting locally."""
+        self.search_view.fill_table(geoms, sort=False)
 
-    def request_mapflow_metadata_error_handler(self, response: QNetworkReply):
-        title = self.tr("We couldn't get metadata from the Mapflow Imagery Catalog")
-        error = response.attribute(QNetworkRequest.HttpStatusCodeAttribute)
-        if error is not None:
-            title += self.tr(". Error {error}").format(error=error)
-        self.report_http_error(response, title, error_message_parser=api_message_parser)
-
-    def display_metadata_geojson_layer(self, filename, layer_name):
-        try:
-            self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
-        except (AttributeError, RuntimeError):  # metadata layer has been deleted
-            pass
-        # Assigned (before add_layer) so the AOI-area monitor recognizes and skips it.
-        self.app_context.metadata_layer = QgsVectorLayer(filename, layer_name, 'ogr')
-        self.app_context.metadata_layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
-        # Place search results just under the AOI layer, if that layer has a legend node.
-        # (A layer added with addToLegend=False has no tree node -> findLayer returns None;
-        # fall back to a plain add instead of dereferencing a missing parent.)
-        aoi_layer = self.dlg.polygonCombo.currentLayer()
-        aoi_layer_tree = (self.app_context.project.layerTreeRoot().findLayer(aoi_layer.id())
-                          if aoi_layer else None)
-        if aoi_layer_tree is not None and aoi_layer_tree.parent() is not None:
-            index = aoi_layer_tree.parent().children().index(aoi_layer_tree)
-            self.result_loader.add_layer(layer=self.app_context.metadata_layer, order=index + 1)
-        else:
-            self.result_loader.add_layer(layer=self.app_context.metadata_layer)
-        # Connect layer with metadata table
-        self.app_context.meta_layer_table_connection = self.app_context.metadata_layer.selectionChanged.connect(
+    def _on_metadata_layer_ready(self, layer) -> None:
+        """Selecting a footprint on the map selects the matching table row (and triggers preview)."""
+        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
             self.sync_layer_selection_with_table)
-        self.app_context.search_footprints = {
-            feature['local_index']: feature
-            for feature in self.app_context.metadata_layer.getFeatures()
-        }
-
-    def request_mapflow_metadata_callback(self, response: QNetworkReply,
-                                          min_intersection: int = 0,
-                                          max_cloud_cover: int = 90):
-        response_json = json.loads(response.readAll().data())
-        if not response_json.get("images"):
-            self.alert(
-                self.tr('No images match your criteria. Try relaxing the filters.'),
-                QMessageBox.Information
-            )
-            return
-        response_data = ImageCatalogResponseSchema(**response_json)
-        geoms = response_data.as_geojson()
-        # Add index to map table and layer
-        for position, feature in enumerate(geoms.get("features", ())):
-            feature['properties']['local_index'] = position
-
-        # Save the current search results to load later
-        provider = self.imagery_search_provider
-        save_failed_message = self.tr("<b>Results could not be loaded </b><br>Please, make sure you chose the right output folder in the Settings tab \
-                                and you have access rights to this folder")
-        try:
-            filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
-        except OSError:
-            # The case the message describes: missing/unwritable output folder.
-            self.alert(save_failed_message)
-            return
-        except Exception:
-            logger.exception("Unexpected error saving the search layer")
-            self.alert(save_failed_message)
-            return
-        self.display_metadata_geojson_layer(filename, f"{provider.name} metadata")
-        # Retain the raw results so the instant local filter can reorder/re-render them without
-        # a new request (fill emits metadataTableFilled -> apply_local_filter).
-        self.app_context.search_result_geojson = geoms
-        # Built-in Qt sorting stays OFF; the results already arrive in the server sort order and
-        # header clicks re-request with sortBy/sortOrder (see on_metadata_header_clicked).
-        self.dlg.fill_metadata_table(geoms, sort=False)
-
-        self._update_search_pager(response_data.total, response_data.limit, response_data.offset)
 
     def sync_table_selection_with_image_id_and_layer(self) -> None:
         """
@@ -3065,7 +2928,7 @@ class Mapflow(QObject):
         self.dlg.metadataTable.clearContents()
         self.dlg.metadataTable.setRowCount(0)
         # Clear the template search-results pagination so it is not preserved on re-open.
-        self.search_page_offset = 0
+        self.search_service.page_offset = 0
         self.dlg.enable_search_pages(False)
 
     def on_template_aois_changed(self, template):
@@ -3605,29 +3468,16 @@ class Mapflow(QObject):
             product_types = []
         return provider_names, product_types
     
-    def _update_search_pager(self, total: int, limit: int, offset: int):
-        """Show/hide and wire the imagery-search page navigation from a search response's
-        ``total``/``limit``/``offset``. Shared by regular search and template search (T6):
-        template results used to fill the table but never toggle the pager."""
-        if limit and total > limit:
-            self.search_page_offset = offset
-            self.search_page_limit = limit
-            quotient, remainder = divmod(total, limit)
-            total_pages = quotient + (remainder > 0)
-            page_number = int(offset / limit) + 1
-            self.search_view.show_pages(page_number, total_pages)
-        else:
-            self.search_view.hide_pages()
-
     def show_search_next_page(self):
-        offset = self.search_page_offset + self.search_page_limit
-        if self.processing_service.in_template_mode:
-            self._load_template_search_page(offset)
-        else:
-            self.get_metadata(offset=offset)
+        self._show_search_page(self.search_service.next_page_offset())
 
     def show_search_previous_page(self):
-        offset = self.search_page_offset - self.search_page_limit
+        self._show_search_page(self.search_service.previous_page_offset())
+
+    def _show_search_page(self, offset: int):
+        """Which endpoint serves the page depends on where the results came from, so the branch
+        stays out of `SearchService` — it is coordination between two regions, and moves to
+        `SearchController` / `TemplateController` rather than into either service."""
         if self.processing_service.in_template_mode:
             self._load_template_search_page(offset)
         else:
@@ -3710,9 +3560,3 @@ class Mapflow(QObject):
         else:
             self.dlg_login.show()
 
-    @property
-    def imagery_search_provider(self):
-        for provider in self.provider_service.providers:
-            if isinstance(provider, ImagerySearchProvider):
-                return provider
-        return None

--- a/spec/006_error_reporting.md
+++ b/spec/006_error_reporting.md
@@ -60,9 +60,7 @@ not emit a signal for someone else to report on its behalf, and it does not cons
 ### Volume limit
 
 **Contract: no failure, however often it recurs, may produce an unbounded number of
-dialogs.** This covers *every* dialog tier — report and message alike. Both use `exec()`, so
-both stack; a modal that says "Could not refresh" on a 6-second poll locks QGIS just as
-effectively as an unthrottled crash report.
+dialogs.** This covers *every* dialog tier — report and message alike.
 
 This is not a nicety. Plugin modals are opened with `exec()`, which runs a nested event
 loop, so `QTimer` keeps firing while a dialog is up and dialogs *stack* rather than queue.
@@ -70,6 +68,9 @@ Several plugin operations are timer-driven — processing table refresh (6s), te
 refresh (15s), user status (30s) — so an unthrottled failure on any polled path renders
 QGIS unusable. That is a worse outcome than the unhandled exception the reporting was
 introduced to replace.
+
+None of that is specific to the report dialog: a message-tier modal saying "Could not refresh"
+on a 6-second poll locks QGIS exactly as thoroughly as an unthrottled crash report.
 
 `mapflow/report_throttle.py` implements the limit:
 

--- a/tests/qgis/test_local_filter.py
+++ b/tests/qgis/test_local_filter.py
@@ -414,7 +414,7 @@ def _plugin_orchestration(unfit):
     plugin._unfit_local_indices = MagicMock(return_value=set(unfit))
     plugin._mark_unfit_rows = MagicMock()
     plugin._hide_unfit_footprints = MagicMock()
-    plugin._reconnect_cell_preview = MagicMock()
+    plugin.search_controller = MagicMock()  # apply_local_filter drives reconnect_cell_preview
     plugin._update_widen_indicator = MagicMock()
     plugin._apply_new_image_markers = MagicMock()
     plugin._restore_search_sort_indicator = MagicMock()

--- a/tests/qgis/test_off_nadir_filter.py
+++ b/tests/qgis/test_off_nadir_filter.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 from qgis.core import QgsSettings
 
 from mapflow.dialogs.main_dialog import MainDialog
-from mapflow.mapflow import Mapflow
+from mapflow.functional.view.search_view import SearchView
 
 
 def _dialog():
@@ -45,17 +45,18 @@ def test_inverted_spinboxes_are_ordered():
     assert lower <= upper
 
 
-def _plugin(full_range, bounds=(5, 20)):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    plugin.dlg.off_nadir_is_full_range.return_value = full_range
-    plugin.dlg.off_nadir_range.return_value = bounds
-    return plugin
+def _view(full_range, bounds=(5, 20)):
+    """The API-bounds helper is `SearchView` since the search extraction — it reads two widgets
+    and decides what the request may omit, which is a view's job."""
+    dlg = MagicMock()
+    dlg.off_nadir_is_full_range.return_value = full_range
+    dlg.off_nadir_range.return_value = bounds
+    return SearchView(dlg=dlg, config=MagicMock())
 
 
 def test_request_bounds_none_at_full_range():
-    assert _plugin(full_range=True)._off_nadir_request_bounds() == (None, None)
+    assert _view(full_range=True).off_nadir_bounds() == (None, None)
 
 
 def test_request_bounds_sends_values_when_narrowed():
-    assert _plugin(full_range=False, bounds=(5, 20))._off_nadir_request_bounds() == (5, 20)
+    assert _view(full_range=False, bounds=(5, 20)).off_nadir_bounds() == (5, 20)

--- a/tests/qgis/test_search_controller.py
+++ b/tests/qgis/test_search_controller.py
@@ -1,0 +1,123 @@
+"""SearchController — the imagery-search preview dispatch.
+
+These behaviours (`preview`, `preview_or_search`, `preview_search_from_cell`) had no direct
+tests before the extraction: they ran only through the plugin. `spec/007_architecture.md` says a
+step that moves code must not leave a behaviour covered by neither suite, so they are pinned here
+against the new owner.
+
+The controller reads *which* image through `SearchView` and dispatches to `PreviewService`; the
+provider it acts on comes from `ProviderService`. Alerts go through the message tier, patched
+here so the singleton is never touched.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mapflow.functional.controller.search_controller import SearchController
+from mapflow.functional.view.search_view import SearchView
+from mapflow.model.provider.default import ImagerySearchProvider
+
+
+def _xyz_provider(requires_id):
+    """A non-search provider (the isinstance check must send it down the XYZ path)."""
+    return SimpleNamespace(requires_image_id=requires_id)
+
+
+@pytest.fixture
+def controller(monkeypatch):
+    """A controller whose search_button/metadata_table are mocks (only `.connect` is called on
+    them at construction) and whose collaborators are mocks."""
+    alerts = []
+    monkeypatch.setattr("mapflow.functional.controller.search_controller.alert",
+                        lambda *a, **k: alerts.append(a[0] if a else ""))
+    view = MagicMock(spec=SearchView)
+    view.provider_index.return_value = 0
+    controller = SearchController(search_service=MagicMock(),
+                                  search_view=view,
+                                  preview_service=MagicMock(),
+                                  provider_service=SimpleNamespace(providers=[]),
+                                  search_button=MagicMock(),
+                                  metadata_table=MagicMock())
+    controller._alerts = alerts
+    return controller
+
+
+# ---------- preview (double-click / Preview) ----------
+
+def test_preview_of_search_provider_goes_to_the_catalog(controller):
+    provider = ImagerySearchProvider(proxy="https://example.com/rest")
+    provider.requires_id = True
+    controller.provider_service.providers = [provider]
+    controller.search_view.selected_image_id.return_value = "IMG-1"
+
+    controller.preview()
+
+    controller.preview_service.preview_catalog.assert_called_once_with(image_id="IMG-1")
+    controller.preview_service.preview_xyz.assert_not_called()
+
+
+def test_preview_of_xyz_provider_goes_to_xyz(controller):
+    provider = _xyz_provider(requires_id=False)
+    controller.provider_service.providers = [provider]
+    controller.search_view.selected_image_id.return_value = None
+
+    controller.preview()
+
+    controller.preview_service.preview_xyz.assert_called_once_with(provider=provider,
+                                                                   image_id=None)
+    controller.preview_service.preview_catalog.assert_not_called()
+
+
+def test_preview_requires_image_id_alerts_and_stops(controller):
+    provider = _xyz_provider(requires_id=True)
+    controller.provider_service.providers = [provider]
+    controller.search_view.selected_image_id.return_value = None  # none selected
+
+    controller.preview()
+
+    assert len(controller._alerts) == 1
+    controller.preview_service.preview_catalog.assert_not_called()
+    controller.preview_service.preview_xyz.assert_not_called()
+
+
+# ---------- preview_or_search (the Search button) ----------
+
+def test_search_button_sends_id_provider_to_the_search_tab(controller):
+    controller.provider_service.providers = [_xyz_provider(requires_id=True)]
+
+    controller.preview_or_search()
+
+    controller.search_view.switch_to_search_tab.assert_called_once()
+    controller.preview_service.preview_catalog.assert_not_called()
+
+
+def test_search_button_previews_a_non_id_provider_directly(controller):
+    provider = _xyz_provider(requires_id=False)
+    controller.provider_service.providers = [provider]
+    controller.search_view.selected_image_id.return_value = None
+
+    controller.preview_or_search()
+
+    controller.search_view.switch_to_search_tab.assert_not_called()
+    controller.preview_service.preview_xyz.assert_called_once()
+
+
+# ---------- preview_search_from_cell (Preview column click) ----------
+
+def test_cell_click_in_preview_column_previews_that_row(controller):
+    controller.search_view.is_preview_column.return_value = True
+    controller.search_view.image_id_at.return_value = "IMG-9"
+
+    controller.preview_search_from_cell(row=3, column=1)
+
+    controller.search_view.image_id_at.assert_called_once_with(3)
+    controller.preview_service.preview_catalog.assert_called_once_with("IMG-9")
+
+
+def test_cell_click_outside_preview_column_does_nothing(controller):
+    controller.search_view.is_preview_column.return_value = False
+
+    controller.preview_search_from_cell(row=3, column=0)
+
+    controller.preview_service.preview_catalog.assert_not_called()

--- a/tests/qgis/test_search_sort.py
+++ b/tests/qgis/test_search_sort.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from mapflow.config import Config, ConfigColumns
+from mapflow.functional.service.search_service import SearchService
 from mapflow.mapflow import Mapflow
 from mapflow.schema.catalog import ImageCatalogRequestSchema
 
@@ -20,15 +21,30 @@ def _column(attr):
     return _ATTRS.index(attr)
 
 
+def _search_service(sort_by, sort_order):
+    """Real service: the sort state and the column->token lookup are its logic now. What stays in
+    `mapflow.py` is only the choice of which endpoint to re-request from."""
+    service = SearchService(iface=MagicMock(),
+                            app_context=MagicMock(),
+                            http=MagicMock(),
+                            plugin_dir="",
+                            config=Config,
+                            config_search_columns=ConfigColumns(),
+                            result_loader=MagicMock(),
+                            provider_service=MagicMock())
+    service.sort_by = sort_by
+    service.sort_order = sort_order
+    return service
+
+
 def _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC", in_template=False, rows=5):
     plugin = Mapflow.__new__(Mapflow)
     plugin.config = Config
     plugin.config_search_columns = ConfigColumns()
+    plugin.search_service = _search_service(sort_by, sort_order)
     plugin.processing_service = SimpleNamespace(in_template_mode=in_template)
     plugin.dlg = MagicMock()
     plugin.dlg.metadataTable.rowCount.return_value = rows
-    plugin._search_sort_by = sort_by
-    plugin._search_sort_order = sort_order
     plugin._update_search_sort_indicator = MagicMock()
     plugin.get_metadata = MagicMock()
     plugin._load_template_search_page = MagicMock()
@@ -48,8 +64,8 @@ def test_click_new_sortable_column_sets_field_desc_and_researches():
 
     plugin.on_metadata_header_clicked(_column("cloudCover"))
 
-    assert plugin._search_sort_by == "CLOUD_COVER"
-    assert plugin._search_sort_order == "DESC"
+    assert plugin.search_service.sort_by == "CLOUD_COVER"
+    assert plugin.search_service.sort_order == "DESC"
     plugin.get_metadata.assert_called_once()
 
 
@@ -57,10 +73,10 @@ def test_click_same_column_toggles_order():
     plugin = _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC")
 
     plugin.on_metadata_header_clicked(_column("acquisitionDate"))
-    assert plugin._search_sort_order == "ASC"
+    assert plugin.search_service.sort_order == "ASC"
     plugin.on_metadata_header_clicked(_column("acquisitionDate"))
-    assert plugin._search_sort_order == "DESC"
-    assert plugin._search_sort_by == "ACQUISITION_DATE"
+    assert plugin.search_service.sort_order == "DESC"
+    assert plugin.search_service.sort_by == "ACQUISITION_DATE"
     assert plugin.get_metadata.call_count == 2
 
 
@@ -70,7 +86,7 @@ def test_non_sortable_column_does_nothing():
     plugin.on_metadata_header_clicked(_column("productType"))  # not in SEARCH_SORT_FIELDS
     plugin.on_metadata_header_clicked(_column("preview"))
 
-    assert plugin._search_sort_by == "ACQUISITION_DATE"  # unchanged
+    assert plugin.search_service.sort_by == "ACQUISITION_DATE"  # unchanged
     plugin.get_metadata.assert_not_called()
 
 
@@ -80,7 +96,7 @@ def test_template_mode_reloads_template_search_with_new_sort():
     plugin.on_metadata_header_clicked(_column("cloudCover"))
 
     # Template results re-fetch (first page) with the updated sort; the regular search is untouched.
-    assert plugin._search_sort_by == "CLOUD_COVER"
+    assert plugin.search_service.sort_by == "CLOUD_COVER"
     plugin._load_template_search_page.assert_called_once_with(0)
     plugin.get_metadata.assert_not_called()
 

--- a/tests/qgis/test_template_area_limit.py
+++ b/tests/qgis/test_template_area_limit.py
@@ -13,6 +13,7 @@ from qgis.core import QgsGeometry
 
 from mapflow.functional.app_context import AppContext
 from mapflow.functional.service.aoi_service import AoiService
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 
@@ -37,6 +38,7 @@ def test_set_processing_limit_stores_template_area_limit_in_sq_km():
     plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
     plugin.app_context = AppContext()
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
 
     plugin.set_processing_limit(_user_status_response())
 
@@ -50,6 +52,7 @@ def test_set_processing_limit_defaults_template_area_limit_to_zero_when_absent()
     plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
     plugin.app_context = AppContext()
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
 
     response = _user_status_response()
     payload = json.loads(response.readAll.return_value.data.return_value)
@@ -67,6 +70,7 @@ def test_create_search_template_blocks_when_aoi_exceeds_template_area_limit():
     plugin.replace_search_provider_index = MagicMock()
     plugin.alert = MagicMock()
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.processing_service = MagicMock()
     plugin.app_context = SimpleNamespace(
         aoi=MagicMock(),  # truthy AOI
@@ -109,6 +113,7 @@ def test_create_search_template_proceeds_when_limit_is_unknown():
     )
 
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.dlg.processingName.text.return_value = "My template"
     plugin.dlg.searchProvidersCombo.checkedItemsData.return_value = ["arcgis_world_imagery"]
     plugin.dlg.maxCloudCover.value.return_value = 50

--- a/tests/qgis/test_template_create_providers.py
+++ b/tests/qgis/test_template_create_providers.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 from qgis.core import QgsGeometry
 
 from mapflow.functional.service.aoi_service import AoiService
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 
@@ -40,6 +41,7 @@ def _plugin_ready_to_create_template(checked_providers):
     )
 
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.dlg.processingName.text.return_value = "My template"
     plugin.dlg.metadataFrom.dateTime.return_value.toUTC.return_value.toString.return_value = "2022-09-24T17:00:00.000Z"
     plugin.dlg.metadataTo.dateTime.return_value.toUTC.return_value.toString.return_value = "2026-09-24T17:00:00.000Z"
@@ -93,6 +95,7 @@ def test_providers_omitted_when_available_filter_is_off_even_if_selected():
 def test_selected_search_providers_respects_available_filter_checkbox():
     plugin = Mapflow.__new__(Mapflow)
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.dlg.searchProvidersCombo.checkedItemsData.return_value = ["arcgis_world_imagery"]
 
     plugin.dlg.hideUnavailableResults.isChecked.return_value = False

--- a/tests/qgis/test_template_errors_pagination.py
+++ b/tests/qgis/test_template_errors_pagination.py
@@ -6,7 +6,22 @@ from unittest.mock import MagicMock
 
 from mapflow.functional.service import processing_service as ps_mod
 from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.config import Config, ConfigColumns
+from mapflow.functional.service.search_service import SearchService
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
+
+
+def _search_service():
+    """Real, not mocked: these tests assert on the paging state it owns."""
+    return SearchService(iface=MagicMock(),
+                         app_context=MagicMock(),
+                         http=MagicMock(),
+                         plugin_dir="",
+                         config=Config,
+                         config_search_columns=ConfigColumns(),
+                         result_loader=MagicMock(),
+                         provider_service=MagicMock())
 
 
 def _error_response(message, code="BAD_REQUEST"):
@@ -66,26 +81,29 @@ def test_on_template_closed_resets_search_pagination():
     plugin = Mapflow.__new__(Mapflow)
     plugin.app_context = SimpleNamespace(open_template_results_id="x")
     plugin._template_search_aoi_filter = "aoi-1"
-    plugin.search_page_offset = 60
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
+    plugin.search_service = _search_service()
+    plugin.search_service.page_offset = 60
     plugin._remove_template_group = MagicMock()
     plugin.aoi_service = MagicMock()
 
     plugin.on_template_closed(None)
 
-    assert plugin.search_page_offset == 0
+    assert plugin.search_service.page_offset == 0
     plugin.dlg.enable_search_pages.assert_called_once_with(False)
 
 
 def test_load_template_search_starts_from_first_page():
     plugin = Mapflow.__new__(Mapflow)
-    plugin.search_page_offset = 30
-    plugin.search_page_limit = 30
     plugin.dlg = MagicMock()
+    plugin.search_service = _search_service()
+    plugin.search_service.page_offset = 30
+    plugin.search_service.page_limit = 30
     plugin.processing_service = MagicMock()
     plugin._aoi_ids_from_template = MagicMock(return_value=[])
 
     plugin._load_template_search(SimpleNamespace(id="t-1"))
 
-    assert plugin.search_page_offset == 0
+    assert plugin.search_service.page_offset == 0
     assert plugin.processing_service.api.get_template_images.call_args.kwargs["offset"] == 0

--- a/tests/qgis/test_template_group_and_preview.py
+++ b/tests/qgis/test_template_group_and_preview.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 from qgis.core import QgsProject
 
 from mapflow.functional.service.preview_service import PreviewService
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 
@@ -91,33 +92,31 @@ def test_finding_a_template_group_returns_the_one_ensure_made():
     assert plugin._find_template_group("T1", subgroup_name="AOI: North") is created
 
 
-def _plugin_for_preview(in_template_mode):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    plugin.preview_search_from_cell = MagicMock()
-    plugin.result_loader = MagicMock()
-    plugin.processing_service = SimpleNamespace(in_template_mode=in_template_mode)
-    return plugin
+def _search_view():
+    """The Preview-cell reconnect is `SearchView.connect_cell_preview` since the search
+    extraction — the connection lifecycle it manages is the view's dlg, not the plugin's."""
+    return SearchView(dlg=MagicMock(), config=MagicMock())
 
 
 def test_reconnect_cell_preview_disconnects_previous_first():
-    plugin = _plugin_for_preview(in_template_mode=False)
-    plugin.cell_preview_connection = object()
+    view = _search_view()
+    view._cell_preview_connection = object()  # a prior connection exists
+    handler = object()
 
-    plugin._reconnect_cell_preview()
+    view.connect_cell_preview(handler)
 
-    plugin.dlg.metadataTable.disconnect.assert_called_once()
-    plugin.dlg.metadataTable.cellClicked.connect.assert_called_once_with(
-        plugin.preview_search_from_cell)
+    view.dlg.metadataTable.disconnect.assert_called_once()
+    view.dlg.metadataTable.cellClicked.connect.assert_called_once_with(handler)
 
 
 def test_reconnect_cell_preview_first_time_no_disconnect_error():
-    plugin = _plugin_for_preview(in_template_mode=False)
-    # No prior cell_preview_connection: disconnect raises, must be swallowed.
+    view = _search_view()
+    # No prior connection: disconnect raises, must be swallowed.
+    view.dlg.metadataTable.disconnect.side_effect = TypeError
 
-    plugin._reconnect_cell_preview()
+    view.connect_cell_preview(object())
 
-    plugin.dlg.metadataTable.cellClicked.connect.assert_called_once()
+    view.dlg.metadataTable.cellClicked.connect.assert_called_once()
 
 
 def _preview_service(in_template_mode):

--- a/tests/qgis/test_template_search_footprints.py
+++ b/tests/qgis/test_template_search_footprints.py
@@ -16,6 +16,7 @@ from qgis.core import QgsProject
 
 from mapflow import mapflow as mapflow_module
 from mapflow.model.provider.default import ImagerySearchProvider
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 PLUGIN_DIR = os.path.dirname(mapflow_module.__file__)
@@ -47,6 +48,7 @@ def _plugin_with_search_provider(tmp_path, template_name="Template A"):
     plugin.tr = lambda text: text
     plugin.alert = MagicMock()
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     # fill_metadata_table is mocked, so no real rows exist -> the marker pass is a no-op.
     plugin.dlg.metadataTable.rowCount.return_value = 0
     plugin.plugin_dir = PLUGIN_DIR

--- a/tests/qgis/test_template_search_footprints.py
+++ b/tests/qgis/test_template_search_footprints.py
@@ -15,7 +15,9 @@ from unittest.mock import MagicMock, patch
 from qgis.core import QgsProject
 
 from mapflow import mapflow as mapflow_module
+from mapflow.config import Config, ConfigColumns
 from mapflow.model.provider.default import ImagerySearchProvider
+from mapflow.functional.service.search_service import SearchService
 from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
@@ -68,6 +70,16 @@ def _plugin_with_search_provider(tmp_path, template_name="Template A"):
         plugin_name="Mapflow",
         metadata_layer=None,
     )
+    # Real service: these tests assert on the footprints it stores and where it puts the layer.
+    plugin.search_service = SearchService(iface=MagicMock(),
+                                          app_context=plugin.app_context,
+                                          http=MagicMock(),
+                                          plugin_dir=PLUGIN_DIR,
+                                          config=Config,
+                                          config_search_columns=ConfigColumns(),
+                                          result_loader=plugin.result_loader,
+                                          provider_service=plugin.provider_service)
+    plugin.search_service.metadataLayerReady.connect(lambda _layer: None)
     return plugin
 
 
@@ -138,6 +150,15 @@ def test_monitor_skips_current_search_metadata_layer():
     metadata_layer = MagicMock()
     metadata_layer.id.return_value = "meta-1"
     plugin.app_context = SimpleNamespace(metadata_layer=metadata_layer)
+    # "is this the search-results layer?" is SearchService's answer since the search extraction.
+    plugin.search_service = SearchService(iface=MagicMock(),
+                                          app_context=plugin.app_context,
+                                          http=MagicMock(),
+                                          plugin_dir="",
+                                          config=Config,
+                                          config_search_columns=ConfigColumns(),
+                                          result_loader=MagicMock(),
+                                          provider_service=MagicMock())
 
     footprint_layer = MagicMock()  # same id as the current metadata layer -> skipped
     footprint_layer.id.return_value = "meta-1"

--- a/tests/qgis/test_template_search_pagination.py
+++ b/tests/qgis/test_template_search_pagination.py
@@ -5,25 +5,52 @@ page (preserving the AOI filter), rather than falling through to a regular searc
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.config import Config, ConfigColumns
+from mapflow.functional.service.search_service import SearchService
 from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
+
+
+def _service(page_limit=5):
+    service = SearchService(iface=MagicMock(),
+                            app_context=MagicMock(),
+                            http=MagicMock(),
+                            plugin_dir="",
+                            config=Config,
+                            config_search_columns=ConfigColumns(),
+                            result_loader=MagicMock(),
+                            provider_service=MagicMock())
+    service.page_offset = 0
+    service.page_limit = page_limit
+    return service
 
 
 def _plugin(in_template_mode=True):
     plugin = Mapflow.__new__(Mapflow)
     plugin.dlg = MagicMock()
     plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
-    plugin.search_page_offset = 0
-    plugin.search_page_limit = 5
+    plugin.search_service = _service()
     plugin._template_search_aoi_filter = None
     plugin.processing_service = SimpleNamespace(in_template_mode=in_template_mode, active_template=None)
     return plugin
 
 
+# The pager computation is `SearchService.update_pager`; turning its answer into enabled buttons
+# is `SearchView`. Wiring them here is what the plugin does, so the assertions stay on the dialog.
+
+def _pager(view):
+    """A service whose pager signals drive `view`, as mapflow.py wires them."""
+    service = _service()
+    service.pagerChanged.connect(view.show_pages)
+    service.pagerHidden.connect(view.hide_pages)
+    return service
+
+
 def test_pager_shown_and_first_page_disables_left():
     plugin = _plugin()
+    service = _pager(plugin.search_view)
 
-    plugin._update_search_pager(total=12, limit=5, offset=0)
+    service.update_pager(total=12, limit=5, offset=0)
 
     plugin.dlg.enable_search_pages.assert_called_once_with(True, 1, 3)
     plugin.dlg.searchLeftButton.setEnabled.assert_called_once_with(False)  # first page
@@ -32,8 +59,9 @@ def test_pager_shown_and_first_page_disables_left():
 
 def test_pager_last_page_disables_right():
     plugin = _plugin()
+    service = _pager(plugin.search_view)
 
-    plugin._update_search_pager(total=12, limit=5, offset=10)  # page 3 of 3
+    service.update_pager(total=12, limit=5, offset=10)  # page 3 of 3
 
     plugin.dlg.enable_search_pages.assert_called_once_with(True, 3, 3)
     plugin.dlg.searchRightButton.setEnabled.assert_called_once_with(False)
@@ -42,8 +70,20 @@ def test_pager_last_page_disables_right():
 
 def test_pager_hidden_when_single_page():
     plugin = _plugin()
+    service = _pager(plugin.search_view)
 
-    plugin._update_search_pager(total=4, limit=5, offset=0)
+    service.update_pager(total=4, limit=5, offset=0)
+
+    plugin.dlg.enable_search_pages.assert_called_once_with(False)
+
+
+def test_pager_hidden_when_results_exactly_fill_one_page():
+    """The boundary: `total == limit` is still one page. A `>=` here would show a two-page pager
+    whose second page is empty — and `total < limit` alone does not catch that."""
+    plugin = _plugin()
+    service = _pager(plugin.search_view)
+
+    service.update_pager(total=5, limit=5, offset=0)
 
     plugin.dlg.enable_search_pages.assert_called_once_with(False)
 
@@ -52,7 +92,7 @@ def test_next_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
     plugin._load_template_search_page = MagicMock()
     plugin.get_metadata = MagicMock()
-    plugin.search_page_offset = 0
+    plugin.search_service.page_offset = 0
 
     plugin.show_search_next_page()
 
@@ -64,7 +104,7 @@ def test_prev_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
     plugin._load_template_search_page = MagicMock()
     plugin.get_metadata = MagicMock()
-    plugin.search_page_offset = 10
+    plugin.search_service.page_offset = 10
 
     plugin.show_search_previous_page()
 
@@ -75,7 +115,7 @@ def test_next_page_outside_template_mode_uses_regular_search():
     plugin = _plugin(in_template_mode=False)
     plugin._load_template_search_page = MagicMock()
     plugin.get_metadata = MagicMock()
-    plugin.search_page_offset = 5
+    plugin.search_service.page_offset = 5
 
     plugin.show_search_next_page()
 

--- a/tests/qgis/test_template_search_pagination.py
+++ b/tests/qgis/test_template_search_pagination.py
@@ -5,12 +5,14 @@ page (preserving the AOI filter), rather than falling through to a regular searc
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 
 def _plugin(in_template_mode=True):
     plugin = Mapflow.__new__(Mapflow)
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.search_page_offset = 0
     plugin.search_page_limit = 5
     plugin._template_search_aoi_filter = None

--- a/tests/qgis/test_template_updates.py
+++ b/tests/qgis/test_template_updates.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from mapflow.functional.geometry import geometry_from_geojson
+from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 from mapflow.schema.template import TemplateAoiDTO, AoiProcessingLink
 
@@ -25,6 +26,7 @@ def _plugin_f1():
     plugin = Mapflow.__new__(Mapflow)
     plugin.tr = lambda t: t
     plugin.dlg = MagicMock()
+    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.iface = MagicMock()
     plugin.app_context = SimpleNamespace(plugin_name="Mapflow")
     plugin.dlg.metadataFrom.dateTime.return_value.toUTC.return_value.toString.return_value = "2025-01-01T00:00:00.000Z"


### PR DESCRIPTION
- **docs: retire the merged preview step and scope imagery search**
- **refactor: give the imagery-search tab a view**
- **docs: stop the volume-limit contract explaining exec() twice**
