### PR TITLE
refactor: move the template seen-markers into TemplateService/View

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -43,18 +43,26 @@ plus the template half of `processing_service.py` — and ~50 references reach t
 state (`in_template_mode` 13×, `active_template` 16×) through `processing_service` from the other
 services. Split into two MRs so the high-blast-radius part is reviewable on its own.
 
-[ ] Extract templates MR-1 → `TemplateService` + `TemplateController` (`mapflow.py` half)
-Move the ~50 template methods OUT of `mapflow.py`: `create_search_template*`,
-`_build_search_params`, `_load_template_search(_page)`, `show_template_search_results`,
-`update_template_search_params`, `exclude_processing_from_search`, `_template_filter_baseline`,
-`apply_search_params_to_ui`, `_store_template_search_footprints`, `_prompt_plan_search`, the
-seen-markers cluster, the template AOI display layers (`_add_geojson_aoi_layer`,
-`on_template_aois_changed`, `_no_aoi_*`), and the in-template navigation slots.
-Takes `filter_search_by_selected_aoi` (confirmed): the AOI step assigned it to `SearchService`,
-but it reads `processing_service.selected_aois()` and calls `_load_template_search` — template
-code. `TemplateService` reads navigation state from `processing_service` for now (service→service);
-ownership moves in MR-2. Directly serves the phase acceptance (de-god `mapflow.py`), which the
-`processing_service` half does not block since it is already out of the god object.
+MR-1 (de-god `mapflow.py`) is being done as several small MRs. Landed: create/update-search-params/
+exclude + plan-search gating (`TemplateService`+`TemplateController`+`TemplateView` created;
+`SearchView.template_search_params`/`ensure_search_provider`). `TemplateService` reads navigation
+state from `processing_service` for now (service→service); ownership moves in MR-2.
+
+[ ] Templates: seen-markers cluster → `TemplateService` + `TemplateView`
+`_seen_template_id`, `mark_selected/all_template_images_seen`, `_mark_template_image_seen_by_row`,
+`_template_image_at_row`, `_on_template_image_seen`, `_on_all_template_images_seen`,
+`_apply_new_image_markers`, `_set_new_image_marker`, `_new_image_marker_column`, `_find_template`,
+`_decrement/_reset_template_new_images_count`, `_refresh_template_status_cell`, and the
+`template_search_images` DTO map. Spans two tables (metadata results + processings) with async
+callbacks — service owns the DTO state + api orchestration + emits marker/status signals; view
+owns the table icons and the status cell; controller loops rows.
+
+[ ] Templates: layers + navigation + `filter_search_by_selected_aoi` + `apply_search_params_to_ui`
+Remaining `mapflow.py` template half: `_load_template_search(_page)`, `show_template_search_results`,
+`_template_filter_baseline`, `apply_search_params_to_ui`, `_store_template_search_footprints`, the
+template AOI display layers (`_add_geojson_aoi_layer`, `on_template_aois_changed`, `_no_aoi_*`),
+the in-template navigation slots, and `filter_search_by_selected_aoi` (confirmed transfer — it
+reads `processing_service.selected_aois()` and calls `_load_template_search`, both template).
 
 [ ] Extract templates MR-2 → carve the template half out of `processing_service`
 Move `enter/exit/refresh_template_view`, `pause/resume/restart/delete_template`, `update_template`,

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -42,12 +42,18 @@ class TemplateController(QObject):
 
         update_search_button.clicked.connect(self.update_template_search_params)
         exclude_action.triggered.connect(self.template_service.exclude_processing_from_search)
+        # The Seen / Seen-all actions are created later (setup_metadata_seen_dropdown), so
+        # mapflow.py wires them to mark_selected_images_seen / mark_all_images_seen.
 
         self.template_service.creationBusy.connect(
             lambda busy: self.template_view.set_search_enabled(not busy))
         self.template_service.projectRequired.connect(self.template_view.show_project_required)
         self.template_service.statusMessage.connect(
             lambda message: self.iface.messageBar().pushInfo(self.app_context.plugin_name, message))
