### PR TITLE
refactor: extract the local filter into a functional-tier service

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -38,27 +38,15 @@ leaf-first so each extraction depends only on what already moved.
 
 Service and controller boundaries are tabulated in `spec/007_architecture.md`.
 
-[ready-for-review] Extract imagery search → `SearchService` + `SearchController` + `view/search_view.py`
-Boundary drawn at the gate, because most search-*named* code is not imagery search:
-in scope are the request and its results (`get_metadata`, `request_mapflow_metadata` + callback
-+ error handler, `display_metadata_geojson_layer`, `clear_metadata`, `_is_search_metadata_layer`),
-the footprints layer, pagination, sort, the search-provider selection, the search-tab mode
-controls, and the four preview slots the preview step deliberately left behind
-(`preview`, `preview_search_from_cell`, `preview_or_search`, `_reconnect_cell_preview`).
-Out of scope and deferred to the two steps below: the local filter, and everything that operates
-on a *template's* search.
-`_build_search_params` turns out to be called only from template creation and template update,
-never from `get_metadata` — so it is template code despite the name. That single fact is what
-keeps this step from swallowing the two after it.
-First step with a real `view/` rather than deferring widget reads, so larger than AOI or preview.
-`SearchController` starts small on purpose — the three preview-dispatch handlers and their
-wiring. A controller owns a connection only when it owns the handler, and the run/sort/pagination
-handlers still call unextracted collaborators (provider selection, template loader, local
-filter); their connections stay in `mapflow.py` and the controller grows as those handlers move,
-the same way `ProcessingController` began with AOI selection alone.
-[ ] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
-Bigger than it looks: `apply_local_filter` alone has 10 widget connections and
-`tests/qgis/test_local_filter.py` has 39 tests.
+[ready-for-review] Extract the local filter → `LocalFilterService` (pure computation; functional-tier tests)
+Scope faithful to "pure computation": the per-feature filtering (`unfit_indices`), the widen
+`(!)` comparison (`widen_messages`), and the pure helpers (`product_category`, `to_float`,
+`passes_optional`, `utc_date_from_iso`) move to a widget-free, QGIS-free service tested in the
+functional tier. What stays in `mapflow.py`: the criteria assembly (`_allowed_provider_set`,
+`_product_category_filter`, the widget reads → `FilterCriteria`) because it touches `app_context`,
+and the result application (`_mark_unfit_rows`, `_hide_unfit_footprints`, `_update_widen_indicator`,
+`reset_filters`, the `apply_local_filter` orchestration) because it drives the table and layer. A
+later view pass can take the application; this step is the pure-math extraction.
 [ ] Extract templates → `TemplateService` + `TemplateController` (largest domain, ~55 methods
     in `mapflow.py` plus the template half of `processing_service.py`)
 Takes `filter_search_by_selected_aoi` with it. The AOI step assigned that to `SearchService`;

