### PR TITLE
refactor: move the template map layers and their navigation into TemplateService/Controller

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -44,25 +44,27 @@ state (`in_template_mode` 13×, `active_template` 16×) through `processing_serv
 services. Split into two MRs so the high-blast-radius part is reviewable on its own.
 
 MR-1 (de-god `mapflow.py`) is being done as several small MRs. Landed: create/update-search-params/
-exclude + plan-search gating (`TemplateService`+`TemplateController`+`TemplateView` created;
-`SearchView.template_search_params`/`ensure_search_provider`). `TemplateService` reads navigation
-state from `processing_service` for now (service→service); ownership moves in MR-2.
+exclude + plan-search gating; the seen-markers cluster. `TemplateService` reads navigation state
+from `processing_service` for now (service→service); ownership moves in MR-2.
 
-[ ] Templates: seen-markers cluster → `TemplateService` + `TemplateView`
-`_seen_template_id`, `mark_selected/all_template_images_seen`, `_mark_template_image_seen_by_row`,
-`_template_image_at_row`, `_on_template_image_seen`, `_on_all_template_images_seen`,
-`_apply_new_image_markers`, `_set_new_image_marker`, `_new_image_marker_column`, `_find_template`,
-`_decrement/_reset_template_new_images_count`, `_refresh_template_status_cell`, and the
-`template_search_images` DTO map. Spans two tables (metadata results + processings) with async
-callbacks — service owns the DTO state + api orchestration + emits marker/status signals; view
-owns the table icons and the status cell; controller loops rows.
+[ready-for-review] Templates layers + layer-related navigation → `TemplateService` + `TemplateController`
+Area A of the layers+navigation step (sliced in two; Area B/C is the entry below). Moves the
+template's map-layer building/placement and the layer-related navigation slots out of `mapflow.py`:
+`ensure/find/remove_template_group`, `remove_template_aoi_subgroups`, `add_geojson_aoi_layer`,
+`load_template_layers`, the `no_aoi_*` lazy-fetch + `show_template_details` (service); the
+`on_template_aois_changed/processings_loaded/no_aoi_processing_clicked`, `select_template_processings`,
+`sync_processing_area_to_selected_aois`, and the layer side of `templateOpened/Closed` (controller).
+`ensure_template_group` moved now (only mapflow.py called it) — a down payment on MR-2's group-placement
+decision; the read-only `layer_utils.find_template_group` stays shared until MR-2 repoints AoiService/
+PreviewService.
 
-[ ] Templates: layers + navigation + `filter_search_by_selected_aoi` + `apply_search_params_to_ui`
+[ ] Templates search render + filter + params-to-UI (Area B/C of layers+navigation)
 Remaining `mapflow.py` template half: `_load_template_search(_page)`, `show_template_search_results`,
-`_template_filter_baseline`, `apply_search_params_to_ui`, `_store_template_search_footprints`, the
-template AOI display layers (`_add_geojson_aoi_layer`, `on_template_aois_changed`, `_no_aoi_*`),
-the in-template navigation slots, and `filter_search_by_selected_aoi` (confirmed transfer — it
-reads `processing_service.selected_aois()` and calls `_load_template_search`, both template).
+`get_selected_template_callback`, `_store_template_search_footprints`, `_aoi_ids_from_template`,
+`_template_single_data_provider`, `_template_filter_baseline`, `apply_search_params_to_ui`, and
+`filter_search_by_selected_aoi` (reads `processing_service.selected_aois()` and calls
+`_load_template_search`, both template). Needs the service→widget view split for the metadata table
+and the search filter widgets.
 
 [ ] Extract templates MR-2 → carve the template half out of `processing_service`
 Move `enter/exit/refresh_template_view`, `pause/resume/restart/delete_template`, `update_template`,

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -82,6 +82,23 @@ class ProcessingApi(QObject):
                          use_default_error_handler=True,
                          timeout=5)
 
+    def get_processing_aois(self,
+                            processing_id: Union[UUID, str],
+                            callback: Callable,
+                            error_handler: Callable,
+                            callback_kwargs: Optional[dict] = None,
+                            error_handler_kwargs: Optional[dict] = None) -> None:
+        """A processing's own AOI geometries (a JSON list of AOI objects). Used to draw a
+        'No AOI' template processing lazily on click — its geometry is absent from the
+        template's aoiDetails, so it is fetched per processing."""
+        self.http.get(path=f"processings/{processing_id}/aois",
+                      callback=callback,
+                      callback_kwargs=callback_kwargs or {},
+                      error_handler=error_handler,
+                      error_handler_kwargs=error_handler_kwargs or {},
+                      use_default_error_handler=False,
+                      timeout=30)
+
     def get_processings(self, project_id: Union[UUID, str], request_body: ProcessingsRequest, callback: Callable):
         self.http.post(path=f"projects/{project_id}/processings/v2/page",
                        body=request_body.as_json().encode(),

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -26,10 +26,13 @@ class TemplateController(QObject):
                  aoi_view,
                  aoi_service: AoiService,
                  provider_service,
+                 processing_service,
                  app_context: AppContext,
                  iface,
                  update_search_button,
-                 exclude_action):
+                 exclude_action,
+                 processings_table,
+                 see_processings_action):
         super().__init__()
         self.template_service = template_service
         self.template_view = template_view
@@ -37,6 +40,9 @@ class TemplateController(QObject):
         self.aoi_view = aoi_view
         self.aoi_service = aoi_service
         self.provider_service = provider_service
+        #: Read for navigation state (`in_template_mode`, `active_template`,
+        #: `selected_template/processing`, `selected_aois`) and for `hydrate_template`.
+        self.processing_service = processing_service
         self.app_context = app_context
         self.iface = iface
 
@@ -44,6 +50,19 @@ class TemplateController(QObject):
         exclude_action.triggered.connect(self.template_service.exclude_processing_from_search)
         # The Seen / Seen-all actions are created later (setup_metadata_seen_dropdown), so
         # mapflow.py wires them to mark_selected_images_seen / mark_all_images_seen.
+
+        # In-template navigation: the map layers a template draws, plus the selection-driven
+        # effects that only apply while a template is open. The processings table itself is the
+        # ProjectProcessingController's region; these listeners react to it for template concerns.
+        see_processings_action.triggered.connect(self.select_template_processings)
+        processings_table.itemSelectionChanged.connect(self.sync_processing_area_to_selected_aois)
+        processings_table.cellClicked.connect(self.on_no_aoi_processing_clicked)
+        processing_service.templateAoisChanged.connect(self.on_template_aois_changed)
+        processing_service.templateProcessingsLoaded.connect(self.on_template_processings_loaded)
+        # The layer side of entering/leaving a template. A second listener on these signals — the
+        # search/filter side stays in mapflow.py — so neither edits the other (spec § Controllers).
+        processing_service.templateOpened.connect(self._on_template_opened_layers)
+        processing_service.templateClosed.connect(self._on_template_closed_layers)
 
         self.template_service.creationBusy.connect(
             lambda busy: self.template_view.set_search_enabled(not busy))
@@ -123,3 +142,63 @@ class TemplateController(QObject):
         if not features:
             return None
         return {"type": "FeatureCollection", "features": features}
+
+    # ---------- in-template navigation: draw / redraw / clean up the template's map layers ----------
+
+    def select_template_processings(self, *args) -> None:
+        """Menu action: load AOI/processing layers for the selected template."""
+        template = self.processing_service.selected_template()
+        if not template or self.processing_service.selected_processing():
+            return
+        # Hydrate first (the list view's template omits aoiDetails), then draw layers.
+        self.processing_service.hydrate_template(template, self.template_service.load_template_layers)
+
+    def on_template_processings_loaded(self, template) -> None:
+        """Once a template's processings load, create the (initially empty) 'No AOI' group if any
+        processing is not bound to an AOI. Each such AOI is fetched and added lazily when the user
+        single-clicks its row (see on_no_aoi_processing_clicked) — no bulk requests on open."""
+        if not template or not self.processing_service.no_aoi_processing_ids():
+            return
+        self.template_service.ensure_template_group(str(template.name),
+                                                    self.template_service.no_aoi_subgroup_name())
+
+    def on_no_aoi_processing_clicked(self, *args) -> None:
+        """Single-click on a 'No AOI' processing row: fetch that processing's AOI and add it to the
+        'No AOI' group. No-op outside a template; the service ignores AOI/bound-processing rows, an
+        AOI already on the map, or a request already in flight (double-click still loads results)."""
+        if not self.processing_service.in_template_mode:
+            return
+        self.template_service.load_no_aoi_processing_aoi(self.processing_service.selected_processing())
+
+    def on_template_aois_changed(self, template) -> None:
+        """Redraw the template's AOI/processing map layers after its AOIs change (add / rename
+        / delete / geometry update / exclude-from-search), so the layer tree stays in sync
+        without re-entering the template."""
+        if not template:
+            return
+        self.template_service.remove_template_aoi_subgroups(str(template.name))
+        self.template_service.load_template_layers(template)
+
+    def sync_processing_area_to_selected_aois(self, *args) -> None:
+        """Inside a template, point the Area combo at the selected AOI(s), so the Area shown in
+        the combo IS the one a processing will use — one place to look, no silent override.
+
+        A single selection points at that AOI's own (already visible) layer; a multi-selection
+        points at a visible "Selected AOIs" layer holding one feature per AOI. No-op when no AOI
+        is selected, keeping the current Area (e.g. while a processing row is selected)."""
+        if not self.processing_service.in_template_mode:
+            return
+        template = self.processing_service.active_template
+        self.aoi_service.select_aois_as_processing_area(
+            self.processing_service.selected_aois(),
+            self.template_service.find_template_group(str(template.name)) if template else None)
+
+    def _on_template_opened_layers(self, template) -> None:
+        """Layer side of entering a template: draw its AOI/processing layers. The search results
+        and filter widgets are handled by mapflow.py's own `templateOpened` listener."""
+        self.template_service.load_template_layers(template)
+
+    def _on_template_closed_layers(self, template) -> None:
+        """Layer side of leaving a template: drop its map group."""
+        if template is not None:
+            self.template_service.remove_template_group(str(template.name))

--- a/mapflow/functional/layer_utils.py
+++ b/mapflow/functional/layer_utils.py
@@ -112,9 +112,9 @@ def find_template_group(project,
                         subgroup_name: Optional[str] = None):
     """The ``<mapflow group> > <template> [> <subgroup>]`` layer-tree group, or None.
 
-    Creates nothing — that is `Mapflow._ensure_template_group`. Lives here because both the
-    plugin and the services that place an already-built layer need the lookup, and a service may
-    not reach back into `mapflow.py` for it.
+    Creates nothing — that is `TemplateService.ensure_template_group`. Lives here because several
+    services that place an already-built layer need the lookup, and a service may not reach into
+    another service for it.
     """
     root = project.layerTreeRoot()
     parent_group = root.findGroup(mapflow_group_name) or root

--- a/mapflow/functional/service/aoi_service.py
+++ b/mapflow/functional/service/aoi_service.py
@@ -230,8 +230,8 @@ class AoiService(QObject):
         selected, keeping the current Area (e.g. while a processing row is selected).
 
         ``group`` is the template's layer-tree group, or None to leave the built layer at the
-        root. Looking it up is side-effect free (`Mapflow._find_template_group`), so it can be
-        resolved before the call rather than deferred into it.
+        root. Looking it up is side-effect free (`TemplateService.find_template_group`), so it can
+        be resolved before the call rather than deferred into it.
         """
         aois = [aoi for aoi in aois if aoi and aoi.id]
         selected_ids = frozenset(str(aoi.id) for aoi in aois)

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -1,4 +1,5 @@
-"""Planned processings (templates): creation, search-param update, and exclude-from-search.
+"""Planned processings (templates): creation, search-param update, exclude-from-search, the
+seen-image markers, and the template's map layers.
 
 This is MR-1 of the templates extraction — the half that was tangled into `mapflow.py`. The
 lifecycle half (enter/exit/pause/resume, navigation state) is still in `ProcessingService` and is
@@ -7,17 +8,26 @@ read from there for now; MR-2 moves it here.
 Holds no widget (`spec/007_architecture.md` § Layer rules). Inputs that come from widgets — the
 template name, the assembled `SearchParams`, the AOI FeatureCollection — arrive as arguments from
 `TemplateController`; UI effects the service must cause (the busy button, the "select a project"
-label) leave as signals. `ProcessingService` is read for navigation state and reached for its
-`api`; that dependency becomes `TemplateService`'s own in MR-2.
+label) leave as signals. The map layers a template draws are QGIS layer-tree work, not widgets, so
+they live here alongside `AoiService`/`PreviewService`'s own layer building. `ProcessingService` is
+read for navigation state and reached for its `api`; that dependency becomes `TemplateService`'s
+own in MR-2.
 """
 import json
+import logging
+import os
 from datetime import datetime, timedelta
 from typing import Optional
 
+from osgeo import ogr
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
-from qgis.core import QgsGeometry
+from qgis.core import (QgsFeature,
+                       QgsGeometry,
+                       QgsLayerTreeGroup,
+                       QgsVectorLayer)
 
+from .. import layer_utils
 from ..app_context import AppContext
 from ..geometry import geometry_from_geojson
 from .alert_service import (alert, alert_confirm, alert_info, alert_warning,
@@ -29,6 +39,8 @@ from ...schema.template import (CreateProcessingTemplateSchema,
                                 SearchParams,
                                 UpdateAoiSchema,
                                 UpdateProcessingTemplateSchema)
+
+logger = logging.getLogger(__name__)
 
 
 class TemplateService(QObject):
@@ -48,15 +60,27 @@ class TemplateService(QObject):
 
     def __init__(self,
                  app_context: AppContext,
-                 processing_service):
+                 processing_service,
+                 plugin_dir: Optional[str] = None,
+                 aoi_service=None,
+                 result_loader=None):
         super().__init__()
         self.app_context = app_context
         #: Read for navigation state (`active_template`, `selected_template`,
         #: `selected_processing`) and reached for `api`. MR-2 gives TemplateService its own.
         self.processing_service = processing_service
+        #: For the .qml style paths of the template AOI/footprint layers (mirrors `AoiService`).
+        self.plugin_dir = plugin_dir
+        #: Reached to register a built AOI layer (area monitor / registry). Service→service.
+        self.aoi_service = aoi_service
+        #: Read for `add_layers_to_group` (whether the user keeps a Mapflow layer group at all).
+        self.result_loader = result_loader
         #: The current template-search results, keyed by image id, carrying the ``isNew`` flag
         #: the seen markers read. Set when a template's results load.
         self.template_search_images = {}
+        #: 'No AOI' processing ids whose per-processing AOI fetch is in flight, so a second click
+        #: does not fire a duplicate request before the first returns.
+        self._pending_no_aoi_ids = set()
 
     # ---------- plan-search gating ----------
 
@@ -317,3 +341,290 @@ class TemplateService(QObject):
             return
         template.newImagesCount = 0
         self.templateStatusChanged.emit(template)
+
+    # ---------- template layer-tree groups (place / find / remove) ----------
+
+    def ensure_template_group(self,
+                              template_group_name: str,
+                              subgroup_name: Optional[str] = None):
+        """Find or create the ``Mapflow > <template> [> <subgroup>]`` group, and return the node
+        new layers should be inserted into.
+
+        For the callers that are *adding* the template's layers, and so legitimately bring the
+        group into being. Everything that merely places an already-built layer wants
+        ``find_template_group`` instead.
+
+        The Mapflow group is created here when missing so the template group is nested under it
+        from the very first (template-open) call. Previously the open path fell back to the root
+        because the Mapflow group did not exist yet, and a later preview — by which point the
+        group had been created — added a SECOND template group under it (feedback 4.1). If the
+        user has deleted the Mapflow group (the result loader then adds to root), respect that
+        and place template groups at the root too, keeping a single path."""
+        root = self.app_context.project.layerTreeRoot()
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        mapflow_group = root.findGroup(mapflow_group_name)
+        if mapflow_group is None and getattr(self.result_loader, 'add_layers_to_group', True):
+            mapflow_group = root.insertGroup(0, mapflow_group_name)
+            self.app_context.settings.setValue('layerGroup', mapflow_group_name)
+        parent_group = mapflow_group if mapflow_group else root
+        template_group = parent_group.findGroup(template_group_name)
+        if not template_group:
+            template_group = parent_group.insertGroup(0, template_group_name)
+        if subgroup_name:
+            subgroup = template_group.findGroup(subgroup_name)
+            if not subgroup:
+                subgroup = template_group.insertGroup(0, subgroup_name)
+            return subgroup
+        return template_group
+
+    def find_template_group(self,
+                            template_group_name: str,
+                            subgroup_name: Optional[str] = None):
+        """The ``Mapflow > <template name> [> <subgroup>]`` layer-tree group, or None.
+
+        Creates nothing. Callers that only need to *place* a layer next to the template's other
+        layers use this: they run on selection changes and preview clicks, and a lookup that
+        materialises a group as a side effect cannot be called on a path like that without a
+        lambda to defer it."""
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        return layer_utils.find_template_group(self.app_context.project, mapflow_group_name,
+                                               template_group_name, subgroup_name)
+
+    def remove_template_group(self, template_group_name: str) -> None:
+        """Remove the template's layer-tree group (and its layers) from the map."""
+        if not template_group_name:
+            return
+        root = self.app_context.project.layerTreeRoot()
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        mapflow_group = root.findGroup(mapflow_group_name)
+        parent_group = mapflow_group if mapflow_group else root
+        template_group = parent_group.findGroup(template_group_name)
+        if template_group is None:
+            return
+        for layer in template_group.findLayers():
+            layer_id = layer.layerId()
+            if layer_id:
+                try:
+                    self.app_context.project.removeMapLayer(layer_id)
+                except (RuntimeError, KeyError):
+                    pass
+        parent_group.removeChildNode(template_group)
+
+    def remove_template_aoi_subgroups(self, template_group_name: str) -> None:
+        """Remove the per-AOI subgroups (and their layers) under the template group, keeping
+        the search-results footprint layer that sits directly in the template group."""
+        if not template_group_name:
+            return
+        root = self.app_context.project.layerTreeRoot()
+        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
+        mapflow_group = root.findGroup(mapflow_group_name)
+        parent_group = mapflow_group if mapflow_group else root
+        template_group = parent_group.findGroup(template_group_name)
+        if template_group is None:
+            return
+        for child in list(template_group.children()):
+            # AOI subgroups are groups; the search-footprints node is a layer — leave it.
+            if isinstance(child, QgsLayerTreeGroup):
+                for layer in child.findLayers():
+                    layer_id = layer.layerId()
+                    if layer_id:
+                        try:
+                            self.app_context.project.removeMapLayer(layer_id)
+                        except (RuntimeError, KeyError):
+                            pass
+                template_group.removeChildNode(child)
+
+    # ---------- building the template's AOI / footprint layers ----------
+
+    def add_geojson_aoi_layer(self,
+                              features: list,
+                              layer_name: str,
+                              style_name: str,
+                              template_group_name: Optional[str] = None,
+                              subgroup_name: Optional[str] = None,
+                              reference_layer_id: Optional[str] = None,
+                              aoi_id: Optional[str] = None) -> Optional[QgsVectorLayer]:
+        if not features:
+            return None
+        aoi_layer = QgsVectorLayer('Polygon?crs=epsg:4326', layer_name, 'memory')
+        # Tag the AOI's own polygon layer with its id so "Update selected AOI" can find and edit
+        # this exact layer in place (processing-footprint layers are left untagged).
+        if aoi_id is not None:
+            aoi_layer.setCustomProperty('mapflow/aoi_id', str(aoi_id))
+        provider = aoi_layer.dataProvider()
+        qgs_features = []
+        for feature in features:
+            geom_dict = feature.get("geometry")
+            if not geom_dict:
+                continue
+            try:
+                ogr_geom = ogr.CreateGeometryFromJson(json.dumps(geom_dict))
+                if not ogr_geom:
+                    continue
+                qgs_geom = QgsGeometry.fromWkt(ogr_geom.ExportToWkt())
+                qgs_feat = QgsFeature()
+                qgs_feat.setGeometry(qgs_geom)
+                qgs_features.append(qgs_feat)
+            except Exception as e:
+                # Per-feature, inside a loop: no traceback, or one malformed response
+                # buries the panel in near-identical stack dumps.
+                logger.warning("Skipping a search feature that failed to parse: %s", e)
+                continue
+        if not qgs_features:
+            return None
+        provider.addFeatures(qgs_features)
+        aoi_layer.updateExtents()
+
+        root = self.app_context.project.layerTreeRoot()
+        if template_group_name:
+            target_group = self.ensure_template_group(template_group_name, subgroup_name)
+            self.app_context.project.addMapLayer(aoi_layer, addToLegend=False)
+            target_group.insertLayer(0, aoi_layer)
+        elif reference_layer_id:
+            root = self.app_context.project.layerTreeRoot()
+            ref_node = root.findLayer(reference_layer_id)
+            if ref_node and ref_node.parent():
+                self.app_context.project.addMapLayer(aoi_layer, addToLegend=False)
+                ref_node.parent().insertLayer(0, aoi_layer)
+            else:
+                self.app_context.project.addMapLayer(aoi_layer)
+        else:
+            self.app_context.project.addMapLayer(aoi_layer)
+
+        aoi_layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', style_name))
+        # Template AOI layers are added in bulk on open; don't fire a cost request per layer,
+        # and don't let them become the current processing Area (feedback 8.1) — the Area is
+        # set from the AOI table selection (see sync_processing_area_to_selected_aois).
+        self.aoi_service.register_layer(aoi_layer, recompute_cost=False, set_current=False)
+        return aoi_layer
+
+    def load_template_layers(self, template) -> None:
+        """Draw, per AOI, a subgroup named after the AOI containing the AOI polygon (blue)
+        and each of its processings' footprints (green), all from the template's
+        ``aoiDetails`` (no extra requests)."""
+        if not template:
+            return
+        template_group_name = str(template.name)
+        for aoi in template.aoi_dtos():
+            subgroup_name = self.tr("AOI: {name}").format(name=aoi.display_name)
+            if aoi.geometry:
+                self.add_geojson_aoi_layer(
+                    features=[{"type": "Feature", "geometry": aoi.geometry, "properties": {}}],
+                    layer_name=aoi.display_name,
+                    style_name='aoi_template_blue.qml',
+                    template_group_name=template_group_name,
+                    subgroup_name=subgroup_name,
+                    aoi_id=aoi.id,
+                )
+            for link in aoi.processings:
+                if not link.geometry:
+                    continue
+                self.add_geojson_aoi_layer(
+                    features=[{"type": "Feature", "geometry": link.geometry, "properties": {}}],
+                    layer_name=link.processingName or str(link.processingId),
+                    style_name='aoi_template_processing_green.qml',
+                    template_group_name=template_group_name,
+                    subgroup_name=subgroup_name,
+                )
+
+    # ---------- 'No AOI' processings: lazy per-processing AOI fetch + draw ----------
+
+    def no_aoi_subgroup_name(self) -> str:
+        return self.tr("No AOI")
+
+    def no_aoi_aoi_on_map(self, pid) -> bool:
+        """Whether a 'No AOI' processing's AOI layer (tagged with its id) is already on the map."""
+        return any(layer.customProperty('mapflow/no_aoi_processing_id') == str(pid)
+                   for layer in self.app_context.project.mapLayers().values())
+
+    def load_no_aoi_processing_aoi(self, processing) -> None:
+        """Fetch a 'No AOI' processing's AOI (absent from aoiDetails) and add it to the template's
+        'No AOI' group. No-op for a bound processing, one whose AOI is already on the map, or one
+        whose request is already in flight (a second click before the first returns)."""
+        if not processing:
+            return
+        pid = str(processing.id)
+        if not self.processing_service.is_no_aoi_processing(pid):
+            return
+        if pid in self._pending_no_aoi_ids or self.no_aoi_aoi_on_map(pid):
+            return
+        self._pending_no_aoi_ids.add(pid)
+        self.processing_service.api.get_processing_aois(
+            processing_id=pid,
+            callback=self._add_no_aoi_processing_aoi_callback,
+            callback_kwargs={'pid': pid, 'name': processing.name},
+            error_handler=self._add_no_aoi_processing_aoi_error,
+            error_handler_kwargs={'pid': pid},
+        )
+
+    def _add_no_aoi_processing_aoi_callback(self, response: QNetworkReply, pid: str, name: str) -> None:
+        self._pending_no_aoi_ids.discard(pid)
+        template = self.processing_service.active_template
+        if not template or not self.processing_service.in_template_mode or self.no_aoi_aoi_on_map(pid):
+            return
+        # GET /processings/{id}/aois returns a JSON list of AOI objects (each with a `geometry`),
+        # not a FeatureCollection — wrap each geometry into a feature the layer builder understands.
+        try:
+            aois = json.loads(response.readAll().data())
+        except ValueError:
+            # Not JSON, or not decodable as UTF-8 (UnicodeDecodeError is a ValueError).
+            return
+        if isinstance(aois, dict):
+            aois = aois.get('aois', [])
+        features = [{"type": "Feature", "geometry": aoi.get("geometry"), "properties": {}}
+                    for aoi in aois if isinstance(aoi, dict) and aoi.get("geometry")]
+        if not features:
+            return
+        layer = self.add_geojson_aoi_layer(
+            features=features,
+            layer_name=name or pid,
+            style_name='aoi_template_processing_green.qml',
+            template_group_name=str(template.name),
+            subgroup_name=self.no_aoi_subgroup_name(),
+        )
+        if layer is not None:
+            layer.setCustomProperty('mapflow/no_aoi_processing_id', str(pid))
+
+    def _add_no_aoi_processing_aoi_error(self, response: QNetworkReply, pid: str = None) -> None:
+        self._pending_no_aoi_ids.discard(pid)
+
+    # ---------- template details ----------
+
+    def show_template_details(self, template) -> None:
+        """Show a template summary. The processings count is fetched from the ``/processings``
+        endpoint (aoiDetails links are not always populated)."""
+        self.processing_service.api.get_template_processings(
+            template_id=template.id,
+            callback=lambda response: self._show_template_details_callback(template, response),
+        )
+
+    def _show_template_details_callback(self, template, response: QNetworkReply) -> None:
+        try:
+            data = json.loads(response.readAll().data())
+            items = data.get("results") if isinstance(data, dict) else data
+            linked_count = len([i for i in (items or []) if isinstance(i, dict)])
+        except (ValueError, TypeError):
+            # Not JSON (ValueError, which UnicodeDecodeError subclasses), or a payload whose
+            # `results` is not iterable.
+            linked_count = 0
+        new_images = template.newImagesCount or 0
+        local_created_at = template.createdAt.astimezone()
+        local_active_until = template.activeUntil.astimezone()
+
+        details = self.tr(
+            "<b>{name}</b><br/>"
+            "<b>Status:</b> {status}<br/>"
+            "<b>Created:</b> {created}<br/>"
+            "<b>Active Until:</b> {active_until}<br/>"
+            "<b>Linked processings:</b> {linked}<br/>"
+            "<b>New images:</b> {new_images}"
+        ).format(
+            name=template.name,
+            status=template.status,
+            created=local_created_at.strftime('%Y-%m-%d %H:%M'),
+            active_until=local_active_until.strftime('%Y-%m-%d %H:%M'),
+            linked=linked_count,
+            new_images=new_images,
+        )
+
+        alert_info(details)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -6,7 +6,6 @@ from base64 import b64decode
 from configparser import ConfigParser  # parse metadata.txt -> QGIS version check (compatibility)
 from pathlib import Path
 from typing import List, Optional, Callable
-from osgeo import ogr
 
 from PyQt5.QtCore import (
     QCoreApplication, QDate, QObject, Qt,
@@ -19,8 +18,7 @@ from PyQt5.QtWidgets import (
     QMenu, QMessageBox, QWidget, QToolButton
 )
 from qgis.core import (
-    QgsDistanceArea, QgsFeature, QgsGeometry,
-    QgsLayerTreeGroup, QgsMapLayer, QgsMapLayerType,
+    QgsDistanceArea, QgsMapLayer, QgsMapLayerType,
     QgsProject, QgsVectorLayer
 )
 
@@ -339,7 +337,10 @@ class Mapflow(QObject):
 
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
-                                                processing_service=self.processing_service)
+                                                processing_service=self.processing_service,
+                                                plugin_dir=self.plugin_dir,
+                                                aoi_service=self.aoi_service,
+                                                result_loader=self.result_loader)
         self.template_view = TemplateView(dlg=self.dlg, iface=self.iface, config=self.config)
         self.template_controller = TemplateController(
             template_service=self.template_service,
@@ -348,10 +349,13 @@ class Mapflow(QObject):
             aoi_view=self.aoi_view,
             aoi_service=self.aoi_service,
             provider_service=self.provider_service,
+            processing_service=self.processing_service,
             app_context=self.app_context,
             iface=self.iface,
             update_search_button=self.dlg.updateTemplateSearch,
-            exclude_action=self.dlg.exclude_from_search_action)
+            exclude_action=self.dlg.exclude_from_search_action,
+            processings_table=self.dlg.processingsTable,
+            see_processings_action=self.dlg.see_processings_action)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -409,13 +413,11 @@ class Mapflow(QObject):
         self.dlg.processingsTable.cellDoubleClicked.connect(self.load_results)
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
         self.processing_service.connect_processings_pagination()
-        # In-template navigation: map side-effects on enter/leave a template.
+        # In-template navigation: the search/filter side of entering or leaving a template. The
+        # map-layer side (aoiDetails redraw, 'No AOI' group, selected-AOI Area) is TemplateController's.
         self.processing_service.templateOpened.connect(self.on_template_opened)
         self.processing_service.templateClosed.connect(self.on_template_closed)
-        self.processing_service.templateAoisChanged.connect(self.on_template_aois_changed)
-        self.processing_service.templateProcessingsLoaded.connect(self.on_template_processings_loaded)
         self.dlg.processingsTable.itemSelectionChanged.connect(self.filter_search_by_selected_aoi)
-        self.dlg.processingsTable.itemSelectionChanged.connect(self.sync_processing_area_to_selected_aois)
         # Processings ratings
         self.dlg.processingsTable.itemSelectionChanged.connect(self.enable_feedback)
         self.dlg.processingsTable.itemSelectionChanged.connect(self.on_processings_selection_changed)
@@ -425,9 +427,6 @@ class Mapflow(QObject):
         # Processing feedback
         self.dlg.ratingComboBox.activated.connect(self.enable_feedback)
         self.dlg.processingsTable.cellClicked.connect(self.update_processing_current_rating)
-        # In a template, single-clicking a 'No AOI' processing row adds its AOI to the map
-        # (double-click still loads results).
-        self.dlg.processingsTable.cellClicked.connect(self.on_no_aoi_processing_clicked)
         # Processing review
         self.dlg.acceptButton.clicked.connect(self.accept_processing)
         self.dlg.reviewButton.clicked.connect(self.show_review_dialog)
@@ -440,8 +439,6 @@ class Mapflow(QObject):
         self.dlg.editProvider.clicked.connect(self.edit_provider)
         self.dlg.removeProvider.clicked.connect(self.remove_provider)
 
-        # Processing ids whose 'No AOI' AOI request is in flight (guards rapid re-clicks).
-        self._pending_no_aoi_ids = set()
         self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
             self.sync_table_selection_with_image_id_and_layer)
         self.dlg.metadataTable.itemSelectionChanged.connect(self.update_start_processing_button_state)
@@ -567,7 +564,6 @@ class Mapflow(QObject):
         self.dlg.save_result_action.triggered.connect(self.download_results_file)
         self.dlg.download_aoi_action.triggered.connect(self.download_aoi_file)
         self.dlg.see_details_action.triggered.connect(self.show_selected_details)
-        self.dlg.see_processings_action.triggered.connect(self.select_template_processings)
         self.dlg.see_search_results_action.triggered.connect(self.show_template_search_results)
         self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
         self.dlg.processing_restart_action.triggered.connect(self.processing_service.restart_processing)
@@ -676,7 +672,7 @@ class Mapflow(QObject):
         """Open details based on selected entity type."""
         template = self.processing_service.selected_template()
         if template and not self.processing_service.selected_processing():
-            self.show_template_details_and_navigation(template)
+            self.template_service.show_template_details(template)
             return
         self.show_details()
 
@@ -820,7 +816,7 @@ class Mapflow(QObject):
         # the AOI-area monitor (which reacts to layersAdded) recognizes and skips it.
         self.app_context.metadata_layer = layer
         if template_group_name:
-            target_group = self._ensure_template_group(template_group_name)
+            target_group = self.template_service.ensure_template_group(template_group_name)
             self.app_context.project.addMapLayer(layer, addToLegend=False)
             # Append (bottom) so the search-results footprints sit below the AOI/processing
             # subgroups rather than on top of them.
@@ -851,262 +847,6 @@ class Mapflow(QObject):
             if aoi_id:
                 ids.append(str(aoi_id))
         return ids
-
-    def show_template_details_and_navigation(self, template):
-        """Show template summary. The processings count is fetched from the
-        ``/processings`` endpoint (aoiDetails links are not always populated)."""
-        self.processing_service.api.get_template_processings(
-            template_id=template.id,
-            callback=lambda response: self._show_template_details_callback(template, response),
-        )
-
-    def _show_template_details_callback(self, template, response: QNetworkReply):
-        try:
-            data = json.loads(response.readAll().data())
-            items = data.get("results") if isinstance(data, dict) else data
-            linked_count = len([i for i in (items or []) if isinstance(i, dict)])
-        except (ValueError, TypeError):
-            # Not JSON (ValueError, which UnicodeDecodeError subclasses), or a payload whose
-            # `results` is not iterable.
-            linked_count = 0
-        new_images = template.newImagesCount or 0
-        local_created_at = template.createdAt.astimezone()
-        local_active_until = template.activeUntil.astimezone()
-
-        details = self.tr(
-            "<b>{name}</b><br/>"
-            "<b>Status:</b> {status}<br/>"
-            "<b>Created:</b> {created}<br/>"
-            "<b>Active Until:</b> {active_until}<br/>"
-            "<b>Linked processings:</b> {linked}<br/>"
-            "<b>New images:</b> {new_images}"
-        ).format(
-            name=template.name,
-            status=template.status,
-            created=local_created_at.strftime('%Y-%m-%d %H:%M'),
-            active_until=local_active_until.strftime('%Y-%m-%d %H:%M'),
-            linked=linked_count,
-            new_images=new_images,
-        )
-
-        alert(details, QMessageBox.Information)
-
-    def select_template_processings(self):
-        """Menu action: load AOI/processing layers for the selected template."""
-        template = self.processing_service.selected_template()
-        if not template or self.processing_service.selected_processing():
-            return
-        # Hydrate first (the list view's template omits aoiDetails), then draw layers.
-        self.processing_service.hydrate_template(template, self._load_template_layers)
-
-    def _load_template_layers(self, template):
-        """Draw, per AOI, a subgroup named after the AOI containing the AOI polygon (blue)
-        and each of its processings' footprints (green), all from the template's
-        ``aoiDetails`` (no extra requests)."""
-        if not template:
-            return
-        template_group_name = str(template.name)
-        for aoi in template.aoi_dtos():
-            subgroup_name = self.tr("AOI: {name}").format(name=aoi.display_name)
-            if aoi.geometry:
-                self._add_geojson_aoi_layer(
-                    features=[{"type": "Feature", "geometry": aoi.geometry, "properties": {}}],
-                    layer_name=aoi.display_name,
-                    style_name='aoi_template_blue.qml',
-                    template_group_name=template_group_name,
-                    subgroup_name=subgroup_name,
-                    aoi_id=aoi.id,
-                )
-            for link in aoi.processings:
-                if not link.geometry:
-                    continue
-                self._add_geojson_aoi_layer(
-                    features=[{"type": "Feature", "geometry": link.geometry, "properties": {}}],
-                    layer_name=link.processingName or str(link.processingId),
-                    style_name='aoi_template_processing_green.qml',
-                    template_group_name=template_group_name,
-                    subgroup_name=subgroup_name,
-                )
-
-    def _no_aoi_subgroup_name(self) -> str:
-        return self.tr("No AOI")
-
-    def on_template_processings_loaded(self, template) -> None:
-        """Once a template's processings load, create the (initially empty) 'No AOI' group if any
-        processing is not bound to an AOI. Each such AOI is fetched and added lazily when the user
-        single-clicks its row (see on_no_aoi_processing_clicked) — no bulk requests on open."""
-        if not template or not self.processing_service.no_aoi_processing_ids():
-            return
-        self._ensure_template_group(str(template.name), self._no_aoi_subgroup_name())
-
-    def on_no_aoi_processing_clicked(self, *args) -> None:
-        """Single-click on a 'No AOI' processing row: fetch that processing's AOI and add it to the
-        'No AOI' group. No-op outside a template, for AOI/bound-processing rows, or when the AOI is
-        already on the map or its request is already in flight (double-click still loads results)."""
-        if not self.processing_service.in_template_mode:
-            return
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        pid = str(processing.id)
-        if not self.processing_service.is_no_aoi_processing(pid):
-            return
-        if pid in self._pending_no_aoi_ids or self._no_aoi_aoi_on_map(pid):
-            return
-        self._pending_no_aoi_ids.add(pid)
-        self.http.get(
-            url=f'{self.server}/processings/{pid}/aois',
-            callback=self._add_no_aoi_processing_aoi_callback,
-            callback_kwargs={'pid': pid, 'name': processing.name},
-            error_handler=self._add_no_aoi_processing_aoi_error,
-            error_handler_kwargs={'pid': pid},
-            use_default_error_handler=False,
-            timeout=30,
-        )
-
-    def _add_no_aoi_processing_aoi_callback(self, response: QNetworkReply, pid: str, name: str) -> None:
-        self._pending_no_aoi_ids.discard(pid)
-        template = self.processing_service.active_template
-        if not template or not self.processing_service.in_template_mode or self._no_aoi_aoi_on_map(pid):
-            return
-        # GET /processings/{id}/aois returns a JSON list of AOI objects (each with a `geometry`),
-        # not a FeatureCollection — wrap each geometry into a feature the layer builder understands.
-        try:
-            aois = json.loads(response.readAll().data())
-        except ValueError:
-            # Not JSON, or not decodable as UTF-8 (UnicodeDecodeError is a ValueError).
-            return
-        if isinstance(aois, dict):
-            aois = aois.get('aois', [])
-        features = [{"type": "Feature", "geometry": aoi.get("geometry"), "properties": {}}
-                    for aoi in aois if isinstance(aoi, dict) and aoi.get("geometry")]
-        if not features:
-            return
-        layer = self._add_geojson_aoi_layer(
-            features=features,
-            layer_name=name or pid,
-            style_name='aoi_template_processing_green.qml',
-            template_group_name=str(template.name),
-            subgroup_name=self._no_aoi_subgroup_name(),
-        )
-        if layer is not None:
-            layer.setCustomProperty('mapflow/no_aoi_processing_id', str(pid))
-
-    def _add_no_aoi_processing_aoi_error(self, response: QNetworkReply, pid: str = None) -> None:
-        self._pending_no_aoi_ids.discard(pid)
-
-    def _no_aoi_aoi_on_map(self, pid) -> bool:
-        """Whether a 'No AOI' processing's AOI layer (tagged with its id) is already on the map."""
-        return any(layer.customProperty('mapflow/no_aoi_processing_id') == str(pid)
-                   for layer in self.app_context.project.mapLayers().values())
-
-    def _add_geojson_aoi_layer(self,
-                               features: list,
-                               layer_name: str,
-                               style_name: str,
-                               template_group_name: Optional[str] = None,
-                               subgroup_name: Optional[str] = None,
-                               reference_layer_id: Optional[str] = None,
-                               aoi_id: Optional[str] = None) -> Optional[QgsVectorLayer]:
-        if not features:
-            return None
-        aoi_layer = QgsVectorLayer('Polygon?crs=epsg:4326', layer_name, 'memory')
-        # Tag the AOI's own polygon layer with its id so "Update selected AOI" can find and edit
-        # this exact layer in place (processing-footprint layers are left untagged).
-        if aoi_id is not None:
-            aoi_layer.setCustomProperty('mapflow/aoi_id', str(aoi_id))
-        provider = aoi_layer.dataProvider()
-        qgs_features = []
-        for feature in features:
-            geom_dict = feature.get("geometry")
-            if not geom_dict:
-                continue
-            try:
-                ogr_geom = ogr.CreateGeometryFromJson(json.dumps(geom_dict))
-                if not ogr_geom:
-                    continue
-                qgs_geom = QgsGeometry.fromWkt(ogr_geom.ExportToWkt())
-                qgs_feat = QgsFeature()
-                qgs_feat.setGeometry(qgs_geom)
-                qgs_features.append(qgs_feat)
-            except Exception as e:
-                # Per-feature, inside a loop: no traceback, or one malformed response
-                # buries the panel in near-identical stack dumps.
-                logger.warning("Skipping a search feature that failed to parse: %s", e)
-                continue
-        if not qgs_features:
-            return None
-        provider.addFeatures(qgs_features)
-        aoi_layer.updateExtents()
-
-        root = self.app_context.project.layerTreeRoot()
-        if template_group_name:
-            target_group = self._ensure_template_group(template_group_name, subgroup_name)
-            self.app_context.project.addMapLayer(aoi_layer, addToLegend=False)
-            target_group.insertLayer(0, aoi_layer)
-        elif reference_layer_id:
-            root = self.app_context.project.layerTreeRoot()
-            ref_node = root.findLayer(reference_layer_id)
-            if ref_node and ref_node.parent():
-                self.app_context.project.addMapLayer(aoi_layer, addToLegend=False)
-                ref_node.parent().insertLayer(0, aoi_layer)
-            else:
-                self.app_context.project.addMapLayer(aoi_layer)
-        else:
-            self.app_context.project.addMapLayer(aoi_layer)
-
-        aoi_layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', style_name))
-        # Template AOI layers are added in bulk on open; don't fire a cost request per layer,
-        # and don't let them become the current processing Area (feedback 8.1) — the Area is
-        # set from the AOI table selection (see sync_processing_area_to_selected_aois).
-        self.aoi_service.register_layer(aoi_layer, recompute_cost=False, set_current=False)
-        return aoi_layer
-
-    def _find_template_group(self,
-                             template_group_name: str,
-                             subgroup_name: Optional[str] = None):
-        """The ``Mapflow > <template name> [> <subgroup>]`` layer-tree group, or None.
-
-        Creates nothing. Callers that only need to *place* a layer next to the template's other
-        layers use this: they run on selection changes and preview clicks, and a lookup that
-        materialises a group as a side effect cannot be called on a path like that without a
-        lambda to defer it.
-        """
-        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
-        return layer_utils.find_template_group(self.app_context.project, mapflow_group_name,
-                                               template_group_name, subgroup_name)
-
-    def _ensure_template_group(self,
-                               template_group_name: str,
-                               subgroup_name: Optional[str] = None):
-        """Find or create that group, and return the node new layers should be inserted into.
-
-        For the callers that are *adding* the template's layers, and so legitimately bring the
-        group into being. Everything that merely places an already-built layer wants
-        ``_find_template_group`` instead.
-
-        The Mapflow group is created here when missing so the template group is nested under it
-        from the very first (template-open) call. Previously the open path fell back to the root
-        because the Mapflow group did not exist yet, and a later preview — by which point the
-        group had been created — added a SECOND template group under it (feedback 4.1). If the
-        user has deleted the Mapflow group (the result loader then adds to root), respect that
-        and place template groups at the root too, keeping a single path."""
-        root = self.app_context.project.layerTreeRoot()
-        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
-        mapflow_group = root.findGroup(mapflow_group_name)
-        if mapflow_group is None and getattr(self.result_loader, 'add_layers_to_group', True):
-            mapflow_group = root.insertGroup(0, mapflow_group_name)
-            self.app_context.settings.setValue('layerGroup', mapflow_group_name)
-        parent_group = mapflow_group if mapflow_group else root
-        template_group = parent_group.findGroup(template_group_name)
-        if not template_group:
-            template_group = parent_group.insertGroup(0, template_group_name)
-        if subgroup_name:
-            subgroup = template_group.findGroup(subgroup_name)
-            if not subgroup:
-                subgroup = template_group.insertGroup(0, subgroup_name)
-            return subgroup
-        return template_group
 
     def show_template_search_results(self):
         """Menu action: fill the imagery-search table with the selected template's results."""
@@ -1193,20 +933,6 @@ class Mapflow(QObject):
             return
         self._template_search_aoi_filter = selected_ids or None
         self._load_template_search(template, aoi_ids=list(selected_ids) or None)
-
-    def sync_processing_area_to_selected_aois(self):
-        """Inside a template, point the Area combo at the selected AOI(s), so the Area shown in
-        the combo IS the one a processing will use — one place to look, no silent override.
-
-        A single selection points at that AOI's own (already visible) layer; a multi-selection
-        points at a visible "Selected AOIs" layer holding one feature per AOI. No-op when no AOI
-        is selected, keeping the current Area (e.g. while a processing row is selected)."""
-        if not self.processing_service.in_template_mode:
-            return
-        template = self.processing_service.active_template
-        self.aoi_service.select_aois_as_processing_area(
-            self.processing_service.selected_aois(),
-            self._find_template_group(str(template.name)) if template else None)
 
     def select_processing_in_table(self, processing_id: str):
         """Select processing row by ID and open processing details."""
@@ -2338,7 +2064,9 @@ class Mapflow(QObject):
         self.project_processing_controller.enter_template(template)
 
     def on_template_opened(self, template):
-        """React to entering a template: fill search results and load AOI/processing layers."""
+        """React to entering a template: fill the search results and mirror its params into the
+        filter widgets. The AOI/processing map layers are drawn by TemplateController's own
+        `templateOpened` listener."""
         # Initial results are the whole template (no AOI filter applied yet).
         self._template_search_aoi_filter = None
         # Drop the previous view's results/baseline first, so the widget updates below (which
@@ -2352,12 +2080,10 @@ class Mapflow(QObject):
         self.dlg.updateTemplateSearch.setVisible(True)
         self.apply_search_params_to_ui(getattr(template, "searchParams", None))
         self._load_template_search(template)
-        self._load_template_layers(template)
 
     def on_template_closed(self, template):
-        """React to leaving a template: drop its map group and clear the search table."""
-        if template is not None:
-            self._remove_template_group(str(template.name))
+        """React to leaving a template: clear the search table and view state. The template's map
+        group is dropped by TemplateController's own `templateClosed` listener."""
         self.app_context.open_template_results_id = None
         self._template_search_aoi_filter = None
         self.app_context.search_result_geojson = None
@@ -2371,39 +2097,6 @@ class Mapflow(QObject):
         # Clear the template search-results pagination so it is not preserved on re-open.
         self.search_service.page_offset = 0
         self.dlg.enable_search_pages(False)
-
-    def on_template_aois_changed(self, template):
-        """Redraw the template's AOI/processing map layers after its AOIs change (add / rename
-        / delete / geometry update / exclude-from-search), so the layer tree stays in sync
-        without re-entering the template."""
-        if not template:
-            return
-        self._remove_template_aoi_subgroups(str(template.name))
-        self._load_template_layers(template)
-
-    def _remove_template_aoi_subgroups(self, template_group_name: str):
-        """Remove the per-AOI subgroups (and their layers) under the template group, keeping
-        the search-results footprint layer that sits directly in the template group."""
-        if not template_group_name:
-            return
-        root = self.app_context.project.layerTreeRoot()
-        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
-        mapflow_group = root.findGroup(mapflow_group_name)
-        parent_group = mapflow_group if mapflow_group else root
-        template_group = parent_group.findGroup(template_group_name)
-        if template_group is None:
-            return
-        for child in list(template_group.children()):
-            # AOI subgroups are groups; the search-footprints node is a layer — leave it.
-            if isinstance(child, QgsLayerTreeGroup):
-                for layer in child.findLayers():
-                    layer_id = layer.layerId()
-                    if layer_id:
-                        try:
-                            self.app_context.project.removeMapLayer(layer_id)
-                        except (RuntimeError, KeyError):
-                            pass
-                template_group.removeChildNode(child)
 
     def apply_search_params_to_ui(self, search_params):
         """Populate the Imagery Search filters from a template's stored ``searchParams``
@@ -2448,26 +2141,6 @@ class Mapflow(QObject):
         for index in range(combo.count()):
             if combo.itemData(index) in wanted:
                 combo.setItemCheckState(index, Qt.Checked)
-
-    def _remove_template_group(self, template_group_name: str):
-        """Remove the template's layer-tree group (and its layers) from the map."""
-        if not template_group_name:
-            return
-        root = self.app_context.project.layerTreeRoot()
-        mapflow_group_name = self.app_context.settings.value('layerGroup') or self.app_context.plugin_name
-        mapflow_group = root.findGroup(mapflow_group_name)
-        parent_group = mapflow_group if mapflow_group else root
-        template_group = parent_group.findGroup(template_group_name)
-        if template_group is None:
-            return
-        for layer in template_group.findLayers():
-            layer_id = layer.layerId()
-            if layer_id:
-                try:
-                    self.app_context.project.removeMapLayer(layer_id)
-                except (RuntimeError, KeyError):
-                    pass
-        parent_group.removeChildNode(template_group)
 
     def load_results(self):
         # Check if it's a template first

--- a/tests/qgis/test_no_aoi_processings.py
+++ b/tests/qgis/test_no_aoi_processings.py
@@ -3,12 +3,17 @@
 Processings attached to a template but not intersecting any AOI are omitted from aoiDetails, so
 their geometry is fetched per-processing (GET /processings/{id}/aois) on a single click of the row
 and added to a 'No AOI' group — with dedup so an already-added processing is not re-fetched.
+
+Owners after the layers/navigation extraction: `TemplateController` reads the click and the
+in-template guard; `TemplateService` owns the request, the in-flight set, and the callback that
+draws the layer (`spec/007_architecture.md` § Layer rules / § Controllers).
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service.processing_service import ProcessingService
-from mapflow.mapflow import Mapflow
+from mapflow.functional.service.template_service import TemplateService
 
 
 # ---------------- service: which processings are 'No AOI' ----------------
@@ -29,92 +34,113 @@ def test_no_aoi_processing_ids_are_the_unbound_ones():
     assert service.is_no_aoi_processing("p1") is False
 
 
-# ---------------- Mapflow: create the group, click to add ----------------
+# ---------------- controller: the click reads the row, guards in-template ----------------
 
-def _plugin_click(in_template=True, is_no_aoi=True, on_map=False, processing=None):
-    if processing is None:
-        processing = SimpleNamespace(id="p2", name="proc")
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.server = "https://server"
-    plugin.http = MagicMock()
-    plugin._pending_no_aoi_ids = set()
-    plugin._no_aoi_aoi_on_map = MagicMock(return_value=on_map)
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = in_template
-    plugin.processing_service.selected_processing.return_value = processing
-    plugin.processing_service.is_no_aoi_processing.return_value = is_no_aoi
-    return plugin
+def _controller(in_template=True, processing=None):
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.processing_service.in_template_mode = in_template
+    controller.processing_service.selected_processing.return_value = processing
+    return controller
 
 
-def test_click_fetches_and_marks_in_flight_for_no_aoi_processing():
-    plugin = _plugin_click()
+def test_click_delegates_the_selected_processing_in_template():
+    processing = SimpleNamespace(id="p2", name="proc")
+    controller = _controller(processing=processing)
 
-    plugin.on_no_aoi_processing_clicked(0, 0)
+    controller.on_no_aoi_processing_clicked(0, 0)
 
-    plugin.http.get.assert_called_once()
-    assert plugin.http.get.call_args.kwargs["url"].endswith("/processings/p2/aois")
-    assert "p2" in plugin._pending_no_aoi_ids
-
-
-def test_click_ignored_for_bound_processing():
-    plugin = _plugin_click(is_no_aoi=False)
-    plugin.on_no_aoi_processing_clicked(0, 0)
-    plugin.http.get.assert_not_called()
+    controller.template_service.load_no_aoi_processing_aoi.assert_called_once_with(processing)
 
 
 def test_click_ignored_outside_template():
-    plugin = _plugin_click(in_template=False)
-    plugin.on_no_aoi_processing_clicked(0, 0)
-    plugin.http.get.assert_not_called()
+    controller = _controller(in_template=False)
+    controller.on_no_aoi_processing_clicked(0, 0)
+    controller.template_service.load_no_aoi_processing_aoi.assert_not_called()
 
 
-def test_click_ignored_when_aoi_already_on_map():
-    plugin = _plugin_click(on_map=True)
-    plugin.on_no_aoi_processing_clicked(0, 0)
-    plugin.http.get.assert_not_called()
+# ---------------- service: fetch on demand, dedup, mark in flight ----------------
+
+def _service_load(is_no_aoi=True, on_map=False, pending=None):
+    processing_service = MagicMock()
+    processing_service.is_no_aoi_processing.return_value = is_no_aoi
+    service = TemplateService(app_context=MagicMock(), processing_service=processing_service)
+    service.no_aoi_aoi_on_map = MagicMock(return_value=on_map)
+    if pending:
+        service._pending_no_aoi_ids.update(pending)
+    return service
 
 
-def test_click_ignored_when_request_in_flight():
-    plugin = _plugin_click()
-    plugin._pending_no_aoi_ids.add("p2")
-    plugin.on_no_aoi_processing_clicked(0, 0)
-    plugin.http.get.assert_not_called()
+def test_load_fetches_and_marks_in_flight_for_no_aoi_processing():
+    service = _service_load()
+
+    service.load_no_aoi_processing_aoi(SimpleNamespace(id="p2", name="proc"))
+
+    service.processing_service.api.get_processing_aois.assert_called_once()
+    assert service.processing_service.api.get_processing_aois.call_args.kwargs["processing_id"] == "p2"
+    assert "p2" in service._pending_no_aoi_ids
+
+
+def test_load_ignored_for_bound_processing():
+    service = _service_load(is_no_aoi=False)
+    service.load_no_aoi_processing_aoi(SimpleNamespace(id="p2", name="proc"))
+    service.processing_service.api.get_processing_aois.assert_not_called()
+
+
+def test_load_ignored_when_aoi_already_on_map():
+    service = _service_load(on_map=True)
+    service.load_no_aoi_processing_aoi(SimpleNamespace(id="p2", name="proc"))
+    service.processing_service.api.get_processing_aois.assert_not_called()
+
+
+def test_load_ignored_when_request_in_flight():
+    service = _service_load(pending={"p2"})
+    service.load_no_aoi_processing_aoi(SimpleNamespace(id="p2", name="proc"))
+    service.processing_service.api.get_processing_aois.assert_not_called()
+
+
+def test_load_ignored_for_no_processing():
+    service = _service_load()
+    service.load_no_aoi_processing_aoi(None)
+    service.processing_service.api.get_processing_aois.assert_not_called()
 
 
 def test_callback_draws_layer_tags_it_and_clears_in_flight():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin._pending_no_aoi_ids = {"p2"}
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = True
-    plugin.processing_service.active_template = SimpleNamespace(name="T")
-    plugin._no_aoi_aoi_on_map = MagicMock(return_value=False)
+    processing_service = MagicMock()
+    processing_service.in_template_mode = True
+    processing_service.active_template = SimpleNamespace(name="T")
+    service = TemplateService(app_context=MagicMock(), processing_service=processing_service)
+    service._pending_no_aoi_ids = {"p2"}
+    service.no_aoi_aoi_on_map = MagicMock(return_value=False)
     layer = MagicMock()
-    plugin._add_geojson_aoi_layer = MagicMock(return_value=layer)
+    service.add_geojson_aoi_layer = MagicMock(return_value=layer)
     response = MagicMock()
     # /processings/{id}/aois returns a JSON list of AOI objects, each with a geometry.
     response.readAll.return_value.data.return_value = (
         b'[{"id":"a1","geometry":{"type":"Polygon","coordinates":[]}}]')
 
-    plugin._add_no_aoi_processing_aoi_callback(response, pid="p2", name="proc")
+    service._add_no_aoi_processing_aoi_callback(response, pid="p2", name="proc")
 
-    plugin._add_geojson_aoi_layer.assert_called_once()
-    assert plugin._add_geojson_aoi_layer.call_args.kwargs["subgroup_name"] == "No AOI"
+    service.add_geojson_aoi_layer.assert_called_once()
+    assert service.add_geojson_aoi_layer.call_args.kwargs["subgroup_name"] == "No AOI"
     layer.setCustomProperty.assert_called_once_with("mapflow/no_aoi_processing_id", "p2")
-    assert "p2" not in plugin._pending_no_aoi_ids
+    assert "p2" not in service._pending_no_aoi_ids
 
+
+# ---------------- controller: create the 'No AOI' group only when unbound processings exist ----------------
 
 def test_processings_loaded_creates_no_aoi_group_only_when_unbound_exist():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.processing_service = MagicMock()
-    plugin._ensure_template_group = MagicMock()
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.template_service.no_aoi_subgroup_name.return_value = "No AOI"
+    controller.processing_service = MagicMock()
 
-    plugin.processing_service.no_aoi_processing_ids.return_value = {"p2"}
-    plugin.on_template_processings_loaded(SimpleNamespace(name="T"))
-    plugin._ensure_template_group.assert_called_once_with("T", "No AOI")
+    controller.processing_service.no_aoi_processing_ids.return_value = {"p2"}
+    controller.on_template_processings_loaded(SimpleNamespace(name="T"))
+    controller.template_service.ensure_template_group.assert_called_once_with("T", "No AOI")
 
-    plugin._ensure_template_group.reset_mock()
-    plugin.processing_service.no_aoi_processing_ids.return_value = set()
-    plugin.on_template_processings_loaded(SimpleNamespace(name="T"))
-    plugin._ensure_template_group.assert_not_called()
+    controller.template_service.ensure_template_group.reset_mock()
+    controller.processing_service.no_aoi_processing_ids.return_value = set()
+    controller.on_template_processings_loaded(SimpleNamespace(name="T"))
+    controller.template_service.ensure_template_group.assert_not_called()

--- a/tests/qgis/test_template_errors_pagination.py
+++ b/tests/qgis/test_template_errors_pagination.py
@@ -85,7 +85,6 @@ def test_on_template_closed_resets_search_pagination():
     plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.search_service = _search_service()
     plugin.search_service.page_offset = 60
-    plugin._remove_template_group = MagicMock()
     plugin.aoi_service = MagicMock()
 
     plugin.on_template_closed(None)

--- a/tests/qgis/test_template_group_and_preview.py
+++ b/tests/qgis/test_template_group_and_preview.py
@@ -12,25 +12,26 @@ from unittest.mock import MagicMock
 from qgis.core import QgsProject
 
 from mapflow.functional.service.preview_service import PreviewService
+from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.search_view import SearchView
-from mapflow.mapflow import Mapflow
 
 
-def _plugin_for_group(project, add_layers_to_group=True):
-    plugin = Mapflow.__new__(Mapflow)
+def _service_for_group(project, add_layers_to_group=True):
     settings = MagicMock()
     settings.value.return_value = None  # no custom layerGroup -> falls back to plugin_name
-    plugin.app_context = SimpleNamespace(project=project, settings=settings, plugin_name="Mapflow")
-    plugin.result_loader = SimpleNamespace(add_layers_to_group=add_layers_to_group)
-    return plugin
+    app_context = SimpleNamespace(project=project, settings=settings, plugin_name="Mapflow")
+    return TemplateService(
+        app_context=app_context,
+        processing_service=MagicMock(),
+        result_loader=SimpleNamespace(add_layers_to_group=add_layers_to_group))
 
 
 def test_template_group_created_under_mapflow_group_when_absent():
     project = QgsProject()
     root = project.layerTreeRoot()
-    plugin = _plugin_for_group(project)
+    service = _service_for_group(project)
 
-    group = plugin._ensure_template_group("T1")
+    group = service.ensure_template_group("T1")
 
     mapflow_group = root.findGroup("Mapflow")
     assert mapflow_group is not None
@@ -42,10 +43,10 @@ def test_template_group_created_under_mapflow_group_when_absent():
 def test_open_then_preview_reuse_the_same_single_group():
     project = QgsProject()
     root = project.layerTreeRoot()
-    plugin = _plugin_for_group(project)
+    service = _service_for_group(project)
 
-    open_group = plugin._ensure_template_group("T1", subgroup_name="AOI: North")
-    preview_group = plugin._ensure_template_group("T1")  # later preview call
+    open_group = service.ensure_template_group("T1", subgroup_name="AOI: North")
+    preview_group = service.ensure_template_group("T1")  # later preview call
 
     mapflow_group = root.findGroup("Mapflow")
     # Exactly one "T1" group exists, under the Mapflow group.
@@ -58,25 +59,25 @@ def test_open_then_preview_reuse_the_same_single_group():
 def test_template_group_falls_back_to_root_when_user_deleted_mapflow_group():
     project = QgsProject()
     root = project.layerTreeRoot()
-    plugin = _plugin_for_group(project, add_layers_to_group=False)
+    service = _service_for_group(project, add_layers_to_group=False)
 
-    group = plugin._ensure_template_group("T1")
+    group = service.ensure_template_group("T1")
 
     assert root.findGroup("Mapflow") is None
     assert root.findGroup("T1") is group
 
 
 def test_finding_a_template_group_creates_nothing():
-    """The whole point of the find/ensure split. `_find_template_group` is called from paths
+    """The whole point of the find/ensure split. `find_template_group` is called from paths
     that fire on every AOI selection and every preview click; if it created the group as a
     side effect, opening a template and clicking around would conjure groups the user never
     asked for — which is why those callers previously had to defer it behind a lambda."""
     project = QgsProject()
     root = project.layerTreeRoot()
-    plugin = _plugin_for_group(project)
+    service = _service_for_group(project)
 
-    assert plugin._find_template_group("T1") is None
-    assert plugin._find_template_group("T1", subgroup_name="AOI: North") is None
+    assert service.find_template_group("T1") is None
+    assert service.find_template_group("T1", subgroup_name="AOI: North") is None
 
     assert root.findGroup("Mapflow") is None
     assert not any(child.name() == "T1" for child in root.children())
@@ -84,12 +85,12 @@ def test_finding_a_template_group_creates_nothing():
 
 def test_finding_a_template_group_returns_the_one_ensure_made():
     project = QgsProject()
-    plugin = _plugin_for_group(project)
+    service = _service_for_group(project)
 
-    created = plugin._ensure_template_group("T1", subgroup_name="AOI: North")
+    created = service.ensure_template_group("T1", subgroup_name="AOI: North")
 
-    assert plugin._find_template_group("T1") is created.parent()
-    assert plugin._find_template_group("T1", subgroup_name="AOI: North") is created
+    assert service.find_template_group("T1") is created.parent()
+    assert service.find_template_group("T1", subgroup_name="AOI: North") is created
 
 
 def _search_view():

--- a/tests/qgis/test_template_processing_area.py
+++ b/tests/qgis/test_template_processing_area.py
@@ -16,9 +16,9 @@ from unittest.mock import MagicMock
 import pytest
 from qgis.core import QgsVectorLayer
 
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.geometry import geometry_from_geojson
 from mapflow.functional.service.aoi_service import AoiService
-from mapflow.mapflow import Mapflow
 
 
 def _square(x0, y0, size=1.0):
@@ -108,7 +108,7 @@ def test_missing_aoi_layer_leaves_the_area_untouched(service, area_layers):
 
 def test_a_single_selection_does_not_touch_the_template_group(service, area_layers):
     """A single AOI uses its own layer, so nothing is built and nothing is placed. The group is
-    resolved by the caller now (`Mapflow._find_template_group`, which creates nothing), so this
+    resolved by the caller now (`TemplateService.find_template_group`, which creates nothing), so this
     no longer needs to assert on how it was passed — only that no layer is built for it."""
     service.select_aois_as_processing_area([_aoi("a1", _square(0, 0))], group=None)
 
@@ -142,14 +142,16 @@ def test_leaving_the_template_forgets_the_selection(service, area_layers):
 
 
 def test_not_in_template_mode_is_noop():
-    """The in-template check stays with the caller: `AoiService` has no view of navigation."""
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.aoi_service = MagicMock()
-    plugin.processing_service = SimpleNamespace(in_template_mode=False)
+    """The in-template check stays with the caller (now `TemplateController`): `AoiService` has
+    no view of navigation."""
+    controller = TemplateController.__new__(TemplateController)
+    controller.aoi_service = MagicMock()
+    controller.template_service = MagicMock()
+    controller.processing_service = SimpleNamespace(in_template_mode=False)
 
-    plugin.sync_processing_area_to_selected_aois()
+    controller.sync_processing_area_to_selected_aois()
 
-    plugin.aoi_service.select_aois_as_processing_area.assert_not_called()
+    controller.aoi_service.select_aois_as_processing_area.assert_not_called()
 
 
 def test_geometry_from_geojson_none_for_empty():

--- a/tests/qgis/test_template_search_params_ui.py
+++ b/tests/qgis/test_template_search_params_ui.py
@@ -118,7 +118,6 @@ def test_on_template_opened_populates_search_filters():
     plugin = _plugin()
     plugin.apply_search_params_to_ui = MagicMock()
     plugin._load_template_search = MagicMock()
-    plugin._load_template_layers = MagicMock()
     search_params = _search_params()
     template = SimpleNamespace(id="tpl-1", name="T1", searchParams=search_params)
 
@@ -126,4 +125,5 @@ def test_on_template_opened_populates_search_filters():
 
     plugin.apply_search_params_to_ui.assert_called_once_with(search_params)
     plugin._load_template_search.assert_called_once_with(template)
-    plugin._load_template_layers.assert_called_once_with(template)
+    # The AOI/processing layers are drawn by TemplateController's own templateOpened listener,
+    # not by on_template_opened (which now handles only the search/filter side).

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -223,9 +223,8 @@ def test_load_template_layers_builds_per_aoi_subgroups_from_aoidetails():
     all from aoiDetails — no per-processing AOI requests."""
     from mapflow.schema.template import AoiProcessingLink, TemplateAoiDTO
 
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin._add_geojson_aoi_layer = MagicMock()
+    service = TemplateService(app_context=MagicMock(), processing_service=MagicMock())
+    service.add_geojson_aoi_layer = MagicMock()
 
     geom = {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [0, 0]]]}
     proc_geom = {"type": "Polygon", "coordinates": [[[0, 0], [0, 2], [2, 2], [0, 0]]]}
@@ -235,13 +234,13 @@ def test_load_template_layers_builds_per_aoi_subgroups_from_aoidetails():
     )
     template = SimpleNamespace(name="Template A", aoi_dtos=lambda: [aoi])
 
-    plugin._load_template_layers(template)
+    service.load_template_layers(template)
 
     # One AOI (blue) layer + one processing (green) layer, both in the AOI's subgroup.
-    assert plugin._add_geojson_aoi_layer.call_count == 2
-    styles = [c.kwargs["style_name"] for c in plugin._add_geojson_aoi_layer.call_args_list]
+    assert service.add_geojson_aoi_layer.call_count == 2
+    styles = [c.kwargs["style_name"] for c in service.add_geojson_aoi_layer.call_args_list]
     assert styles == ["aoi_template_blue.qml", "aoi_template_processing_green.qml"]
-    subgroups = {c.kwargs["subgroup_name"] for c in plugin._add_geojson_aoi_layer.call_args_list}
+    subgroups = {c.kwargs["subgroup_name"] for c in service.add_geojson_aoi_layer.call_args_list}
     assert subgroups == {"AOI: North"}
 
 

--- a/tests/qgis/test_template_updates.py
+++ b/tests/qgis/test_template_updates.py
@@ -13,7 +13,6 @@ from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.geometry import geometry_from_geojson
 from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.search_view import SearchView
-from mapflow.mapflow import Mapflow
 from mapflow.schema.template import TemplateAoiDTO, AoiProcessingLink
 
 
@@ -160,27 +159,26 @@ def test_exclude_noop_when_processing_not_linked(monkeypatch):
     service.processing_service.api.delete_aois.assert_not_called()
 
 
-# ---------- Item 1: redraw template layers on AOI change ----------
+# ---------- Item 1: redraw template layers on AOI change (TemplateController -> TemplateService) ----------
 
 def test_on_template_aois_changed_redraws_layers():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin._remove_template_aoi_subgroups = MagicMock()
-    plugin._load_template_layers = MagicMock()
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
     template = SimpleNamespace(name="T1")
 
-    plugin.on_template_aois_changed(template)
+    controller.on_template_aois_changed(template)
 
-    plugin._remove_template_aoi_subgroups.assert_called_once_with("T1")
-    plugin._load_template_layers.assert_called_once_with(template)
+    controller.template_service.remove_template_aoi_subgroups.assert_called_once_with("T1")
+    controller.template_service.load_template_layers.assert_called_once_with(template)
 
 
 def test_on_template_aois_changed_noop_without_template():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin._load_template_layers = MagicMock()
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
 
-    plugin.on_template_aois_changed(None)
+    controller.on_template_aois_changed(None)
 
-    plugin._load_template_layers.assert_not_called()
+    controller.template_service.load_template_layers.assert_not_called()
 
 
 def test_reopen_template_callback_emits_aois_changed():


### PR DESCRIPTION
Area A of the templates layers+navigation step, sliced in two so each MR stays the size of the earlier template MRs. The template's map-layer building/placement and the layer-related in-template navigation leave mapflow.py; the search-render/filter half (Area B/C) is the next MR.

TemplateService gains the QGIS layer-tree work — ensure/find/remove_template_group, remove_template_aoi_subgroups, add_geojson_aoi_layer, load_template_layers, the 'No AOI' lazy per-processing fetch, and show_template_details. This is layer-tree work, not widgets, so it belongs in a service alongside AoiService/PreviewService's own layer building (spec/007 § Layer rules). TemplateController takes the signal slots (entry points): the aoiDetails redraw, the 'No AOI' group, the selected-AOI processing Area, "See processings", and a SECOND listener on templateOpened/Closed for the layer side — so mapflow.py's own listener (the search/filter side) and the controller's never edit each other (spec/007 § Controllers). Verified order-independent: load_template_layers reads only the template and the project, and _load_template_search is async, so the footprint layer lands after both slots regardless; the behavioral enter/leave-template journeys pass unchanged.

ensure_template_group moved now even though the WAL reserves group placement for MR-2: only mapflow.py called it, so moving it is clean and a down payment on that decision. The read-only layer_utils.find_template_group that AoiService/PreviewService share stays a free function until MR-2 repoints those two.

The 'No AOI' request moved off the controller and into the service via a new ProcessingApi.get_processing_aois, so the controller never touches Http (spec/007 § Layer rules); the in-flight guard set moved with it. show_template_details alerts through alert_info instead of alert(..., QMessageBox.Information) so the service imports no QtWidgets.

Moving the methods stranded four imports in mapflow.py (osgeo.ogr, QgsFeature, QgsGeometry, QgsLayerTreeGroup) — F401 is suppressed in the ledger, so these were found by hand, not by lint.

The transient Class.__new__(Mapflow) tests for these methods are rewritten against the new owners; the AoiService/PreviewService/ProcessingService tests living in the same files are untouched. The group/layer tests still drive a real QgsProject and assert the actual tree, so they discriminate the move rather than just asserting a call.

## Manual test
Enter a template (select a template row, click the "enter template" arrow, or double-click): its AOIs draw as blue polygons in per-AOI subgroups under Mapflow > <template>, with each linked processing's footprint in green; a "No AOI" group appears when the template has processings not bound to an AOI. Single-click a "No AOI" processing row: its AOI is fetched once and added under "No AOI" (a second click does nothing; double-click still loads results). Select AOI rows: the Area combo points at the selection. Right-click a template > "See processings" draws its layers; "See details" shows the summary popup. Add/rename/delete a template AOI, or "Exclude from search": the map layers redraw. Leave the template (left arrow): its whole group is removed. Regression surface: opening/closing a template must not leave a stray or duplicated layer group, and the search-results footprint layer (added asynchronously) must still sit at the bottom of the template group, below the AOI subgroups.