+        self.template_service.templateStatusChanged.connect(
+            self.template_view.refresh_template_status_cell)
+        self.template_service.warningMessage.connect(
+            lambda message: self.iface.messageBar().pushWarning(self.app_context.plugin_name, message))
 
     def create_search_template(self, name_override: str = None) -> None:
         """Assemble the request from the widgets and hand it to the service. Called by the
@@ -74,6 +80,37 @@ class TemplateController(QObject):
         # geometry; the backend merges the rest and preserves the AOIs).
         search_params = self.search_view.template_search_params(aoi_details=None)
         self.template_service.update_template_search_params(search_params)
+
+    # ---------- seen markers: read rows here, DTO state + api in the service, icons in the view ----------
+
+    def mark_selected_images_seen(self, *args) -> None:
+        template_id = self.template_service.seen_template_id()
+        if not template_id:
+            return
+        for row in self.template_view.selected_metadata_rows():
+            image_id = self.template_view.image_id_at(row)
+            self.template_service.mark_image_seen(
+                template_id, image_id,
+                on_success=lambda r=row: self.template_view.set_new_image_marker(r, False))
+
+    def mark_all_images_seen(self, *args) -> None:
+        template_id = self.template_service.seen_template_id()
+        if not template_id:
+            return
+        # Snapshot the rows that are new BEFORE the request: the service clears every DTO's
+        # isNew on success, so afterwards there is no way to tell which rows to un-mark.
+        new_rows = [row for row in range(self.template_view.metadata_row_count())
+                    if self.template_service.image_is_new(self.template_view.image_id_at(row))]
+        self.template_service.mark_all_seen(
+            template_id,
+            on_success=lambda: [self.template_view.set_new_image_marker(r, False) for r in new_rows])
+
+    def apply_new_image_markers(self) -> None:
+        """Show the 'new image' icon on every row whose image DTO is still new. Called after a
+        template's results (re)fill."""
+        for row in range(self.template_view.metadata_row_count()):
+            image_id = self.template_view.image_id_at(row)
+            self.template_view.set_new_image_marker(row, self.template_service.image_is_new(image_id))
 
     def _build_template_aoi_details(self):
         """The ``searchParams.aoiDetails`` FeatureCollection for template creation: named features

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -40,6 +40,11 @@ class TemplateService(QObject):
     projectRequired = pyqtSignal(str)
     #: A short "creating…/updating…" status for the message bar.
     statusMessage = pyqtSignal(str)
+    #: A template's new-images count changed; the controller refreshes its status cell. Carries
+    #: the template DTO (a schema type, which a view may read).
+    templateStatusChanged = pyqtSignal(object)
+    #: A non-modal warning for the message bar (a seen request failed).
+    warningMessage = pyqtSignal(str)
 
     def __init__(self,
                  app_context: AppContext,
@@ -49,6 +54,9 @@ class TemplateService(QObject):
         #: Read for navigation state (`active_template`, `selected_template`,
         #: `selected_processing`) and reached for `api`. MR-2 gives TemplateService its own.
         self.processing_service = processing_service
+        #: The current template-search results, keyed by image id, carrying the ``isNew`` flag
+        #: the seen markers read. Set when a template's results load.
+        self.template_search_images = {}
 
     # ---------- plan-search gating ----------
 
@@ -229,3 +237,83 @@ class TemplateService(QObject):
             if footprints:
                 result.append((aoi, footprints))
         return result
+
+    # ---------- seen markers (DTO state + api; the table effects are the view's) ----------
+
+    def store_template_images(self, images) -> None:
+        """The template-search results, so the seen flow can find each image's DTO by id."""
+        self.template_search_images = {str(image.id): image for image in images}
+
+    def seen_template_id(self) -> Optional[str]:
+        """Id of the template whose search results are currently shown.
+
+        NOT from the processings-table selection: inside the in-template view the selected rows
+        are AOIs/processings, so a selection-derived id is None there and both Seen actions
+        silently sent no request. ``open_template_results_id`` is set whenever template results
+        load (entering a template and "See search results" alike)."""
+        open_id = getattr(self.app_context, "open_template_results_id", None)
+        if open_id:
+            return str(open_id)
+        template = self.processing_service.active_template
+        return str(template.id) if template else None
+
+    def image_is_new(self, image_id: Optional[str]) -> bool:
+        image = self.template_search_images.get(image_id)
+        return bool(image is not None and image.isNew)
+
+    def mark_image_seen(self, template_id: str, image_id: str, on_success) -> None:
+        """Request 'seen' for one image, only if its DTO is still new. On success the DTO's
+        ``isNew`` is cleared and the counter decremented (never optimistically); ``on_success``
+        — bound by the controller to the row — clears that row's marker."""
+        image = self.template_search_images.get(image_id)
+        if image is None or not image.isNew:
+            return
+        self.processing_service.api.mark_template_image_seen(
+            template_id=template_id,
+            image_id=str(image_id),
+            callback=lambda _response, img=image, tid=template_id: (
+                self._on_image_seen(img, tid), on_success()),
+            error_handler=self._seen_error_handler,
+        )
+
+    def mark_all_seen(self, template_id: str, on_success) -> None:
+        """Mark every image of the shown template as seen with a single request."""
+        self.processing_service.api.mark_all_template_images_seen(
+            template_id=template_id,
+            callback=lambda _response, tid=template_id: (self._on_all_seen(tid), on_success()),
+            error_handler=self._seen_error_handler,
+        )
+
+    def _on_image_seen(self, image, template_id: str) -> None:
+        image.isNew = False
+        self._decrement_new_images_count(template_id)
+
+    def _on_all_seen(self, template_id: str) -> None:
+        for image in self.template_search_images.values():
+            image.isNew = False
+        self._reset_new_images_count(template_id)
+
+    def _seen_error_handler(self, response: QNetworkReply) -> None:
+        self.warningMessage.emit(self.tr("Could not mark image(s) as seen, please try again."))
+
+    def _find_template(self, template_id: str):
+        template_map = getattr(self.processing_service, "templates", {}) or {}
+        for key, value in template_map.items():
+            if str(key) == str(template_id):
+                return value
+        return None
+
+    def _decrement_new_images_count(self, template_id: str) -> None:
+        template = self._find_template(template_id)
+        if template is None:
+            return
+        if template.newImagesCount and template.newImagesCount > 0:
+            template.newImagesCount -= 1
+        self.templateStatusChanged.emit(template)
+
+    def _reset_new_images_count(self, template_id: str) -> None:
+        template = self._find_template(template_id)
+        if template is None:
+            return
+        template.newImagesCount = 0
+        self.templateStatusChanged.emit(template)

--- a/mapflow/functional/view/template_view.py
+++ b/mapflow/functional/view/template_view.py
@@ -1,22 +1,28 @@
-from PyQt5.QtCore import QObject
+from typing import List, Optional
+
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QMessageBox
 