--- a/mapflow/functional/service/local_filter_service.py
+++ b/mapflow/functional/service/local_filter_service.py
@@ -1,0 +1,187 @@
+"""Client-side narrowing of an already-fetched imagery-search result set.
+
+Pure computation: features in, the set of results that fail the current filter out; and the
+comparison that decides whether the filter widgets now ask for MORE than the last search fetched
+(the widen `(!)` indicator). No widget, no QGIS, no network — so it is tested in the functional
+tier. The widget reads that produce a `FilterCriteria`, and the table/layer changes that act on
+the result, stay with the caller (`mapflow.py`), which is why they are not here.
+
+`spec/007_architecture.md` § Services: LocalFilterService owns "client-side narrowing of an
+already-fetched result set, and the 'filter is wider than what was fetched' warning".
+"""
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Set
+
+from PyQt5.QtCore import QDate, QDateTime, QObject, Qt
+
+from ...schema.catalog import ProductType
+
+
+def utc_date_from_iso(value: Optional[str]) -> Optional[QDate]:
+    """Parse an ISO-8601 timestamp (as stored in ``searchParams`` or a result's
+    ``acquisitionDate``) into a UTC QDate, or None when absent/unparseable.
+
+    A free function, not a method: the template baseline (`mapflow.py`, → TemplateService) needs
+    the same parse, and a pure date conversion is no reason for template code to depend on the
+    filter service.
+    """
+    if not value:
+        return None
+    parsed = QDateTime.fromString(value, Qt.ISODateWithMs)
+    if not parsed.isValid():
+        parsed = QDateTime.fromString(value, Qt.ISODate)
+    return parsed.toUTC().date() if parsed.isValid() else None
+
+
+@dataclass
+class FilterCriteria:
+    """The filter-widget state, resolved to values, that a local filter pass needs.
+
+    Assembled by the caller from the widgets and `app_context` (the provider set folds in the
+    user's available providers), so the service reads neither. ``None`` on ``provider_set`` /
+    ``product_filter`` means "no filtering on that axis"; the cloud/intersection sentinels
+    (>=100, <=0) match the widgets' "off" positions.
+    """
+    date_from: Optional[QDate]
+    date_to: Optional[QDate]
+    max_cloud_cover: float
+    min_intersection: float
+    off_nadir_filtered: bool
+    min_off_nadir: float
+    max_off_nadir: float
+    provider_set: Optional[Set[str]]   # lowercased api-names to keep, or None for all
+    product_filter: Optional[Set[str]]  # {'MOSAIC'} / {'IMAGE'}, or None for all
+
+
+class LocalFilterService(QObject):
+
+    @staticmethod
+    def to_float(value) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def passes_optional(value, predicate: Callable) -> bool:
+        """A metadata filter clause where a missing value matches any condition: ``None`` passes,
+        otherwise the row must satisfy ``predicate``. My Imagery results carry mostly-empty
+        metadata (no date/cloud), which the server counts as matching every filter; the local
+        filter follows the same rule so user imagery is not hidden when a filter is set."""
+        return value is None or predicate(value)
+
+    @staticmethod
+    def product_category(product_type) -> str:
+        """Map a result's ``productType`` to a Mosaic/Image category: 'Mosaic' -> MOSAIC, anything
+        else -> IMAGE.
+        #WARNING: ``productType`` is free text (e.g. 'OPTICAL', 'Image', ''); this
+        Mosaic-vs-everything-else split is a product decision and may misclassify some providers."""
+        if str(product_type).strip().lower() == ProductType.mosaic.lower():
+            return ProductType.mosaic.upper()
+        return ProductType.image.upper()
+
+    def unfit_indices(self, features: list, criteria: FilterCriteria) -> Set[int]:
+        """``local_index`` of every result (GeoJSON feature) that FAILS ``criteria``: date range,
+        cloud cover, off-nadir range, provider selection / availability, product type, and (where
+        an intersection reference exists) min intersection %. A per-feature parsing error never
+        hides the row (treated as fit)."""
+        unfit: Set[int] = set()
+        for feature in features:
+            props = feature.get("properties", {})
+            local_index = props.get("local_index")
+            if local_index is None:
+                continue
+            try:
+                # Missing metadata matches any condition: user imagery (My Imagery search) has no
+                # acquisition date / cloud cover, and the server already treats a NULL column as
+                # satisfying every predicate — the local filter must not then demote those rows.
+                acquisition_date = utc_date_from_iso(props.get("acquisitionDate"))
+                date_ok = self.passes_optional(
+                    acquisition_date, lambda d: criteria.date_from <= d <= criteria.date_to)
+                cloud_cover = self.to_float(props.get("cloudCover"))
+                # 100% = don't filter by cloud at all.
+                cloud_ok = criteria.max_cloud_cover >= 100 or self.passes_optional(
+                    cloud_cover, lambda c: c <= criteria.max_cloud_cover)
+                off_nadir = self.to_float(props.get("offNadirAngle"))
+                # Full 0-30 range = don't filter; a missing angle passes the range check.
+                off_nadir_ok = not criteria.off_nadir_filtered or self.passes_optional(
+                    off_nadir, lambda a: criteria.min_off_nadir <= a <= criteria.max_off_nadir)
+                if criteria.provider_set is None:
+                    provider_ok = True
+                else:
+                    provider_name = props.get("providerName")
+                    provider_ok = (provider_name is not None
+                                   and str(provider_name).lower() in criteria.provider_set)
+                product_ok = (criteria.product_filter is None
+                              or self.product_category(props.get("productType"))
+                              in criteria.product_filter)
+                # Intersection % comes from the backend (aoiIntersectionPercent, computed against
+                # the searched AOI / the template's AOIs), not recomputed locally against a
+                # sub-selection. 0 = don't filter; a missing value passes (like other metadata).
+                if criteria.min_intersection <= 0:
+                    intersection_ok = True
+                else:
+                    aoi_intersection = self.to_float(props.get("aoiIntersectionPercent"))
+                    intersection_ok = self.passes_optional(
+                        aoi_intersection, lambda pct: pct >= criteria.min_intersection)
+                fit = (date_ok and cloud_ok and off_nadir_ok and provider_ok
+                       and product_ok and intersection_ok)
+            except (AttributeError, TypeError, ValueError):
+                # Metadata that is not the shape this code expects: a non-mapping `properties`
+                # raises AttributeError, a value of the wrong type raises TypeError on the
+                # comparisons, an unparseable one ValueError.
+                fit = True  # never hide a row because of a parsing error
+            if not fit:
+                unfit.add(local_index)
+        return unfit
+
+    def widen_messages(self, current: dict, baseline: Optional[dict]) -> List[str]:
+        """Human-readable list of the ways ``current`` filter values are WIDER than the
+        ``baseline`` that fetched the current results — relaxing them cannot surface more images
+        without a new search. Empty when none, or when there is no baseline. Both dicts are the
+        shape `mapflow.py` builds for a search baseline."""
+        if not baseline:
+            return []
+        messages = []
+        cur_from, cur_to = current.get("date_from"), current.get("date_to")
+        base_from, base_to = baseline.get("date_from"), baseline.get("date_to")
+        if base_from is not None and cur_from is not None and cur_from < base_from:
+            messages.append(self.tr("Start date {cur} is earlier than searched ({base})").format(
+                cur=cur_from.toString("yyyy-MM-dd"), base=base_from.toString("yyyy-MM-dd")))
+        if base_to is not None and cur_to is not None and cur_to > base_to:
+            messages.append(self.tr("End date {cur} is later than searched ({base})").format(
+                cur=cur_to.toString("yyyy-MM-dd"), base=base_to.toString("yyyy-MM-dd")))
+        cur_cloud, base_cloud = current.get("max_cloud_cover"), baseline.get("max_cloud_cover")
+        if base_cloud is not None and cur_cloud is not None and cur_cloud > base_cloud:
+            messages.append(self.tr("Max cloud cover {cur}% is higher than searched ({base}%)")
+                            .format(cur=cur_cloud, base=int(base_cloud)))
+        cur_int, base_int = current.get("min_intersection"), baseline.get("min_intersection")
+        if base_int is not None and cur_int is not None and cur_int < base_int:
+            messages.append(self.tr("Min intersection {cur}% is lower than searched ({base}%)")
+                            .format(cur=cur_int, base=int(base_int)))
+        cur_off_lo, cur_off_hi = current.get("min_off_nadir"), current.get("max_off_nadir")
+        base_off_lo, base_off_hi = baseline.get("min_off_nadir"), baseline.get("max_off_nadir")
+        if base_off_lo is not None and base_off_hi is not None \
+                and cur_off_lo is not None and cur_off_hi is not None \
+                and (cur_off_lo < base_off_lo or cur_off_hi > base_off_hi):
+            messages.append(self.tr("Off-nadir range {lo}-{hi}° is wider than searched ({blo}-{bhi}°)")
+                            .format(lo=cur_off_lo, hi=cur_off_hi,
+                                    blo=int(base_off_lo), bhi=int(base_off_hi)))
+        base_products = baseline.get("product_types")
+        if base_products:
+            extra = [p for p in (current.get("product_types") or []) if p not in base_products]
+            if extra:
+                messages.append(self.tr("Product type(s) not searched: {extra}").format(
+                    extra=", ".join(extra)))
+        base_providers = baseline.get("data_providers")
+        if base_providers:
+            cur_providers = current.get("data_providers") or []
+            if not cur_providers:
+                messages.append(self.tr("Showing all providers, but search was limited to: {base}")
+                                .format(base=", ".join(base_providers)))
+            else:
+                extra = [p for p in cur_providers if p not in base_providers]
+                if extra:
+                    messages.append(self.tr("Provider(s) not searched: {extra}").format(
+                        extra=", ".join(extra)))
+        return messages

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -10,7 +10,7 @@ from typing import List, Optional, Callable
 from osgeo import ogr
 
 from PyQt5.QtCore import (
-    QCoreApplication, QDate, QDateTime, QObject, Qt,
+    QCoreApplication, QDate, QObject, Qt,
     QTimer, QTranslator
 )
 from PyQt5.QtGui import QBrush, QColor, QIcon
@@ -41,6 +41,9 @@ from .functional.controller.project_processing_controller import ProjectProcessi
 from .functional.controller.processing_controller import ProcessingController
 from .functional.controller.search_controller import SearchController
 from .functional.service.aoi_service import AoiService
+from .functional.service.local_filter_service import (FilterCriteria,
+                                                      LocalFilterService,
+                                                      utc_date_from_iso)
 from .functional.service.preview_service import PreviewService
 from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
@@ -301,6 +304,7 @@ class Mapflow(QObject):
         # down with the provider-dialog wiring; construction order is load-bearing here.
         self.config_search_columns = ConfigColumns()
         self.search_view = SearchView(dlg=self.dlg, config=self.config)