+from ...dialogs.icons import new_image_icon
 from ...dialogs.main_dialog import MainDialog
 
 
 class TemplateView(QObject):
     """Template-specific widget reads/writes on the panel: the search/plan name field, the
-    Search button's busy state, the "select a project" reminder in the problems label, and the
-    too-large-AOI "Plan Search?" prompt.
+    Search button's busy state, the "select a project" reminder in the problems label, the
+    too-large-AOI "Plan Search?" prompt, and the seen-image markers / status cells across the
+    metadata-results and processings tables.
 
     Holds no service (`spec/007_architecture.md` § Layer rules). `TemplateController` reads from
     here, calls `TemplateService`, and pushes effects back.
     """
 
-    def __init__(self, dlg: MainDialog, iface):
+    def __init__(self, dlg: MainDialog, iface, config):
         super().__init__()
         self.dlg = dlg
         self.iface = iface
+        self.config = config
 
     def template_name(self) -> str:
         return self.dlg.processingName.text().strip()
@@ -51,3 +57,50 @@ class TemplateView(QObject):
         box.setDefaultButton(plan_button)
         box.exec()
         return box.clickedButton() is plan_button
+
+    # ---------- seen markers on the metadata-results table ----------
+
+    def selected_metadata_rows(self) -> List[int]:
+        return sorted({item.row() for item in self.dlg.metadataTable.selectedItems()})
+
+    def metadata_row_count(self) -> int:
+        return self.dlg.metadataTable.rowCount()
+
+    def image_id_at(self, row: int) -> Optional[str]:
+        id_item = self.dlg.metadataTable.item(row, self.config.SEARCH_ID_COLUMN_INDEX)
+        return id_item.text() if id_item else None
+
+    def _new_image_marker_column(self) -> int:
+        """Leftmost visible column — where the 'new image' icon shows. Skips columns the user hid
+        via the search-column checkboxes, so the marker never lands on a hidden column."""
+        start = self.config.NEW_IMAGE_MARKER_COLUMN_INDEX
+        table = self.dlg.metadataTable
+        for col in range(start, table.columnCount()):
+            if not table.isColumnHidden(col):
+                return col
+        return start
+
+    def set_new_image_marker(self, row: int, is_new: bool) -> None:
+        cell = self.dlg.metadataTable.item(row, self._new_image_marker_column())
+        if cell is not None:
+            cell.setIcon(new_image_icon if is_new else QIcon())
+
+    # ---------- template status cell on the processings table ----------
+
+    def refresh_template_status_cell(self, template) -> None:
+        """Update a template's status cell text + tooltip in the processings table."""
+        id_col = self.config.PROCESSING_TABLE_ID_COLUMN_INDEX
+        status_col = list(self.config.PROCESSING_TABLE_COLUMNS).index('status')
+        table = self.dlg.processingsTable
+        for row in range(table.rowCount()):
+            id_item = table.item(row, id_col)
+            if id_item and id_item.text() == str(template.id):
+                status_item = table.item(row, status_col)
+                if status_item:
+                    status_item.setData(Qt.DisplayRole, template.table_status)
+                    tip = self.tr("Planned processing")
+                    if template.newImagesCount and template.newImagesCount > 0:
+                        tip = self.tr("Planned processing. New images: {count}").format(
+                            count=template.newImagesCount)
+                    status_item.setToolTip(tip)
+                break

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import (
     QCoreApplication, QDate, QObject, Qt,
     QTimer, QTranslator
 )
-from PyQt5.QtGui import QBrush, QColor, QIcon
+from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
     QAbstractItemView, QAction, QApplication, QFileDialog,
@@ -75,7 +75,7 @@ from .dialogs import (ErrorMessageWidget,
                       MapflowLoginDialog,
                       ProviderDialog,
                       ReviewDialog)
-from .dialogs.icons import plugin_icon, new_image_icon
+from .dialogs.icons import plugin_icon
 from .dialogs.processing_details_dialog import ProcessingDetailsDialog
 # Providers
 from .model.provider import (create_provider,
@@ -340,7 +340,7 @@ class Mapflow(QObject):
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
                                                 processing_service=self.processing_service)
-        self.template_view = TemplateView(dlg=self.dlg, iface=self.iface)
+        self.template_view = TemplateView(dlg=self.dlg, iface=self.iface, config=self.config)
         self.template_controller = TemplateController(
             template_service=self.template_service,
             template_view=self.template_view,
@@ -779,9 +779,9 @@ class Mapflow(QObject):
         # local-filter-driven (templates); only SEARCH_SORT_FIELDS headers re-sort, server-side.
         self.dlg.fill_metadata_table(geoms, sort=False)
         # Keep the image DTOs (they carry isNew) keyed by id so mark-seen reads truth.
-        self.template_search_images = {str(image.id): image for image in images}
+        self.template_service.store_template_images(images)
         # New images are flagged with an icon in the leftmost column (not by editing text).
-        self._apply_new_image_markers()
+        self.template_controller.apply_new_image_markers()
         # Toggle/wire the search pager for the template results (T6).
         self.search_service.update_pager(response_data.total, response_data.limit, response_data.offset)
 
@@ -1319,7 +1319,7 @@ class Mapflow(QObject):
             self._suppress_local_filter = False
         # Re-filling drops the per-row 'new image' icons; restore them for template results.
         if getattr(self.processing_service, "in_template_mode", False):
-            self._apply_new_image_markers()
+            self.template_controller.apply_new_image_markers()
         self._mark_unfit_rows(unfit)
         self._hide_unfit_footprints(getattr(self.app_context, "metadata_layer", None), unfit)
         self.search_controller.reconnect_cell_preview()
@@ -1821,8 +1821,10 @@ class Mapflow(QObject):
         self.metadata_seen_menu = QMenu(self.dlg.markSeenButton)
         self.metadata_seen_action = self.metadata_seen_menu.addAction(self.tr("Seen"))
         self.metadata_seen_all_action = self.metadata_seen_menu.addAction(self.tr("Seen all"))
-        self.metadata_seen_action.triggered.connect(self.mark_selected_template_images_seen)
-        self.metadata_seen_all_action.triggered.connect(self.mark_all_template_images_seen)
+        self.metadata_seen_action.triggered.connect(
+            self.template_controller.mark_selected_images_seen)
+        self.metadata_seen_all_action.triggered.connect(
+            self.template_controller.mark_all_images_seen)
         self.dlg.markSeenButton.setPopupMode(QToolButton.MenuButtonPopup)
         self.dlg.markSeenButton.setMenu(self.metadata_seen_menu)
         self.dlg.markSeenButton.setDefaultAction(self.metadata_seen_action)
@@ -2169,154 +2171,6 @@ class Mapflow(QObject):
     def on_metadata_table_cell_clicked(self, row: int, column: int):
         """Keep click behavior passive; marking seen is handled by Seen actions only."""
         return
-
-    def _seen_template_id(self) -> Optional[str]:
-        """Id of the template whose search results are currently in the table.
-
-        This must NOT come from the processings-table selection: inside the in-template view the
-        selected rows are AOIs/processings, so a selection-derived id is None there and both Seen
-        actions silently sent no request. ``open_template_results_id`` is set whenever template
-        results are loaded (entering a template and "See search results" alike)."""
-        open_id = getattr(self.app_context, "open_template_results_id", None)
-        if open_id:
-            return str(open_id)
-        template = self.processing_service.active_template
-        return str(template.id) if template else None
-
-    def _mark_template_image_seen_by_row(self, row: int) -> None:
-        """Request 'seen' for one row's image, only if its DTO is still new.
-
-        The row marker and the new-images counter are updated from the success
-        callback (``_on_template_image_seen``) — never optimistically.
-        """
-        template_id = self._seen_template_id()
-        if not template_id:
-            return
-        image = self._template_image_at_row(row)
-        if image is None or not image.isNew:
-            return
-        self.processing_service.api.mark_template_image_seen(
-            template_id=template_id,
-            image_id=str(image.id),
-            callback=lambda _response, r=row, img=image, tid=template_id:
-                self._on_template_image_seen(r, img, tid),
-            error_handler=self._mark_seen_error_handler,
-        )
-
-    def mark_selected_template_images_seen(self):
-        """Mark selected metadata rows as seen for the template whose results are shown."""
-        if not self._seen_template_id():
-            return
-        for row in sorted({item.row() for item in self.dlg.metadataTable.selectedItems()}):
-            self._mark_template_image_seen_by_row(row)
-
-    def mark_all_template_images_seen(self):
-        """Mark every image of the shown template as seen with a single request."""
-        template_id = self._seen_template_id()
-        if not template_id:
-            return
-        self.processing_service.api.mark_all_template_images_seen(
-            template_id=template_id,
-            callback=lambda _response, tid=template_id: self._on_all_template_images_seen(tid),
-            error_handler=self._mark_seen_error_handler,
-        )
-
-    def _template_image_at_row(self, row: int):
-        """Return the stored image DTO for a metadata-table row, or None."""
-        id_item = self.dlg.metadataTable.item(row, self.config.SEARCH_ID_COLUMN_INDEX)
-        if not id_item:
-            return None
-        return getattr(self, "template_search_images", {}).get(id_item.text())
-
-    def _on_template_image_seen(self, row: int, image, template_id: str) -> None:
-        """Success: clear the row marker and decrement the new-images counter."""
-        image.isNew = False
-        self._set_new_image_marker(row, False)
-        self._decrement_template_new_images_count(template_id)
-
-    def _on_all_template_images_seen(self, template_id: str) -> None:
-        """Success: clear every visible marker and zero the new-images counter."""
-        for row in range(self.dlg.metadataTable.rowCount()):
-            image = self._template_image_at_row(row)
-            if image is not None and image.isNew:
-                image.isNew = False
-                self._set_new_image_marker(row, False)
-        self._reset_template_new_images_count(template_id)
-
-    def _mark_seen_error_handler(self, response: QNetworkReply) -> None:
-        """Leave markers/counter untouched and tell the user the request failed."""
-        self.iface.messageBar().pushWarning(
-            self.app_context.plugin_name,
-            self.tr("Could not mark image(s) as seen, please try again."),
-        )
-
-    def _new_image_marker_column(self) -> int:
-        """Leftmost visible column — where the 'new image' icon is shown.
-
-        Starts at the configured leftmost index (0) and skips columns the user hid via
-        the search-column checkboxes, so the marker never lands on a hidden column.
-        """
-        start = self.config.NEW_IMAGE_MARKER_COLUMN_INDEX
-        table = self.dlg.metadataTable
-        for col in range(start, table.columnCount()):
-            if not table.isColumnHidden(col):
-                return col
-        return start
-
-    def _apply_new_image_markers(self) -> None:
-        """Show the 'new image' icon on every row whose image DTO is still new."""
-        for row in range(self.dlg.metadataTable.rowCount()):
-            image = self._template_image_at_row(row)
-            self._set_new_image_marker(row, bool(image is not None and image.isNew))
-
-    def _set_new_image_marker(self, row: int, is_new: bool) -> None:
-        """Set or clear the 'new image' icon on a row's leftmost-visible cell."""
-        cell = self.dlg.metadataTable.item(row, self._new_image_marker_column())
-        if cell is not None:
-            cell.setIcon(new_image_icon if is_new else QIcon())
-
-    def _find_template(self, template_id: str):
-        template_map = getattr(self.processing_service, "templates", {}) or {}
-        for key, value in template_map.items():
-            if str(key) == str(template_id):
-                return value
-        return None
-
-    def _decrement_template_new_images_count(self, template_id: str):
-        """Decrement newImagesCount on the in-memory template DTO and refresh its status cell."""
-        template = self._find_template(template_id)
-        if template is None:
-            return
-        if template.newImagesCount and template.newImagesCount > 0:
-            template.newImagesCount -= 1
-        self._refresh_template_status_cell(template_id, template)
-
-    def _reset_template_new_images_count(self, template_id: str):
-        """Zero newImagesCount on the in-memory template DTO and refresh its status cell."""
-        template = self._find_template(template_id)
-        if template is None:
-            return
-        template.newImagesCount = 0
-        self._refresh_template_status_cell(template_id, template)
-
-    def _refresh_template_status_cell(self, template_id: str, template) -> None:
-        """Update the template's status cell text + tooltip in the processings table."""
-        id_col = self.config.PROCESSING_TABLE_ID_COLUMN_INDEX
-        status_col = list(self.config.PROCESSING_TABLE_COLUMNS).index('status')
-        table = self.dlg.processingsTable
-        for row in range(table.rowCount()):
-            id_item = table.item(row, id_col)
-            if id_item and id_item.text() == str(template_id):
-                status_item = table.item(row, status_col)
-                if status_item:
-                    status_item.setData(Qt.DisplayRole, template.table_status)
-                    tip = self.tr("Planned processing")
-                    if template.newImagesCount and template.newImagesCount > 0:
-                        tip = self.tr("Planned processing. New images: {count}").format(
-                            count=template.newImagesCount
-                        )
-                    status_item.setToolTip(tip)
-                break
 
     def update_processing_current_rating(self) -> None:
         # reset labels:

--- a/tests/qgis/test_local_filter.py
+++ b/tests/qgis/test_local_filter.py
@@ -146,8 +146,8 @@ def _plugin_orchestration(unfit):
     plugin._mark_unfit_rows = MagicMock()
     plugin._hide_unfit_footprints = MagicMock()
     plugin.search_controller = MagicMock()  # apply_local_filter drives reconnect_cell_preview
+    plugin.template_controller = MagicMock()  # ...and apply_new_image_markers in template mode
     plugin._update_widen_indicator = MagicMock()
-    plugin._apply_new_image_markers = MagicMock()
     plugin._restore_search_sort_indicator = MagicMock()
     return plugin
 

--- a/tests/qgis/test_template_project_required.py
+++ b/tests/qgis/test_template_project_required.py
@@ -27,7 +27,7 @@ def _plugin(mode, current_project):
     plugin = Mapflow.__new__(Mapflow)
     plugin.metadata_search_mode = mode
     plugin.dlg = MagicMock()
-    plugin.template_view = TemplateView(dlg=plugin.dlg, iface=MagicMock())
+    plugin.template_view = TemplateView(dlg=plugin.dlg, iface=MagicMock(), config=MagicMock())
     plugin.template_service = _service(current_project)
     plugin.app_context = SimpleNamespace(current_project=current_project)
     return plugin

--- a/tests/qgis/test_template_search_footprints.py
+++ b/tests/qgis/test_template_search_footprints.py
@@ -18,6 +18,7 @@ from mapflow import mapflow as mapflow_module
 from mapflow.config import Config, ConfigColumns
 from mapflow.model.provider.default import ImagerySearchProvider
 from mapflow.functional.service.search_service import SearchService
+from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
@@ -80,6 +81,10 @@ def _plugin_with_search_provider(tmp_path, template_name="Template A"):
                                           result_loader=plugin.result_loader,
                                           provider_service=plugin.provider_service)
     plugin.search_service.metadataLayerReady.connect(lambda _layer: None)