+        self.local_filter_service = LocalFilterService()
         self.search_service = SearchService(iface=self.iface,
                                             app_context=self.app_context,
                                             http=self.http,
@@ -1314,65 +1318,25 @@ class Mapflow(QObject):
         self._restore_search_sort_indicator()
 
     def _unfit_local_indices(self, features: list) -> set:
-        """``local_index`` of every result (GeoJSON feature) that FAILS the active filter
-        widgets: date range, cloud cover, off-nadir angle range, provider selection / availability,
-        product type (Mosaic vs Image), and (where an intersection reference exists) min intersection %. A
-        per-feature parsing error never hides the row (treated as fit)."""
-        from_ = self.dlg.metadataFrom.date()
-        to = self.dlg.metadataTo.date()
-        max_cloud_cover = self.dlg.maxCloudCover.value()
-        min_intersection = self.dlg.minIntersection.value()
+        """Which results fail the current filter, computed by `LocalFilterService`. This wrapper
+        assembles the criteria from the widgets and `app_context`; the computation itself is
+        widget-free and functional-tier tested."""
+        return self.local_filter_service.unfit_indices(features, self._filter_criteria())
+
+    def _filter_criteria(self) -> FilterCriteria:
+        """The filter widgets + available-provider context, resolved to a `FilterCriteria`."""
         min_off_nadir, max_off_nadir = self.dlg.off_nadir_range()
-        off_nadir_filtered = not self.dlg.off_nadir_is_full_range()  # full 0-30 range = no filter
-        provider_set = self._allowed_provider_set()  # None = show all
-        product_filter = self._product_category_filter()  # None = show all
-        unfit = set()
-        for feature in features:
-            props = feature.get("properties", {})
-            local_index = props.get("local_index")
-            if local_index is None:
-                continue
-            try:
-                # Missing metadata matches any condition: user imagery (My Imagery search) has no
-                # acquisition date / cloud cover, and the server already treats a NULL column as
-                # satisfying every predicate — the local filter must not then demote those rows.
-                acquisition_date = self._utc_date_from_iso(props.get("acquisitionDate"))
-                date_ok = self._passes_optional(acquisition_date, lambda d: from_ <= d <= to)
-                cloud_cover = self._to_float(props.get("cloudCover"))
-                # 100% = don't filter by cloud at all.
-                cloud_ok = max_cloud_cover >= 100 or self._passes_optional(
-                    cloud_cover, lambda c: c <= max_cloud_cover)
-                off_nadir = self._to_float(props.get("offNadirAngle"))
-                # Full 0-30 range = don't filter; a missing angle passes the range check.
-                off_nadir_ok = not off_nadir_filtered or self._passes_optional(
-                    off_nadir, lambda a: min_off_nadir <= a <= max_off_nadir)
-                if provider_set is None:
-                    provider_ok = True
-                else:
-                    provider_name = props.get("providerName")
-                    provider_ok = (provider_name is not None
-                                   and str(provider_name).lower() in provider_set)
-                product_ok = (product_filter is None
-                              or self._product_category(props.get("productType")) in product_filter)
-                # Intersection % comes from the backend (aoiIntersectionPercent, computed against
-                # the searched AOI / the template's AOIs), not recomputed locally against a
-                # sub-selection. 0 = don't filter; a missing value passes (like other metadata).
-                if min_intersection <= 0:
-                    intersection_ok = True
-                else:
-                    aoi_intersection = self._to_float(props.get("aoiIntersectionPercent"))
-                    intersection_ok = self._passes_optional(
-                        aoi_intersection, lambda pct: pct >= min_intersection)
-                fit = (date_ok and cloud_ok and off_nadir_ok and provider_ok
-                       and product_ok and intersection_ok)
-            except (AttributeError, TypeError, ValueError):
-                # Metadata that is not the shape this code expects: a non-mapping `properties`
-                # raises AttributeError, a value of the wrong type raises TypeError on the
-                # comparisons, an unparseable one ValueError.
-                fit = True  # never hide a row because of a parsing error
-            if not fit:
-                unfit.add(local_index)
-        return unfit
+        return FilterCriteria(
+            date_from=self.dlg.metadataFrom.date(),
+            date_to=self.dlg.metadataTo.date(),
+            max_cloud_cover=self.dlg.maxCloudCover.value(),
+            min_intersection=self.dlg.minIntersection.value(),
+            off_nadir_filtered=not self.dlg.off_nadir_is_full_range(),  # full 0-30 = no filter
+            min_off_nadir=min_off_nadir,
+            max_off_nadir=max_off_nadir,
+            provider_set=self._allowed_provider_set(),
+            product_filter=self._product_category_filter(),
+        )
 
     def _allowed_provider_set(self) -> Optional[set]:
         """Lowercased provider api-names a result may come from for the LOCAL filter, or ``None``
@@ -1399,31 +1363,6 @@ class Mapflow(QObject):
         if mosaic == image:  # both or neither -> show all
             return None
         return {ProductType.mosaic.upper()} if mosaic else {ProductType.image.upper()}
-
-    @staticmethod
-    def _product_category(product_type) -> str:
-        """Map a result's ``productType`` to a Mosaic/Image category: 'Mosaic' -> MOSAIC, anything
-        else -> IMAGE.
-        #WARNING: ``productType`` is free text (e.g. 'OPTICAL', 'Image', ''); this
-        Mosaic-vs-everything-else split is a product decision and may misclassify some providers."""
-        if str(product_type).strip().lower() == ProductType.mosaic.lower():
-            return ProductType.mosaic.upper()
-        return ProductType.image.upper()
-
-    @staticmethod
-    def _to_float(value) -> Optional[float]:
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-
-    @staticmethod
-    def _passes_optional(value, predicate) -> bool:
-        """A metadata filter clause where a missing value matches any condition: ``None`` passes,
-        otherwise the row must satisfy ``predicate``. My Imagery results carry mostly-empty
-        metadata (no date/cloud), which the server counts as matching every filter; the local
-        filter follows the same rule so user imagery is not hidden when a filter is set."""
-        return value is None or predicate(value)
 
     def _mark_unfit_rows(self, unfit: set) -> None:
         """Grey-out and disable (non-selectable) the rows whose image was filtered out; restore
@@ -1480,58 +1419,11 @@ class Mapflow(QObject):
             button.setVisible(False)
 
     def _widened_filter_messages(self) -> List[str]:
-        """Human-readable list of the ways the current filter widgets are wider than the
-        baseline that fetched the current results (empty when none / no baseline)."""
-        baseline = self.app_context.search_baseline_filters
-        if not baseline:
-            return []
-        messages = []
-        cur_from = self.dlg.metadataFrom.date()
-        cur_to = self.dlg.metadataTo.date()
-        base_from = baseline.get("date_from")
-        base_to = baseline.get("date_to")
-        if base_from is not None and cur_from < base_from:
-            messages.append(self.tr("Start date {cur} is earlier than searched ({base})").format(
-                cur=cur_from.toString("yyyy-MM-dd"), base=base_from.toString("yyyy-MM-dd")))
-        if base_to is not None and cur_to > base_to:
-            messages.append(self.tr("End date {cur} is later than searched ({base})").format(
-                cur=cur_to.toString("yyyy-MM-dd"), base=base_to.toString("yyyy-MM-dd")))
-        cur_cloud = self.dlg.maxCloudCover.value()
-        base_cloud = baseline.get("max_cloud_cover")
-        if base_cloud is not None and cur_cloud > base_cloud:
-            messages.append(self.tr("Max cloud cover {cur}% is higher than searched ({base}%)").format(
-                cur=cur_cloud, base=int(base_cloud)))
-        cur_int = self.dlg.minIntersection.value()
-        base_int = baseline.get("min_intersection")
-        if base_int is not None and cur_int < base_int:
-            messages.append(self.tr("Min intersection {cur}% is lower than searched ({base}%)").format(
-                cur=cur_int, base=int(base_int)))
-        cur_off_lo, cur_off_hi = self.dlg.off_nadir_range()
-        base_off_lo = baseline.get("min_off_nadir")
-        base_off_hi = baseline.get("max_off_nadir")
-        if base_off_lo is not None and base_off_hi is not None \
-                and (cur_off_lo < base_off_lo or cur_off_hi > base_off_hi):
-            messages.append(self.tr("Off-nadir range {lo}-{hi}° is wider than searched ({blo}-{bhi}°)").format(
-                lo=cur_off_lo, hi=cur_off_hi, blo=int(base_off_lo), bhi=int(base_off_hi)))
-        base_products = baseline.get("product_types")
-        if base_products:
-            extra = [p for p in (str(pt).upper() for pt in self.selected_search_product_types())
-                     if p not in base_products]
-            if extra:
-                messages.append(self.tr("Product type(s) not searched: {extra}").format(
-                    extra=", ".join(extra)))
-        base_providers = baseline.get("data_providers")
-        if base_providers:
-            cur_providers = self.selected_search_providers() or []
-            if not cur_providers:
-                messages.append(self.tr("Showing all providers, but search was limited to: {base}").format(
-                    base=", ".join(base_providers)))
-            else:
-                extra = [p for p in cur_providers if p not in base_providers]
-                if extra:
-                    messages.append(self.tr("Provider(s) not searched: {extra}").format(
-                        extra=", ".join(extra)))
-        return messages
+        """The ways the current filter widgets are wider than the baseline that fetched the
+        current results. The comparison is `LocalFilterService`; this passes the current widget
+        values (as a baseline snapshot) and the fetched baseline."""
+        return self.local_filter_service.widen_messages(
+            self._current_filter_baseline(), self.app_context.search_baseline_filters)
 
     @staticmethod
     def _format_widen_message(messages: List[str]) -> str:
@@ -1574,8 +1466,8 @@ class Mapflow(QObject):
         if isinstance(sp, dict):
             sp = SearchParams.from_dict(sp)
         return {
-            "date_from": self._utc_date_from_iso(sp.acquisitionDateFrom),
-            "date_to": self._utc_date_from_iso(sp.acquisitionDateTo),
+            "date_from": utc_date_from_iso(sp.acquisitionDateFrom),
+            "date_to": utc_date_from_iso(sp.acquisitionDateTo),
             "max_cloud_cover": sp.maxCloudCover,
             "min_intersection": sp.minAoiIntersectionPercent,
             "min_off_nadir": sp.minOffNadirAngle,
@@ -2929,10 +2821,10 @@ class Mapflow(QObject):
         if isinstance(search_params, dict):
             search_params = SearchParams.from_dict(search_params)
 
-        date_from = self._utc_date_from_iso(search_params.acquisitionDateFrom)
+        date_from = utc_date_from_iso(search_params.acquisitionDateFrom)
         if date_from is not None:
             self.dlg.metadataFrom.setDate(date_from)
-        date_to = self._utc_date_from_iso(search_params.acquisitionDateTo)
+        date_to = utc_date_from_iso(search_params.acquisitionDateTo)
         if date_to is not None:
             self.dlg.metadataTo.setDate(date_to)
         if search_params.maxCloudCover is not None:
@@ -2949,16 +2841,6 @@ class Mapflow(QObject):
             self.dlg.searchMosaicCheckBox.setChecked(ProductType.mosaic.upper() in product_types)
             self.dlg.searchImageCheckBox.setChecked(ProductType.image.upper() in product_types)
         self._apply_search_providers_to_combo(search_params.dataProviders)
-
-    @staticmethod
-    def _utc_date_from_iso(value: Optional[str]) -> Optional[QDate]:
-        """Parse an ISO-8601 timestamp (as stored in ``searchParams``) into a UTC QDate."""
-        if not value:
-            return None
-        parsed = QDateTime.fromString(value, Qt.ISODateWithMs)
-        if not parsed.isValid():
-            parsed = QDateTime.fromString(value, Qt.ISODate)
-        return parsed.toUTC().date() if parsed.isValid() else None
 
     def _apply_search_providers_to_combo(self, data_providers: Optional[List[str]]):
         """Mirror ``selected_search_providers``: check the combo items whose api-name is in

--- a/tests/functional/test_local_filter.py
+++ b/tests/functional/test_local_filter.py
@@ -1,0 +1,265 @@
+"""Functional-tier tests for LocalFilterService — the pure client-side narrowing of an
+already-fetched imagery-search / template result set, and the widen `(!)` comparison.
+
+Pure computation, so no QGIS runtime: a `FilterCriteria` carries the resolved widget state in,
+and features are plain GeoJSON dicts (the same shape that fills the table). The widget reads that
+build a `FilterCriteria`, and the table/layer changes that act on the result, live in
+`mapflow.py` and are covered in `tests/qgis/test_local_filter.py`.
+
+Ported from that qgis-tier file when the computation moved to LocalFilterService; the behaviours
+(missing metadata matches any filter, backend intersection %, string cloud, Mosaic/Image split)
+are unchanged.
+"""
+from PyQt5.QtCore import QDate
+
+from mapflow.functional.service.local_filter_service import FilterCriteria, LocalFilterService
+
+
+def _criteria(date_from=None, date_to=None, max_cloud_cover=50, min_intersection=50,
+              off_nadir_filtered=False, min_off_nadir=0, max_off_nadir=30,
+              provider_set=None, product_filter=None) -> FilterCriteria:
+    return FilterCriteria(
+        date_from=date_from or QDate(2025, 1, 1),
+        date_to=date_to or QDate(2025, 12, 31),
+        max_cloud_cover=max_cloud_cover,
+        min_intersection=min_intersection,
+        off_nadir_filtered=off_nadir_filtered,
+        min_off_nadir=min_off_nadir,
+        max_off_nadir=max_off_nadir,
+        provider_set=provider_set,
+        product_filter=product_filter,
+    )
+
+
+def _feature(local_index, date, cloud, intersection=None):
+    props = {"local_index": local_index, "acquisitionDate": date, "cloudCover": cloud}
+    if intersection is not None:
+        props["aoiIntersectionPercent"] = intersection
+    return {"type": "Feature", "properties": props}
+
+
+def _features():
+    """Index 0 fits; 1 out of date range; 2 too cloudy; 3 low backend AOI intersection (~1%)."""
+    return [
+        _feature(0, "2025-03-01T00:00:00Z", 10, intersection=100),
+        _feature(1, "2020-01-01T00:00:00Z", 5, intersection=100),
+        _feature(2, "2025-03-01T00:00:00Z", 90, intersection=100),
+        _feature(3, "2025-03-01T00:00:00Z", 10, intersection=1),
+    ]
+
+
+def _service():
+    return LocalFilterService()
+
+
+# ---------- off-nadir ----------
+
+def _off_nadir_feature(local_index, angle):
+    return {"type": "Feature", "properties": {
+        "local_index": local_index, "acquisitionDate": "2025-03-01T00:00:00Z",
+        "cloudCover": 0, "offNadirAngle": angle}}
+
+
+def test_off_nadir_out_of_range_demoted_missing_passes():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100,
+                         off_nadir_filtered=True, min_off_nadir=0, max_off_nadir=5)
+    features = [
+        _off_nadir_feature(0, 3),     # within [0, 5] -> fit
+        _off_nadir_feature(1, 10),    # outside -> unfit
+        _off_nadir_feature(2, None),  # missing angle -> passes (missing matches any)
+    ]
+
+    assert _service().unfit_indices(features, criteria) == {1}
+
+
+def test_off_nadir_full_range_does_not_filter():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100, off_nadir_filtered=False)
+
+    # Even an angle beyond the slider maximum passes when the range is full (= no filter).
+    assert _service().unfit_indices([_off_nadir_feature(0, 45)], criteria) == set()
+
+
+# ---------- date / cloud / intersection ----------
+
+def test_unfit_indices_reject_date_cloud_and_intersection():
+    unfit = _service().unfit_indices(_features(), _criteria())
+    # 0 passes; 1 (date), 2 (cloud), 3 (intersection) fail.
+    assert unfit == {1, 2, 3}
+
+
+def test_unfit_matches_displayed_cloud_value():
+    # At 50% the 90-cloud image is out and the 10-cloud one stays.
+    unfit = _service().unfit_indices(_features(), _criteria(min_intersection=0, max_cloud_cover=50))
+    assert 2 in unfit and 0 not in unfit
+
+
+def test_unfit_handles_string_cloud_without_crashing():
+    # Cloud arriving as a string must not abort the whole pass.
+    features = _features()
+    features[2]["properties"]["cloudCover"] = "90"  # string, still > 50
+    unfit = _service().unfit_indices(features, _criteria(min_intersection=0, max_cloud_cover=50))
+    assert 2 in unfit
+
+
+def test_intersection_not_applied_when_min_is_zero():
+    unfit = _service().unfit_indices(_features(), _criteria(min_intersection=0))
+    # Only date (1) and cloud (2) fail; the tiny-overlap image (3) now passes.
+    assert unfit == {1, 2}
+
+
+def test_cloud_100_disables_cloud_filter():
+    unfit = _service().unfit_indices(_features(), _criteria(min_intersection=0, max_cloud_cover=100))
+    # Cloud no longer filters (image 2 passes); only the out-of-range date (1) fails.
+    assert unfit == {1}
+
+
+def test_intersection_uses_backend_percent():
+    # The filter compares the backend aoiIntersectionPercent to the widget; footprint geometry
+    # is irrelevant.
+    features = [
+        _feature(0, "2025-03-01T00:00:00Z", 10, intersection=80),
+        _feature(1, "2025-03-01T00:00:00Z", 10, intersection=20),
+    ]
+    assert _service().unfit_indices(features, _criteria(min_intersection=50)) == {1}
+
+
+def test_missing_intersection_percent_passes():
+    # A result without a backend intersection value must not be hidden (missing matches any).
+    feature = _feature(0, "2025-03-01T00:00:00Z", 10)
+    assert _service().unfit_indices([feature], _criteria(min_intersection=50)) == set()
+
+
+# ---------- My Imagery: missing metadata matches any filter ----------
+
+def _my_imagery_feature(local_index):
+    return _feature(local_index, None, None)
+
+
+def test_missing_date_passes_date_filter():
+    unfit = _service().unfit_indices([_my_imagery_feature(0)],
+                                     _criteria(min_intersection=0, max_cloud_cover=100))
+    assert unfit == set()
+
+
+def test_missing_cloud_passes_cloud_filter():
+    unfit = _service().unfit_indices([_my_imagery_feature(0)],
+                                     _criteria(min_intersection=0, max_cloud_cover=30))
+    assert unfit == set()
+
+
+def test_missing_date_and_cloud_pass_with_both_filters_active():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=30,
+                         date_from=QDate(2025, 1, 1), date_to=QDate(2025, 2, 1))
+    assert _service().unfit_indices([_my_imagery_feature(0)], criteria) == set()
+
+
+def test_populated_values_still_filter_both_directions():
+    # Guard against over-correcting into "never filter": real out-of-range values must still fail.
+    criteria = _criteria(min_intersection=0, max_cloud_cover=50,
+                         date_from=QDate(2025, 1, 1), date_to=QDate(2025, 12, 31))
+    features = [
+        _feature(0, "2025-06-01T00:00:00Z", 10),   # in range, clear
+        _feature(1, "2019-06-01T00:00:00Z", 10),   # date too old
+        _feature(2, "2025-06-01T00:00:00Z", 80),   # too cloudy
+    ]
+    assert _service().unfit_indices(features, criteria) == {1, 2}
+
+
+# ---------- provider / product-type ----------
+
+def _feature_p(local_index, provider, product_type="OPTICAL"):
+    f = _feature(local_index, "2025-03-01T00:00:00Z", 10)
+    f["properties"]["providerName"] = provider
+    f["properties"]["productType"] = product_type
+    return f
+
+
+def test_provider_filter_greys_disallowed_providers():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100,
+                         provider_set={"orbview_svn1"})
+    features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "orbview_svn3")]
+    assert _service().unfit_indices(features, criteria) == {1}  # svn3 not allowed
+
+
+def test_provider_filter_is_case_insensitive():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100,
+                         provider_set={"orbview_svn1"})
+    assert _service().unfit_indices([_feature_p(0, "OrbView_SVN1")], criteria) == set()
+
+
+def test_provider_filter_off_shows_all():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100, provider_set=None)
+    features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "orbview_svn3")]
+    assert _service().unfit_indices(features, criteria) == set()
+
+
+def test_product_type_mosaic_only_greys_images():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100, product_filter={"MOSAIC"})
+    features = [_feature_p(0, "p", product_type="Mosaic"),
+               _feature_p(1, "p", product_type="OPTICAL")]
+    assert _service().unfit_indices(features, criteria) == {1}  # OPTICAL -> Image, filtered out
+
+
+def test_product_type_image_only_greys_mosaics():
+    criteria = _criteria(min_intersection=0, max_cloud_cover=100, product_filter={"IMAGE"})
+    features = [_feature_p(0, "p", product_type="Mosaic"),
+               _feature_p(1, "p", product_type="OPTICAL")]
+    assert _service().unfit_indices(features, criteria) == {0}  # the Mosaic is filtered out
+
+
+# ---------- pure helpers ----------
+
+def test_passes_optional_rule():
+    assert LocalFilterService.passes_optional(None, lambda v: False) is True  # missing -> passes
+    assert LocalFilterService.passes_optional(5, lambda v: v < 10) is True
+    assert LocalFilterService.passes_optional(50, lambda v: v < 10) is False
+
+
+def test_product_category_maps_mosaic_else_image():
+    assert LocalFilterService.product_category("Mosaic") == "MOSAIC"
+    assert LocalFilterService.product_category("mosaic") == "MOSAIC"
+    assert LocalFilterService.product_category("OPTICAL") == "IMAGE"
+    assert LocalFilterService.product_category("") == "IMAGE"
+    assert LocalFilterService.product_category(None) == "IMAGE"
+
+
+# ---------- widen (!) comparison ----------
+
+def _current(date_from=QDate(2025, 1, 1), date_to=QDate(2025, 6, 1), max_cloud_cover=30,
+             min_intersection=40, min_off_nadir=0, max_off_nadir=30,
+             product_types=("IMAGE",), data_providers=("providerA",)) -> dict:
+    return {
+        "date_from": date_from, "date_to": date_to,
+        "max_cloud_cover": max_cloud_cover, "min_intersection": min_intersection,
+        "min_off_nadir": min_off_nadir, "max_off_nadir": max_off_nadir,
+        "product_types": list(product_types), "data_providers": list(data_providers),
+    }
+
+
+def test_no_widen_when_widgets_match_baseline():
+    baseline = _current()  # identical
+    assert _service().widen_messages(_current(), baseline) == []
+
+
+def test_no_widen_without_a_baseline():
+    assert _service().widen_messages(_current(), None) == []
+
+
+def test_widen_detects_wider_cloud_and_earlier_date():
+    baseline = _current(date_from=QDate(2025, 2, 1), max_cloud_cover=10)
+
+    messages = _service().widen_messages(_current(), baseline)
+
+    # Start date earlier (Jan < Feb) and cloud higher (30 > 10) are both flagged.
+    assert any("Start date" in m for m in messages)
+    assert any("cloud cover" in m for m in messages)
+    assert not any("End date" in m for m in messages)
+
+
+def test_widen_detects_lower_intersection_and_extra_provider():
+    baseline = _current(min_intersection=80, data_providers=("providerB",))
+
+    messages = _service().widen_messages(_current(), baseline)
+
+    assert any("intersection" in m for m in messages)      # 40 < 80
+    assert any("Provider" in m for m in messages)          # providerA not in [providerB]

--- a/tests/qgis/test_local_filter.py
+++ b/tests/qgis/test_local_filter.py
@@ -1,13 +1,12 @@
-"""QGIS-tier tests for instant local filtering of imagery-search / template results.
+"""QGIS-tier tests for the local-filter machinery that stays in `mapflow.py`: assembling a
+`FilterCriteria` from the widgets + context, and applying the result to the table and layer.
 
-The filter widgets (date range, cloud cover, min intersection %) filter the already-fetched
-results on the client on every change — no server request. Unfit rows are not removed: they are
-greyed-out, made non-selectable and sorted to the bottom, and their footprints hidden from the
-result layer. A widen (!) indicator warns when the current widgets ask for MORE than was
-fetched (which local filtering cannot surface without a new Search).
-
-Templates are filtered client-side too (no server-side Filter button); min intersection uses the
-backend-provided per-image aoiIntersectionPercent (no local geometry / AOI-subselection math)."""
+The pure computation (which results fail the filter, and the widen `(!)` comparison) moved to
+`LocalFilterService` and is tested in `tests/functional/test_local_filter.py`. What remains here
+needs the QGIS runtime and/or real widgets: the provider/product resolution that reads
+`app_context`, the `apply_local_filter` orchestration (reorder, re-entrancy guard, skip-unchanged),
+the row greying and footprint hiding, and the widen-indicator button toggle.
+"""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -15,6 +14,7 @@ from PyQt5.QtCore import QDate, Qt
 from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem
 from qgis.core import QgsDistanceArea, QgsGeometry, QgsProject
 
+from mapflow.functional.service.local_filter_service import LocalFilterService
 from mapflow.mapflow import Mapflow
 
 
@@ -35,33 +35,28 @@ def _feature(local_index, date, cloud, geom, intersection=None):
     return {"type": "Feature", "geometry": geom, "properties": props}
 
 
-def _features():
-    """GeoJSON results (same shape as fills the table): index 0 fits; 1 out of date range;
-    2 too cloudy; 3 low backend AOI intersection (~1%)."""
-    return [
-        _feature(0, "2025-03-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10), intersection=100),
-        _feature(1, "2020-01-01T00:00:00Z", 5, _square_geojson(0, 0, 10, 10), intersection=100),
-        _feature(2, "2025-03-01T00:00:00Z", 90, _square_geojson(0, 0, 10, 10), intersection=100),
-        _feature(3, "2025-03-01T00:00:00Z", 10, _square_geojson(9, 9, 11, 11), intersection=1),
-    ]
+def _feature_p(local_index, provider, product_type="OPTICAL"):
+    f = _feature(local_index, "2025-03-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10))
+    f["properties"]["providerName"] = provider
+    f["properties"]["productType"] = product_type
+    return f
 
 
-def _plugin_regular(min_intersection=50, max_cloud=50,
-                    date_from=None, date_to=None):
+def _plugin_regular(min_intersection=50, max_cloud=50, date_from=None, date_to=None):
     date_from = date_from or QDate(2025, 1, 1)
     date_to = date_to or QDate(2025, 12, 31)
     plugin = Mapflow.__new__(Mapflow)
     plugin.tr = lambda t: t
-    plugin.calculator = QgsDistanceArea()
     plugin.dlg = MagicMock()
     plugin.dlg.metadataFrom.date.return_value = date_from
     plugin.dlg.metadataTo.date.return_value = date_to
     plugin.dlg.maxCloudCover.value.return_value = max_cloud
     plugin.dlg.minIntersection.value.return_value = min_intersection
-    # Off-nadir at the full 0-30 range by default = no off-nadir filtering.
     plugin.dlg.off_nadir_range.return_value = (0, 30)
     plugin.dlg.off_nadir_is_full_range.return_value = True
-    # No provider / product-type filter by default; overridden in the relevant tests.
+    # The pure computation lives in the service; these mapflow tests exercise the criteria
+    # assembly that feeds it, so a real service is wired in.
+    plugin.local_filter_service = LocalFilterService()
     plugin._allowed_provider_set = MagicMock(return_value=None)
     plugin._product_category_filter = MagicMock(return_value=None)
     plugin.processing_service = SimpleNamespace(in_template_mode=False)
@@ -74,198 +69,7 @@ def _plugin_regular(min_intersection=50, max_cloud=50,
     return plugin
 
 
-# ---------- _unfit_local_indices ----------
-
-def _off_nadir_feature(local_index, angle):
-    return {"type": "Feature", "geometry": _square_geojson(0, 0, 10, 10),
-            "properties": {"local_index": local_index, "acquisitionDate": "2025-03-01T00:00:00Z",
-                           "cloudCover": 0, "offNadirAngle": angle}}
-
-
-def test_off_nadir_out_of_range_demoted_missing_passes():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin.dlg.off_nadir_range.return_value = (0, 5)
-    plugin.dlg.off_nadir_is_full_range.return_value = False
-    features = [
-        _off_nadir_feature(0, 3),     # within [0, 5] -> fit
-        _off_nadir_feature(1, 10),    # outside -> unfit
-        _off_nadir_feature(2, None),  # missing angle -> passes (missing matches any)
-    ]
-
-    assert plugin._unfit_local_indices(features) == {1}
-
-
-def test_off_nadir_full_range_does_not_filter():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin.dlg.off_nadir_range.return_value = (0, 30)
-    plugin.dlg.off_nadir_is_full_range.return_value = True
-
-    # Even an angle beyond the slider maximum passes when the range is full (= no filter).
-    assert plugin._unfit_local_indices([_off_nadir_feature(0, 45)]) == set()
-
-
-def test_unfit_indices_reject_date_cloud_and_intersection():
-    plugin = _plugin_regular()
-
-    unfit = plugin._unfit_local_indices(_features())
-
-    # 0 passes; 1 (date), 2 (cloud), 3 (intersection) fail.
-    assert unfit == {1, 2, 3}
-
-
-def test_unfit_matches_displayed_cloud_value():
-    # Greying must track the exact Cloud % shown in the table: at 50% the 90-cloud image is out
-    # and the 10-cloud one stays, regardless of any layer field typing.
-    plugin = _plugin_regular(min_intersection=0, max_cloud=50)
-
-    unfit = plugin._unfit_local_indices(_features())
-
-    assert 2 in unfit and 0 not in unfit
-
-
-def test_unfit_handles_string_cloud_without_crashing():
-    # Cloud arriving as a string must not abort the whole pass (which used to freeze the greying).
-    plugin = _plugin_regular(min_intersection=0, max_cloud=50)
-    features = _features()
-    features[2]["properties"]["cloudCover"] = "90"  # string, still > 50
-
-    unfit = plugin._unfit_local_indices(features)
-
-    assert 2 in unfit
-
-
-def test_intersection_not_applied_when_min_is_zero():
-    plugin = _plugin_regular(min_intersection=0)
-
-    unfit = plugin._unfit_local_indices(_features())
-
-    # Only date (1) and cloud (2) fail; the tiny-overlap image (3) now passes.
-    assert unfit == {1, 2}
-
-
-def test_cloud_100_disables_cloud_filter():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-
-    unfit = plugin._unfit_local_indices(_features())
-
-    # Cloud no longer filters (image 2 passes); only the out-of-range date (1) fails.
-    assert unfit == {1}
-
-
-# ---------- My Imagery: missing metadata matches any filter ----------
-
-def _my_imagery_feature(local_index):
-    """A My Imagery row: no acquisition date, no cloud cover, covers the AOI."""
-    return _feature(local_index, None, None, _square_geojson(0, 0, 10, 10))
-
-
-def test_missing_date_passes_date_filter():
-    # Active date range that a real date would have to fall in; the null-date row must stay fit.
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-
-    unfit = plugin._unfit_local_indices([_my_imagery_feature(0)])
-
-    assert unfit == set()
-
-
-def test_missing_cloud_passes_cloud_filter():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=30)  # < 100, so cloud is filtered
-
-    unfit = plugin._unfit_local_indices([_my_imagery_feature(0)])
-
-    assert unfit == set()
-
-
-def test_missing_date_and_cloud_pass_with_both_filters_active():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=30,
-                             date_from=QDate(2025, 1, 1), date_to=QDate(2025, 2, 1))
-
-    unfit = plugin._unfit_local_indices([_my_imagery_feature(0)])
-
-    assert unfit == set()
-
-
-def test_populated_values_still_filter_both_directions():
-    # Guard against over-correcting into "never filter": real out-of-range values must still fail.
-    plugin = _plugin_regular(min_intersection=0, max_cloud=50,
-                             date_from=QDate(2025, 1, 1), date_to=QDate(2025, 12, 31))
-    features = [
-        _feature(0, "2025-06-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10)),   # in range, clear
-        _feature(1, "2019-06-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10)),   # date too old
-        _feature(2, "2025-06-01T00:00:00Z", 80, _square_geojson(0, 0, 10, 10)),   # too cloudy
-    ]
-
-    unfit = plugin._unfit_local_indices(features)
-
-    assert unfit == {1, 2}
-
-
-def test_passes_optional_rule():
-    assert Mapflow._passes_optional(None, lambda v: False) is True   # missing -> always passes
-    assert Mapflow._passes_optional(5, lambda v: v < 10) is True
-    assert Mapflow._passes_optional(50, lambda v: v < 10) is False
-
-
-
-def test_intersection_uses_backend_percent():
-    # The filter compares the backend aoiIntersectionPercent to the widget; the footprint
-    # geometry is irrelevant (here index 1 fully covers the AOI but reports a low %).
-    plugin = _plugin_regular(min_intersection=50)
-    features = [
-        _feature(0, "2025-03-01T00:00:00Z", 10, _square_geojson(9, 9, 11, 11), intersection=80),
-        _feature(1, "2025-03-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10), intersection=20),
-    ]
-
-    assert plugin._unfit_local_indices(features) == {1}
-
-
-def test_missing_intersection_percent_passes():
-    # A result without a backend intersection value must not be hidden (missing matches any).
-    plugin = _plugin_regular(min_intersection=50)
-    feature = _feature(0, "2025-03-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10))
-
-    assert plugin._unfit_local_indices([feature]) == set()
-
-
-def test_template_mode_filters_by_backend_percent_same_as_regular():
-    # Template mode no longer has a special union-of-selected-AOIs path: same backend-% filter.
-    plugin = _plugin_regular(min_intersection=50)
-    plugin.processing_service = SimpleNamespace(in_template_mode=True)
-
-    assert plugin._unfit_local_indices(_features()) == {1, 2, 3}
-
-
-# ---------- provider / product-type filtering ----------
-
-def _feature_p(local_index, provider, product_type="OPTICAL"):
-    f = _feature(local_index, "2025-03-01T00:00:00Z", 10, _square_geojson(0, 0, 10, 10))
-    f["properties"]["providerName"] = provider
-    f["properties"]["productType"] = product_type
-    return f
-
-
-def test_provider_filter_greys_disallowed_providers():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._allowed_provider_set = MagicMock(return_value={"orbview_svn1"})
-    features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "orbview_svn3")]
-
-    assert plugin._unfit_local_indices(features) == {1}  # svn3 not allowed
-
-
-def test_provider_filter_is_case_insensitive():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._allowed_provider_set = MagicMock(return_value={"orbview_svn1"})
-
-    assert plugin._unfit_local_indices([_feature_p(0, "OrbView_SVN1")]) == set()
-
-
-def test_provider_filter_off_shows_all():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._allowed_provider_set = MagicMock(return_value=None)
-    features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "orbview_svn3")]
-
-    assert plugin._unfit_local_indices(features) == set()
-
+# ---------- _allowed_provider_set / _product_category_filter (criteria assembly) ----------
 
 def test_allowed_provider_set_off_when_unavailable_toggle_off():
     plugin = _plugin_regular()
@@ -296,6 +100,8 @@ def test_allowed_provider_set_falls_back_to_available_when_none_checked():
 
 
 def test_search_only_available_greys_unavailable_provider():
+    # End to end through the wrapper: real assembly + real service. A provider not available to
+    # the user is dropped from an otherwise-fit result.
     plugin = _plugin_regular(min_intersection=0, max_cloud=100)
     plugin._product_category_filter = MagicMock(return_value=None)
     plugin.dlg.hideUnavailableResults.isChecked.return_value = True
@@ -304,26 +110,7 @@ def test_search_only_available_greys_unavailable_provider():
     del plugin._allowed_provider_set  # use the real method
     features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "legacy_provider")]
 
-    # legacy_provider is not available to the user -> greyed.
     assert plugin._unfit_local_indices(features) == {1}
-
-
-def test_product_type_mosaic_only_greys_images():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._product_category_filter = MagicMock(return_value={"MOSAIC"})
-    features = [_feature_p(0, "p", product_type="Mosaic"),
-                _feature_p(1, "p", product_type="OPTICAL")]
-
-    assert plugin._unfit_local_indices(features) == {1}  # OPTICAL -> Image, filtered out
-
-
-def test_product_type_image_only_greys_mosaics():
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._product_category_filter = MagicMock(return_value={"IMAGE"})
-    features = [_feature_p(0, "p", product_type="Mosaic"),
-                _feature_p(1, "p", product_type="OPTICAL")]
-
-    assert plugin._unfit_local_indices(features) == {0}  # the Mosaic is filtered out
 
 
 def test_product_category_filter_none_when_both_or_neither():
@@ -336,62 +123,6 @@ def test_product_category_filter_none_when_both_or_neither():
     plugin.dlg.searchMosaicCheckBox.isChecked.return_value = True
     plugin.dlg.searchImageCheckBox.isChecked.return_value = False
     assert plugin._product_category_filter() == {"MOSAIC"}
-
-
-def test_product_category_maps_mosaic_else_image():
-    assert Mapflow._product_category("Mosaic") == "MOSAIC"
-    assert Mapflow._product_category("mosaic") == "MOSAIC"
-    assert Mapflow._product_category("OPTICAL") == "IMAGE"
-    assert Mapflow._product_category("") == "IMAGE"
-    assert Mapflow._product_category(None) == "IMAGE"
-
-
-# ---------- reset filters ----------
-
-def _plugin_reset(baseline):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    plugin.apply_local_filter = MagicMock()
-    plugin._apply_search_providers_to_combo = MagicMock()
-    plugin.app_context = SimpleNamespace(search_baseline_filters=baseline)
-    return plugin
-
-
-def test_reset_filters_restores_baseline_and_refilters():
-    plugin = _plugin_reset({
-        "date_from": QDate(2025, 1, 1), "date_to": QDate(2025, 6, 1),
-        "max_cloud_cover": 30, "min_intersection": 40,
-        "product_types": ["MOSAIC"], "data_providers": ["providerA"],
-        "hide_unavailable": True})
-
-    plugin.reset_filters()
-
-    plugin.dlg.metadataFrom.setDate.assert_called_once_with(QDate(2025, 1, 1))
-    plugin.dlg.maxCloudCover.setValue.assert_called_once_with(30)
-    plugin.dlg.minIntersection.setValue.assert_called_once_with(40)
-    plugin.dlg.searchMosaicCheckBox.setChecked.assert_called_once_with(True)
-    plugin.dlg.searchImageCheckBox.setChecked.assert_called_once_with(False)
-    plugin.dlg.hideUnavailableResults.setChecked.assert_called_once_with(True)
-    plugin._apply_search_providers_to_combo.assert_called_once_with(["providerA"])
-    plugin.apply_local_filter.assert_called_once()
-
-
-def test_reset_filters_leaves_params_the_template_did_not_set():
-    # None baseline fields (params the template did not carry) must not touch their widgets.
-    plugin = _plugin_reset({
-        "date_from": None, "date_to": None, "max_cloud_cover": 20,
-        "min_intersection": None, "product_types": None, "data_providers": None,
-        "hide_unavailable": None})
-
-    plugin.reset_filters()
-
-    plugin.dlg.maxCloudCover.setValue.assert_called_once_with(20)
-    plugin.dlg.minIntersection.setValue.assert_not_called()
-    plugin.dlg.metadataFrom.setDate.assert_not_called()
-    plugin.dlg.searchMosaicCheckBox.setChecked.assert_not_called()
-    plugin.dlg.hideUnavailableResults.setChecked.assert_not_called()
-    plugin._apply_search_providers_to_combo.assert_not_called()
-    plugin.apply_local_filter.assert_called_once()
 
 
 # ---------- apply_local_filter orchestration ----------
@@ -524,7 +255,7 @@ def test_mark_unfit_rows_greys_and_disables_only_unfit():
     assert not (unfit_item.flags() & Qt.ItemIsEnabled)
 
 
-# ---------- widen (!) indicator ----------
+# ---------- widen (!) indicator button ----------
 
 def _plugin_widen(baseline):
     plugin = Mapflow.__new__(Mapflow)
@@ -535,45 +266,11 @@ def _plugin_widen(baseline):
     plugin.dlg.maxCloudCover.value.return_value = 30
     plugin.dlg.minIntersection.value.return_value = 40
     plugin.dlg.off_nadir_range.return_value = (0, 30)
+    plugin.local_filter_service = LocalFilterService()
     plugin.selected_search_product_types = MagicMock(return_value=["IMAGE"])
     plugin.selected_search_providers = MagicMock(return_value=["providerA"])
     plugin.app_context = SimpleNamespace(search_baseline_filters=baseline)
     return plugin
-
-
-def test_no_widen_when_widgets_match_baseline():
-    plugin = _plugin_widen({
-        "date_from": QDate(2025, 1, 1), "date_to": QDate(2025, 6, 1),
-        "max_cloud_cover": 30, "min_intersection": 40,
-        "product_types": ["IMAGE"], "data_providers": ["providerA"]})
-
-    assert plugin._widened_filter_messages() == []
-
-
-def test_widen_detects_wider_cloud_and_earlier_date():
-    plugin = _plugin_widen({
-        "date_from": QDate(2025, 2, 1), "date_to": QDate(2025, 6, 1),
-        "max_cloud_cover": 10, "min_intersection": 40,
-        "product_types": ["IMAGE"], "data_providers": ["providerA"]})
-
-    messages = plugin._widened_filter_messages()
-
-    # Start date earlier (Jan < Feb) and cloud higher (30 > 10) are both flagged.
-    assert any("Start date" in m for m in messages)
-    assert any("cloud cover" in m for m in messages)
-    assert not any("End date" in m for m in messages)
-
-
-def test_widen_detects_lower_intersection_and_extra_provider():
-    plugin = _plugin_widen({
-        "date_from": QDate(2025, 1, 1), "date_to": QDate(2025, 6, 1),
-        "max_cloud_cover": 30, "min_intersection": 80,
-        "product_types": ["IMAGE"], "data_providers": ["providerB"]})
-
-    messages = plugin._widened_filter_messages()
-
-    assert any("intersection" in m for m in messages)      # 40 < 80
-    assert any("Provider" in m for m in messages)          # providerA not in [providerB]
 
 
 def test_update_widen_indicator_toggles_button_visibility():


### PR DESCRIPTION
Fourth Phase C extraction, and the first whose deliverable is testable without the QGIS runtime.
LocalFilterService takes the pure client-side narrowing of an already-fetched result set:
unfit_indices (which results fail the current filter) and widen_messages (the comparison behind
the wider-than-searched `(!)` indicator), plus the pure helpers product_category / to_float /
passes_optional / utc_date_from_iso.

The split is by purity, which is what "pure computation; functional-tier tests" in the WAL asks
for. A FilterCriteria value object carries the resolved widget state into the service, so it
reads no widget and imports no qgis.core — hence functional-tier. What stays in mapflow.py is the
two things that are not pure: the criteria assembly (_allowed_provider_set /
_product_category_filter read app_context.search_data_providers), and the result application
(greying rows, hiding footprints, toggling the indicator, the apply_local_filter orchestration)
which drives the table and layer. A later view pass can take the application.

utc_date_from_iso is a module function rather than a service method: template code parses the
same ISO dates for its baseline, and a date conversion is no reason for template code to depend
on the filter service.

The 39 local-filter tests split the same way: 24 pure ones move to
tests/functional/test_local_filter.py against the service (a FilterCriteria or plain dicts, no
QGIS); the assembly, orchestration, row/footprint application and widen-button tests stay in the
qgis tier. The three moved-computation mutations were verified against the functional tier in six
seconds rather than three minutes — the concrete payoff of making the computation QGIS-free.

QDateTime was left stranded in mapflow.py by the move (only _utc_date_from_iso used it); removed,
found with the AST check since F401 is in the ledger.

## Manual test
Imagery search or a template's results: change the date range, cloud, intersection, off-nadir and
provider/product filters — rows that fail should grey out and sort to the bottom instantly (no
new Search), and their footprints should vanish from the map. Widen any filter beyond what the
last Search fetched and the `(!)` indicator should appear with a tooltip naming the wider
settings; Reset filters should restore the fetched values.

Regression surface: My Imagery rows (empty date/cloud) must stay fit under any filter — missing
metadata matches every predicate, same as the server treats a NULL column. If that inverted,
user-imagery results would vanish whenever a filter is set.