+    # The image DTO map moved to TemplateService; the marker refresh to TemplateController.
+    plugin.template_service = TemplateService(app_context=plugin.app_context,
+                                              processing_service=MagicMock())
+    plugin.template_controller = MagicMock()
     return plugin
 
 
@@ -140,8 +145,8 @@ def test_template_callback_keeps_product_type_text_clean_and_stores_new_flag(tmp
     # The "new" state is shown with an icon now, so the product-type text stays clean.
     assert [f["properties"]["productType"] for f in geoms["features"]] == ["Image", "Image"]
     # Image DTOs are stored by id and carry the authoritative isNew flag for mark-seen.
-    assert plugin.template_search_images["img-new"].isNew is True
-    assert plugin.template_search_images["img-seen"].isNew is False
+    assert plugin.template_service.template_search_images["img-new"].isNew is True
+    assert plugin.template_service.template_search_images["img-seen"].isNew is False
 
 
 def test_monitor_skips_current_search_metadata_layer():

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -3,8 +3,11 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service import processing_service as processing_service_module
 from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.functional.service.template_service import TemplateService
+from mapflow.functional.view.template_view import TemplateView
 from mapflow.mapflow import Mapflow
 from mapflow.schema.processing import PostProcessingSchemaV2
 from mapflow.schema.template import RunTemplateProcessingSchema
@@ -242,96 +245,97 @@ def test_load_template_layers_builds_per_aoi_subgroups_from_aoidetails():
     assert subgroups == {"AOI: North"}
 
 
-def _mark_seen_plugin(selected_rows=None):
-    """Plugin wired for mark-seen tests: rows 0 (img-1, new), 1 (img-2, seen), 2 (img-3, new).
+# ---------- seen markers: TemplateService (DTO+api) + TemplateController (loop) + TemplateView (icons) ----------
 
-    ``_set_new_image_marker`` is mocked here so these tests focus on the request/gating
-    logic; the icon mechanics are covered by ``test_apply_new_image_markers_*``.
-    """
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    # The template whose results are shown drives Seen (NOT the processings-table selection).
-    plugin.app_context = SimpleNamespace(open_template_results_id="tpl-1", plugin_name="Mapflow")
-    plugin.config = SimpleNamespace(SEARCH_ID_COLUMN_INDEX=1, NEW_IMAGE_MARKER_COLUMN_INDEX=0)
-    plugin.processing_service = SimpleNamespace(api=MagicMock(), active_template=None)
-    plugin._decrement_template_new_images_count = MagicMock()
-    plugin._reset_template_new_images_count = MagicMock()
-    plugin._set_new_image_marker = MagicMock()
-    plugin.dlg = MagicMock()
-    plugin.dlg.metadataTable.rowCount.return_value = 3
-    plugin.template_search_images = {
+def _seen_setup(selected_rows=None, open_id="tpl-1", active_template=None):
+    """Rows 0 (img-1, new), 1 (img-2, seen), 2 (img-3, new). Real service + view (mock dlg) +
+    controller; the icon set is what the tests observe, so the view is real."""
+    dlg = MagicMock()
+    dlg.metadataTable.rowCount.return_value = 3
+    dlg.metadataTable.columnCount.return_value = 3
+    dlg.metadataTable.isColumnHidden.return_value = False
+    id_cells = {0: MagicMock(text=MagicMock(return_value="img-1")),
+                1: MagicMock(text=MagicMock(return_value="img-2")),
+                2: MagicMock(text=MagicMock(return_value="img-3"))}
+    marker_cells = {0: MagicMock(), 1: MagicMock(), 2: MagicMock()}
+    dlg.metadataTable.item.side_effect = (
+        lambda row, col: id_cells.get(row) if col == 1 else marker_cells.get(row) if col == 0 else None)
+    if selected_rows is not None:
+        dlg.metadataTable.selectedItems.return_value = [
+            SimpleNamespace(row=lambda r=r: r) for r in selected_rows]
+
+    config = SimpleNamespace(SEARCH_ID_COLUMN_INDEX=1, NEW_IMAGE_MARKER_COLUMN_INDEX=0)
+    app_context = SimpleNamespace(open_template_results_id=open_id, plugin_name="Mapflow")
+    # The in-memory template DTO whose newImagesCount the seen flow decrements.
+    template_dto = SimpleNamespace(id=open_id or (active_template.id if active_template else None),
+                                   newImagesCount=2)
+    processing_service = SimpleNamespace(api=MagicMock(), active_template=active_template,
+                                         templates={template_dto.id: template_dto})
+    service = TemplateService(app_context=app_context, processing_service=processing_service)
+    service.template_search_images = {
         "img-1": SimpleNamespace(id="img-1", isNew=True, productType="Image"),
         "img-2": SimpleNamespace(id="img-2", isNew=False, productType="Image"),
-        "img-3": SimpleNamespace(id="img-3", isNew=True, productType="Mosaic"),
-    }
-    id_cells = {
-        0: MagicMock(text=MagicMock(return_value="img-1")),
-        1: MagicMock(text=MagicMock(return_value="img-2")),
-        2: MagicMock(text=MagicMock(return_value="img-3")),
-    }
-    plugin.dlg.metadataTable.item.side_effect = (
-        lambda row, col: id_cells.get(row) if col == 1 else None
-    )
-    if selected_rows is not None:
-        plugin.dlg.metadataTable.selectedItems.return_value = [
-            SimpleNamespace(row=lambda r=r: r) for r in selected_rows
-        ]
-    return plugin
+        "img-3": SimpleNamespace(id="img-3", isNew=True, productType="Mosaic")}
+    view = TemplateView(dlg=dlg, iface=MagicMock(), config=config)
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = service
+    controller.template_view = view
+    template_dto = processing_service.templates[template_dto.id]
+    return controller, service, view, marker_cells, template_dto
 
 
 def test_mark_selected_template_images_seen_requests_only_new_rows_and_defers_update():
-    plugin = _mark_seen_plugin(selected_rows=[0, 0, 2])
-    api = plugin.processing_service.api
+    # Select rows 0 (new), 1 (SEEN — must be skipped), 2 (new).
+    controller, service, view, marker_cells, template = _seen_setup(selected_rows=[0, 1, 2])
+    api = service.processing_service.api
 
-    plugin.mark_selected_template_images_seen()
+    controller.mark_selected_images_seen()
 
-    # One request per unique selected NEW row (img-2 is not new); update is deferred.
-    assert api.mark_template_image_seen.call_count == 2
+    # A request per selected NEW row only — the seen row (img-2) is gated out; update deferred.
     assert [c.kwargs["image_id"] for c in api.mark_template_image_seen.call_args_list] == ["img-1", "img-3"]
-    plugin._decrement_template_new_images_count.assert_not_called()
-    plugin._set_new_image_marker.assert_not_called()
+    marker_cells[0].setIcon.assert_not_called()
+    assert template.newImagesCount == 2  # not decremented until the requests succeed
 
-    # Simulate a successful response for each request.
     for c in api.mark_template_image_seen.call_args_list:
         c.kwargs["callback"](MagicMock())
 
-    assert plugin._decrement_template_new_images_count.call_count == 2
-    # Marker icon is cleared per row only after its request succeeds.
-    assert plugin._set_new_image_marker.call_args_list == [call(0, False), call(2, False)]
-    assert plugin.template_search_images["img-1"].isNew is False
-    assert plugin.template_search_images["img-3"].isNew is False
+    # Marker cleared per row after its request succeeds; counter decremented once per success.
+    assert marker_cells[0].setIcon.call_args.args[0].isNull()
+    assert marker_cells[2].setIcon.call_args.args[0].isNull()
+    assert service.template_search_images["img-1"].isNew is False
+    assert service.template_search_images["img-3"].isNew is False
+    assert template.newImagesCount == 0  # 2 - 2 successes
 
 
 def test_mark_all_template_images_seen_uses_single_endpoint_and_defers_update():
-    plugin = _mark_seen_plugin()
-    api = plugin.processing_service.api
+    controller, service, view, marker_cells, _ = _seen_setup()
+    api = service.processing_service.api
 
-    plugin.mark_all_template_images_seen()
+    controller.mark_all_images_seen()
 
-    # Single seen-all request, no per-image calls, no optimistic update.
     api.mark_all_template_images_seen.assert_called_once()
     assert api.mark_all_template_images_seen.call_args.kwargs["template_id"] == "tpl-1"
     api.mark_template_image_seen.assert_not_called()
-    plugin._reset_template_new_images_count.assert_not_called()
+    marker_cells[0].setIcon.assert_not_called()
 
     api.mark_all_template_images_seen.call_args.kwargs["callback"](MagicMock())
 
-    # Only the NEW rows get their marker icon cleared; the counter is reset once.
-    assert plugin._set_new_image_marker.call_args_list == [call(0, False), call(2, False)]
-    plugin._reset_template_new_images_count.assert_called_once_with("tpl-1")
+    # Only the NEW rows (0, 2) get their marker icon cleared; the seen row (1) is untouched.
+    assert marker_cells[0].setIcon.call_args.args[0].isNull()
+    assert marker_cells[2].setIcon.call_args.args[0].isNull()
+    marker_cells[1].setIcon.assert_not_called()
 
 
 def test_seen_works_inside_the_template_view():
     """Regression: the template id used to come from the processings-table selection, which is
-    None inside the in-template view (rows are AOIs/processings) — so Seen / Seen all silently
-    sent no request. It must resolve from the results actually on screen."""
-    plugin = _mark_seen_plugin(selected_rows=[0])
-    # In-template view: no template row is selected, results were loaded for tpl-1.
-    plugin.processing_service.active_template = SimpleNamespace(id="tpl-1")
-    api = plugin.processing_service.api
+    None inside the in-template view — so Seen / Seen all silently sent no request. It must
+    resolve from the results actually on screen."""
+    controller, service, _, _, _ = _seen_setup(selected_rows=[0],
+                                            active_template=SimpleNamespace(id="tpl-1"))
+    api = service.processing_service.api
 
-    plugin.mark_all_template_images_seen()
-    plugin.mark_selected_template_images_seen()
+    controller.mark_all_images_seen()
+    controller.mark_selected_images_seen()
 
     api.mark_all_template_images_seen.assert_called_once()
     assert api.mark_all_template_images_seen.call_args.kwargs["template_id"] == "tpl-1"
@@ -339,85 +343,58 @@ def test_seen_works_inside_the_template_view():
 
 
 def test_seen_falls_back_to_the_open_template_when_results_id_missing():
-    plugin = _mark_seen_plugin()
-    plugin.app_context.open_template_results_id = None
-    plugin.processing_service.active_template = SimpleNamespace(id="tpl-7")
+    controller, service, _, _, _ = _seen_setup(open_id=None,
+                                            active_template=SimpleNamespace(id="tpl-7"))
 
-    plugin.mark_all_template_images_seen()
+    controller.mark_all_images_seen()
 
-    kwargs = plugin.processing_service.api.mark_all_template_images_seen.call_args.kwargs
+    kwargs = service.processing_service.api.mark_all_template_images_seen.call_args.kwargs
     assert kwargs["template_id"] == "tpl-7"
 
 
 def test_seen_noop_without_any_template_context():
-    plugin = _mark_seen_plugin()
-    plugin.app_context.open_template_results_id = None
-    plugin.processing_service.active_template = None
+    controller, service, _, _, _ = _seen_setup(selected_rows=[0], open_id=None, active_template=None)
 
-    plugin.mark_all_template_images_seen()
-    plugin.mark_selected_template_images_seen()
+    controller.mark_all_images_seen()
+    controller.mark_selected_images_seen()
 
-    plugin.processing_service.api.mark_all_template_images_seen.assert_not_called()
-    plugin.processing_service.api.mark_template_image_seen.assert_not_called()
+    service.processing_service.api.mark_all_template_images_seen.assert_not_called()
+    service.processing_service.api.mark_template_image_seen.assert_not_called()
 
 
 def test_mark_seen_error_leaves_marker_and_counter_untouched():
-    plugin = _mark_seen_plugin(selected_rows=[0])
-    plugin.iface = MagicMock()
-    api = plugin.processing_service.api
+    controller, service, view, marker_cells, _ = _seen_setup(selected_rows=[0])
+    warnings = []
+    service.warningMessage.connect(warnings.append)
+    api = service.processing_service.api
 
-    plugin.mark_selected_template_images_seen()
+    controller.mark_selected_images_seen()
     api.mark_template_image_seen.call_args.kwargs["error_handler"](MagicMock())
 
-    plugin._set_new_image_marker.assert_not_called()
-    plugin._decrement_template_new_images_count.assert_not_called()
-    assert plugin.template_search_images["img-1"].isNew is True
-    plugin.iface.messageBar().pushWarning.assert_called_once()
+    marker_cells[0].setIcon.assert_not_called()
+    assert service.template_search_images["img-1"].isNew is True
+    assert len(warnings) == 1
 
 
 def test_apply_new_image_markers_sets_icon_only_on_new_rows():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.config = SimpleNamespace(SEARCH_ID_COLUMN_INDEX=1, NEW_IMAGE_MARKER_COLUMN_INDEX=0)
-    plugin.template_search_images = {
-        "img-1": SimpleNamespace(id="img-1", isNew=True, productType="Image"),
-        "img-2": SimpleNamespace(id="img-2", isNew=False, productType="Image"),
-    }
-    plugin.dlg = MagicMock()
-    plugin.dlg.metadataTable.rowCount.return_value = 2
-    plugin.dlg.metadataTable.columnCount.return_value = 3
-    plugin.dlg.metadataTable.isColumnHidden.return_value = False
-    marker_cells = {0: MagicMock(), 1: MagicMock()}
-    id_cells = {
-        0: MagicMock(text=MagicMock(return_value="img-1")),
-        1: MagicMock(text=MagicMock(return_value="img-2")),
-    }
+    controller, service, view, marker_cells, _ = _seen_setup()
 
-    def item_side_effect(row, col):
-        if col == 0:
-            return marker_cells.get(row)
-        if col == 1:
-            return id_cells.get(row)
-        return None
+    controller.apply_new_image_markers()
 
-    plugin.dlg.metadataTable.item.side_effect = item_side_effect
-
-    plugin._apply_new_image_markers()
-
-    new_icon = marker_cells[0].setIcon.call_args.args[0]
-    seen_icon = marker_cells[1].setIcon.call_args.args[0]
-    assert not new_icon.isNull()  # new image -> the exclamation icon
-    assert seen_icon.isNull()     # seen image -> icon cleared
+    assert not marker_cells[0].setIcon.call_args.args[0].isNull()  # new image -> exclamation icon
+    assert marker_cells[1].setIcon.call_args.args[0].isNull()      # seen image -> icon cleared
+    assert not marker_cells[2].setIcon.call_args.args[0].isNull()
 
 
 def test_new_image_marker_column_skips_hidden_leftmost_column():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.config = SimpleNamespace(NEW_IMAGE_MARKER_COLUMN_INDEX=0)
-    plugin.dlg = MagicMock()
-    plugin.dlg.metadataTable.columnCount.return_value = 4
+    dlg = MagicMock()
+    dlg.metadataTable.columnCount.return_value = 4
     # User hid column 0 -> marker falls back to the leftmost visible column (1).
-    plugin.dlg.metadataTable.isColumnHidden.side_effect = lambda col: col == 0
+    dlg.metadataTable.isColumnHidden.side_effect = lambda col: col == 0
+    view = TemplateView(dlg=dlg, iface=MagicMock(),
+                        config=SimpleNamespace(NEW_IMAGE_MARKER_COLUMN_INDEX=0))
 
-    assert plugin._new_image_marker_column() == 1
+    assert view._new_image_marker_column() == 1
 
 
 def test_on_metadata_table_cell_clicked_does_not_mark_seen():


### PR DESCRIPTION
Second template cluster. The "new image" / mark-seen flow leaves mapflow.py: the DTO map and the
seen requests go to TemplateService, the row markers and the status cell to TemplateView, the
per-row loop to TemplateController.

This is the hardest widget-coupling in templates — it spans two tables (the metadata results table
and the processings table) and is driven by async callbacks. The split follows the layer rules:
TemplateService holds template_search_images (the id->DTO map carrying isNew) and the api
orchestration, and emits templateStatusChanged (a template's new-images count changed) and
warningMessage (a request failed); TemplateView owns the marker icons and the status cell;
TemplateController reads the rows and binds each into the async success callback.

One behaviour needed care: "mark all seen" un-marks only the rows that were new, but the service
clears every DTO's isNew on success — so the controller snapshots the new rows before the request
and un-marks exactly those. A "clear all rows" would have changed behaviour, which the test pins.

Two mutations survived the first verification pass and are worth recording, because they are the
same shape: a moved behaviour whose test asserted "the method was called" rather than "it produced
the right value" stops discriminating once that method is inlined into the service. Dropping the
isNew gate survived because the test only selected already-new rows; the counter decrement
survived because nothing asserted the count. Strengthened both (select a seen row; assert the
count reaches zero), then confirmed each mutation fails.

QIcon and new_image_icon were left stranded in mapflow.py by the move; the AST check found them.

Still in mapflow.py: the template layers + navigation + filter_search_by_selected_aoi +
apply_search_params_to_ui cluster (next), and the processing_service template half (MR-2).

## Manual test
Open a template's search results (double-click a template, or "See search results"): rows for
images not yet seen show the exclamation icon in the leftmost column, and the template's row in
the processings table shows a "New images: N" tooltip. Right-click images and "Seen" clears their
icons and decrements the count once each request succeeds; "Seen all" clears every new-image icon
and zeroes the count. A failed seen request should leave the icons and count untouched and show a
message-bar warning.

Regression surface: the count only decrements on a successful response (never optimistically), and
"Seen" skips images already seen. If the gate or the deferral broke, the count would drift from
what the backend holds.
