### PR TITLE
refactor: move the template search results and their filter widgets out of mapflow.py

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -48,13 +48,13 @@ exclude + plan-search gating; the seen-markers cluster; the template map layers 
 layer-related navigation slots. `TemplateService` reads navigation state from `processing_service`
 for now (service→service); ownership moves in MR-2.
 
-[ ] Templates search render + filter + params-to-UI (Area B/C of layers+navigation)
-Remaining `mapflow.py` template half: `_load_template_search(_page)`, `show_template_search_results`,
-`get_selected_template_callback`, `_store_template_search_footprints`, `_aoi_ids_from_template`,
-`_template_single_data_provider`, `_template_filter_baseline`, `apply_search_params_to_ui`, and
-`filter_search_by_selected_aoi` (reads `processing_service.selected_aois()` and calls
-`_load_template_search`, both template). Needs the service→widget view split for the metadata table
-and the search filter widgets.
+[ready-for-review] Templates search render + filter + params-to-UI (Area B/C of layers+navigation)
+The template's search request, its result rendering and footprints layer, the selected-AOI scoping
+and the "template searchParams → filter widgets" mirroring leave `mapflow.py`: the requests and the
+result state to `TemplateService` (reaching `SearchService` for the page size, sort and pager), the
+widget writes to `SearchView`/`TemplateView`, the slots to `TemplateController` — which now owns
+`templateOpened`/`templateClosed` outright. The template footprints builder moved as-is; unifying it
+with `SearchService.display_metadata_geojson_layer` is deferred to the MR-2 item below.
 
 [ ] Extract templates MR-2 → carve the template half out of `processing_service`
 Move `enter/exit/refresh_template_view`, `pause/resume/restart/delete_template`, `update_template`,
@@ -68,6 +68,14 @@ only `mapflow.py` called it. What remains is the shared read-only lookup: `AoiSe
 the built layer and let `TemplateService` place it in the tree (where a layer sits is a template
 concern). The find/ensure split (preview step) already removed the side-effect hazard; this removes
 the question.
+Same item, same reason (user's call when the search render moved): **there are two footprint-layer
+builders** — `TemplateService.store_search_footprints` and
+`SearchService.display_metadata_geojson_layer`. They differ only in where the layer is placed
+(template group vs. beside the AOI layer), how a failed save is reported, and how selection-sync is
+wired. `spec/007_architecture.md` gives "the footprints layer" to `SearchService`, so the merge is
+one shared builder that hands the layer back for placement. Kept out of the search-render MR
+deliberately: unifying them touches the working regular-search path, which is a behaviour risk that
+deserves its own review rather than riding along with the extraction.
 
 [ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
 [ ] Split auth from account status → `SessionService` + `AccountService`

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -10,13 +10,14 @@ from ..view.template_view import TemplateView
 
 
 class TemplateController(QObject):
-    """Planned-processing (template) create / update-search-params / exclude-from-search.
+    """Planned processings: create / update-search-params / exclude-from-search, the in-template
+    navigation, and the template's imagery-search results.
 
     MR-1 of the templates extraction: the operations that were tangled into `mapflow.py`. It is
     the one place that sees both the template/search views and `TemplateService`, so it assembles
     the request inputs from the widgets (name, the `SearchParams` schema, the AOI
-    FeatureCollection) and drives the view from the service's signals. The in-template navigation
-    and lifecycle still live in `ProcessingService`; MR-2 brings them here.
+    FeatureCollection) and drives the view from the service's signals. The template lifecycle
+    (enter/exit, navigation state) still lives in `ProcessingService`; MR-2 brings it here.
     """
 
     def __init__(self,
@@ -32,7 +33,9 @@ class TemplateController(QObject):
                  update_search_button,
                  exclude_action,
                  processings_table,
-                 see_processings_action):
+                 see_processings_action,
+                 see_search_results_action,
+                 selection_sync):
         super().__init__()
         self.template_service = template_service
         self.template_view = template_view
@@ -45,6 +48,10 @@ class TemplateController(QObject):
         self.processing_service = processing_service
         self.app_context = app_context
         self.iface = iface
+        #: Wires a rebuilt footprints layer's selection to the results table. Still owned by
+        #: `mapflow.py` (it serves the regular search too), so it arrives as a callable — the
+        #: same indirection `provider_service.selection_sync_callback` already uses.
+        self.selection_sync = selection_sync
 
         update_search_button.clicked.connect(self.update_template_search_params)
         exclude_action.triggered.connect(self.template_service.exclude_processing_from_search)
@@ -55,14 +62,14 @@ class TemplateController(QObject):
         # effects that only apply while a template is open. The processings table itself is the
         # ProjectProcessingController's region; these listeners react to it for template concerns.
         see_processings_action.triggered.connect(self.select_template_processings)
+        see_search_results_action.triggered.connect(self.show_template_search_results)
         processings_table.itemSelectionChanged.connect(self.sync_processing_area_to_selected_aois)
+        processings_table.itemSelectionChanged.connect(self.filter_search_by_selected_aoi)
         processings_table.cellClicked.connect(self.on_no_aoi_processing_clicked)
         processing_service.templateAoisChanged.connect(self.on_template_aois_changed)
         processing_service.templateProcessingsLoaded.connect(self.on_template_processings_loaded)
-        # The layer side of entering/leaving a template. A second listener on these signals — the
-        # search/filter side stays in mapflow.py — so neither edits the other (spec § Controllers).
-        processing_service.templateOpened.connect(self._on_template_opened_layers)
-        processing_service.templateClosed.connect(self._on_template_closed_layers)
+        processing_service.templateOpened.connect(self.on_template_opened)
+        processing_service.templateClosed.connect(self.on_template_closed)
 
         self.template_service.creationBusy.connect(
             lambda busy: self.template_view.set_search_enabled(not busy))
@@ -73,6 +80,9 @@ class TemplateController(QObject):
             self.template_view.refresh_template_status_cell)
         self.template_service.warningMessage.connect(
             lambda message: self.iface.messageBar().pushWarning(self.app_context.plugin_name, message))
+        self.template_service.searchResultsReady.connect(self.show_search_results)
+        self.template_service.searchResultsEmpty.connect(self.search_view.clear_table)
+        self.template_service.metadataLayerReady.connect(self.bind_metadata_layer_selection)
 
     def create_search_template(self, name_override: str = None) -> None:
         """Assemble the request from the widgets and hand it to the service. Called by the
@@ -193,12 +203,71 @@ class TemplateController(QObject):
             self.processing_service.selected_aois(),
             self.template_service.find_template_group(str(template.name)) if template else None)
 
-    def _on_template_opened_layers(self, template) -> None:
-        """Layer side of entering a template: draw its AOI/processing layers. The search results
-        and filter widgets are handled by mapflow.py's own `templateOpened` listener."""
+    def on_template_opened(self, template) -> None:
+        """Entering a template: draw its AOI/processing layers, mirror its stored search params
+        into the filter widgets, and load its search results."""
         self.template_service.load_template_layers(template)
+        # Drop the previous view's results/baseline first, so the widget updates below (which
+        # fire the local filter) don't briefly compare against a stale baseline. The template's
+        # own results + baseline are set when its search response arrives.
+        self.template_service.clear_search_state()
+        # "Update template" (save the current filters into the template) only makes sense while
+        # viewing a template. The widen (!) indicator manages its own visibility. Template
+        # results are filtered client-side now (no server-side Filter button).
+        self.template_view.set_update_template_visible(True)
+        self.search_view.apply_search_params(getattr(template, "searchParams", None))
+        self.template_service.load_search(template)
 
-    def _on_template_closed_layers(self, template) -> None:
-        """Layer side of leaving a template: drop its map group."""
+    def on_template_closed(self, template) -> None:
+        """Leaving a template: drop its map group, its results and the view state they drove."""
         if template is not None:
             self.template_service.remove_template_group(str(template.name))
+        self.template_service.clear_search_state()
+        self.search_view.set_widen_warning_visible(False)
+        self.template_view.set_update_template_visible(False)
+        # Drop the AOI-selection processing Area so it doesn't leak to the project view.
+        self.aoi_service.clear_processing_area_selection()
+        self.search_view.clear_table()
+        self.search_view.hide_pages()
+
+    # ---------- the template's search results ----------
+
+    def show_template_search_results(self, *args) -> None:
+        """Menu action: fill the imagery-search table with the selected template's results.
+
+        The explicit action is the only path that brings the search tab to front — entering a
+        template or filtering by AOI must not steal focus from the processings tab.
+        """
+        template = self.processing_service.selected_template()
+        if not template or self.processing_service.selected_processing():
+            return
+        self.search_view.switch_to_search_tab()
+        self.template_service.load_search(template)
+
+    def load_search_page(self, offset: int) -> None:
+        """The pager and a header re-sort inside a template. Public because `mapflow.py` still
+        owns the branch that picks between a regular and a template search."""
+        self.template_service.load_search_page(offset)
+
+    def filter_search_by_selected_aoi(self, *args) -> None:
+        """S7: selecting AOI rows scopes the search results to them. No-op outside a template;
+        the service ignores a selection that does not change the effective filter."""
+        if not self.processing_service.in_template_mode:
+            return
+        self.template_service.filter_search_by_selected_aois()
+
+    def show_search_results(self, geoms) -> None:
+        """Render a page of template results: fill the table, then re-draw the new-image markers
+        the fill dropped."""
+        # Built-in Qt column sorting stays OFF: search order is server-driven (regular search) or
+        # local-filter-driven (templates); only SEARCH_SORT_FIELDS headers re-sort, server-side.
+        # Filling the table emits `metadataTableFilled`, which is what runs the local filter —
+        # do not call it here as well, or every page would be filtered twice.
+        self.search_view.fill_table(geoms, sort=False)
+        # New images are flagged with an icon in the leftmost column (not by editing text).
+        self.apply_new_image_markers()
+
+    def bind_metadata_layer_selection(self, layer) -> None:
+        """Selecting a footprint on the map selects the matching table row (and triggers preview)."""
+        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
+            self.selection_sync)

--- a/mapflow/functional/helpers.py
+++ b/mapflow/functional/helpers.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 from typing import Tuple, Union, Optional
 
-from PyQt5.QtCore import QUrl, QCoreApplication
+from PyQt5.QtCore import QDate, QDateTime, Qt, QUrl, QCoreApplication
 from PyQt5.QtGui import QDesktopServices
 from qgis.core import (
     QgsGeometry, QgsProject, QgsCoordinateReferenceSystem, QgsCoordinateTransform,
@@ -22,6 +22,23 @@ URL_PATTERN = r'https?://(www\.)?([-\w]{1,256}\.)+[a-zA-Z0-9]{1,6}'  # schema + 
 URL_REGEX = re.compile(URL_PATTERN)
 XYZ_REGEX = re.compile(URL_PATTERN + r'(.*\{[xyz]\}){3}.*', re.I)
 QUAD_KEY_REGEX = re.compile(URL_PATTERN + r'(.*\{q\}).*', re.I)
+
+
+def utc_date_from_iso(value: Optional[str]) -> Optional[QDate]:
+    """Parse an ISO-8601 timestamp (as stored in ``searchParams`` or a result's
+    ``acquisitionDate``) into a UTC QDate, or None when absent/unparseable.
+
+    Here rather than beside either caller because both the local filter (a service) and the
+    search tab's filter widgets (a view) need this same parse, and a view may not import a
+    service (`spec/007_architecture.md` § Layer rules). A pure date conversion with no plugin
+    state is what this module is for.
+    """
+    if not value:
+        return None
+    parsed = QDateTime.fromString(value, Qt.ISODateWithMs)
+    if not parsed.isValid():
+        parsed = QDateTime.fromString(value, Qt.ISODate)
+    return parsed.toUTC().date() if parsed.isValid() else None
 
 
 def to_wgs84(geometry: QgsGeometry, source_crs: QgsCoordinateReferenceSystem) -> QgsGeometry:

--- a/mapflow/functional/service/local_filter_service.py
+++ b/mapflow/functional/service/local_filter_service.py
@@ -12,25 +12,10 @@ already-fetched result set, and the 'filter is wider than what was fetched' warn
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Set
 
-from PyQt5.QtCore import QDate, QDateTime, QObject, Qt
+from PyQt5.QtCore import QDate, QObject
 
+from ..helpers import utc_date_from_iso
 from ...schema.catalog import ProductType
-
-
-def utc_date_from_iso(value: Optional[str]) -> Optional[QDate]:
-    """Parse an ISO-8601 timestamp (as stored in ``searchParams`` or a result's
-    ``acquisitionDate``) into a UTC QDate, or None when absent/unparseable.
-
-    A free function, not a method: the template baseline (`mapflow.py`, → TemplateService) needs
-    the same parse, and a pure date conversion is no reason for template code to depend on the
-    filter service.
-    """
-    if not value:
-        return None
-    parsed = QDateTime.fromString(value, Qt.ISODateWithMs)
-    if not parsed.isValid():
-        parsed = QDateTime.fromString(value, Qt.ISODate)
-    return parsed.toUTC().date() if parsed.isValid() else None
 
 
 @dataclass

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -1,5 +1,5 @@
 """Planned processings (templates): creation, search-param update, exclude-from-search, the
-seen-image markers, and the template's map layers.
+seen-image markers, the template's map layers, and its imagery-search results.
 
 This is MR-1 of the templates extraction — the half that was tangled into `mapflow.py`. The
 lifecycle half (enter/exit/pause/resume, navigation state) is still in `ProcessingService` and is
@@ -30,10 +30,12 @@ from qgis.core import (QgsFeature,
 from .. import layer_utils
 from ..app_context import AppContext
 from ..geometry import geometry_from_geojson
+from ..helpers import utc_date_from_iso
 from .alert_service import (alert, alert_confirm, alert_info, alert_warning,
                             report_http_error)
 from ...errors import ErrorMessage
 from ...http import api_message_parser
+from ...schema import ImageCatalogResponseSchema
 from ...schema.template import (CreateProcessingTemplateSchema,
                                 DeleteAoisSchema,
                                 SearchParams,
@@ -57,13 +59,21 @@ class TemplateService(QObject):
     templateStatusChanged = pyqtSignal(object)
     #: A non-modal warning for the message bar (a seen request failed).
     warningMessage = pyqtSignal(str)
+    #: A page of the template's search results arrived: the GeoJSON, ready for the table.
+    searchResultsReady = pyqtSignal(object)
+    #: The template's search returned no images; the controller empties the table.
+    searchResultsEmpty = pyqtSignal()
+    #: The search-results footprints layer was (re)built; the controller wires its selection to
+    #: the table.
+    metadataLayerReady = pyqtSignal(object)
 
     def __init__(self,
                  app_context: AppContext,
                  processing_service,
                  plugin_dir: Optional[str] = None,
                  aoi_service=None,
-                 result_loader=None):
+                 result_loader=None,
+                 search_service=None):
         super().__init__()
         self.app_context = app_context
         #: Read for navigation state (`active_template`, `selected_template`,
@@ -75,12 +85,18 @@ class TemplateService(QObject):
         self.aoi_service = aoi_service
         #: Read for `add_layers_to_group` (whether the user keeps a Mapflow layer group at all).
         self.result_loader = result_loader
+        #: Reached for the page size, the server-side sort and the pager — a template's results
+        #: are the same result set, paged and sorted the same way, just from another endpoint.
+        self.search_service = search_service
         #: The current template-search results, keyed by image id, carrying the ``isNew`` flag
         #: the seen markers read. Set when a template's results load.
         self.template_search_images = {}
         #: 'No AOI' processing ids whose per-processing AOI fetch is in flight, so a second click
         #: does not fire a duplicate request before the first returns.
         self._pending_no_aoi_ids = set()
+        #: The AOI ids the in-template results are currently scoped to (None = all the
+        #: template's AOIs). Only used to re-request the same scope on a page change.
+        self.search_aoi_filter = None
 
     # ---------- plan-search gating ----------
 
@@ -628,3 +644,220 @@ class TemplateService(QObject):
         )
 
         alert_info(details)
+
+    # ---------- the template's imagery-search results ----------
+
+    def load_search(self, template, aoi_ids=None, offset: int = 0) -> None:
+        """Fetch the template's search results into the shared imagery-search result set.
+
+        ``aoi_ids`` restricts the results to specific AOIs (S7: filter by selected AOI); when
+        ``None`` all of the template's AOIs are used. ``offset`` selects the page: entering a
+        template or changing the AOI filter resets to the first page (offset 0); the search pager
+        passes a page offset (T6).
+
+        Bringing the search tab to front is the caller's business, not this one's — only the
+        explicit "See search results" action does it, and that is a view effect.
+        """
+        if not template:
+            return
+        self.search_service.page_offset = max(0, offset)
+        if aoi_ids is None:
+            aoi_ids = self._aoi_ids_from_template(template)
+        # Template results are fetched WITHOUT date/cloud server-side filters: those (and the
+        # intersection %) are applied instantly on the client (apply_local_filter). Persisting
+        # them to the template is done separately via the "Update template" button. Only the
+        # selected-AOI scoping (aoi_ids) stays server-side (it decides which AOIs to search).
+        self.processing_service.api.get_template_images(
+            template_id=template.id,
+            callback=lambda response: self.search_results_callback(response, template),
+            limit=self.search_service.page_limit,
+            offset=self.search_service.page_offset,
+            aoi_ids=aoi_ids or None,
+            sort_by=self.search_service.sort_by,
+            sort_order=self.search_service.sort_order,
+        )
+
+    def load_search_page(self, offset: int) -> None:
+        """Re-fetch the active template's search results at ``offset``, preserving the current
+        AOI filter — the search pager's next/prev and a header re-sort inside a template (T6)."""
+        template = self.processing_service.active_template
+        if not template:
+            return
+        aoi_ids = list(self.search_aoi_filter) if self.search_aoi_filter else None
+        self.load_search(template, aoi_ids=aoi_ids, offset=offset)
+
+    def filter_search_by_selected_aois(self) -> None:
+        """S7: scope the in-template search results to the AOIs currently selected; de-selecting
+        all of them (or selecting a processing) restores all of the template's results.
+
+        The caller checks that a template is open — this reloads only when the effective filter
+        actually changed, because a selection signal fires on every click.
+        """
+        template = self.processing_service.active_template
+        if not template:
+            return
+        selected_ids = frozenset(
+            str(aoi.id) for aoi in self.processing_service.selected_aois() if aoi and aoi.id
+        )
+        if selected_ids == (self.search_aoi_filter or frozenset()):
+            return
+        self.search_aoi_filter = selected_ids or None
+        self.load_search(template, aoi_ids=list(selected_ids) or None)
+
+    def search_results_callback(self, response: QNetworkReply, template=None) -> None:
+        """Turn a template-images response into the shared search result set.
+
+        ``template`` is passed explicitly because inside the in-template view the table selection
+        points at AOIs/processings, not at the template row.
+        """
+        response_json = json.loads(response.readAll().data())
+        if not response_json.get("images"):
+            self.app_context.open_template_results_id = None
+            # Empty the table before the modal, so the user is not reading stale rows behind it.
+            self.searchResultsEmpty.emit()
+            alert_info(self.tr("No images was found"))
+            return
+        if template is None:
+            template = self.processing_service.selected_template()
+        template_group_name = str(template.name) if template else None
+        # Mark these results as belonging to this template, so a "Start" runs a planned processing.
+        self.app_context.open_template_results_id = str(template.id) if template else None
+        response_data = ImageCatalogResponseSchema(**response_json)
+        images = response_data.images
+        geoms = response_data.as_geojson()
+        # Template search images may omit per-image providerName; without it a planned
+        # processing (and its cost) cannot resolve `dataProvider` and the backend rejects the
+        # request. Backfill from the template's own searchParams.dataProviders when it searches
+        # a single provider (multi-provider templates rely on the backend providing it).
+        template_provider = self._single_data_provider(template)
+        for position, feature in enumerate(geoms.get("features", ())):
+            props = feature.setdefault("properties", {})
+            props["local_index"] = position
+            if not props.get("providerName") and template_provider:
+                props["providerName"] = template_provider
+        # Footprints must keep the real providerName/productType so that a planned
+        # processing started from these results can resolve its source params (dataProvider).
+        self.store_search_footprints(geoms, template_group_name=template_group_name)
+        # Retain the raw results (for the instant local filter) and the template's own params as
+        # the widen (!) baseline; template results are filtered client-side, not server-side.
+        self.app_context.search_result_geojson = geoms
+        self.app_context.search_baseline_filters = self.filter_baseline(template)
+        # The image DTOs (they carry isNew) are keyed by id before the table is filled, because
+        # filling it is what draws the new-image markers, and those read this map.
+        self.store_template_images(images)
+        self.searchResultsReady.emit(geoms)
+        # Toggle/wire the search pager for the template results (T6).
+        self.search_service.update_pager(response_data.total, response_data.limit,
+                                         response_data.offset)
+
+    def _aoi_ids_from_template(self, template) -> list:
+        """The AOI ids in a template's ``searchParams.aoiDetails`` features."""
+        search_params = template.searchParams or {}
+        if isinstance(search_params, dict):
+            aoi_details = search_params.get("aoiDetails", {})
+        else:
+            aoi_details = search_params.aoiDetails
+
+        if not aoi_details:
+            return []
+
+        ids = []
+        for feature in aoi_details.get("features", []):
+            aoi_id = feature.get("id") or feature.get("properties", {}).get("id")
+            if aoi_id:
+                ids.append(str(aoi_id))
+        return ids
+
+    def _single_data_provider(self, template) -> Optional[str]:
+        """The template's sole search data provider, used to backfill an image's providerName
+        when the backend returns it null. ``None`` when the template searches zero or several
+        providers (then we cannot attribute an image to one)."""
+        if not template:
+            return None
+        search_params = getattr(template, "searchParams", None)
+        if isinstance(search_params, SearchParams):
+            providers = search_params.dataProviders
+        elif isinstance(search_params, dict):
+            providers = search_params.get("dataProviders")
+        else:
+            providers = None
+        providers = [p for p in (providers or []) if p]
+        return providers[0] if len(providers) == 1 else None
+
+    def filter_baseline(self, template) -> Optional[dict]:
+        """Baseline (widen indicator + Reset filters) from a template's stored searchParams. A
+        field the template does not carry stays ``None`` so Reset leaves that widget untouched."""
+        sp = getattr(template, "searchParams", None)
+        if not sp:
+            return None
+        if isinstance(sp, dict):
+            sp = SearchParams.from_dict(sp)
+        return {
+            "date_from": utc_date_from_iso(sp.acquisitionDateFrom),
+            "date_to": utc_date_from_iso(sp.acquisitionDateTo),
+            "max_cloud_cover": sp.maxCloudCover,
+            "min_intersection": sp.minAoiIntersectionPercent,
+            "min_off_nadir": sp.minOffNadirAngle,
+            "max_off_nadir": sp.maxOffNadirAngle,
+            "product_types": ([str(pt).upper() for pt in sp.productTypes]
+                              if sp.productTypes is not None else None),
+            "data_providers": list(sp.dataProviders) if sp.dataProviders is not None else None,
+            "hide_unavailable": sp.hideUnavailable,
+        }
+
+    def clear_search_state(self) -> None:
+        """Forget the template's results on leaving it, so nothing leaks into the project view."""
+        self.app_context.open_template_results_id = None
+        self.search_aoi_filter = None
+        self.app_context.search_result_geojson = None
+        self.app_context.search_baseline_filters = None
+        # Clear the template search-results pagination so it is not preserved on re-open.
+        self.search_service.page_offset = 0
+
+    def store_search_footprints(self,
+                                geoms: dict,
+                                template_group_name: Optional[str] = None) -> None:
+        """Build the template search-results footprint layer.
+
+        Two responsibilities, mirroring a regular imagery search:
+        * populate ``app_context.search_footprints`` (QgsFeatures keyed by ``local_index``)
+          so a planned processing started from these results resolves its source params
+          (``dataProvider`` comes from the footprint ``providerName``; otherwise the
+          backend rejects creation with HTTP 400);
+        * add the styled footprint layer to the map under the template's group so the
+          user can preview image footprints and request imagery previews.
+        """
+        self.app_context.search_footprints = {}
+        provider = self.search_service.imagery_search_provider
+        if not provider:
+            return
+        filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
+        if not filename:
+            return
+        # Drop the previous footprint layer so repeated searches don't stack duplicates.
+        if getattr(self.app_context, 'metadata_layer', None) is not None:
+            try:
+                self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
+            except (AttributeError, RuntimeError):
+                pass
+        layer = QgsVectorLayer(filename, f"{provider.name} metadata", "ogr")
+        if not layer.isValid():
+            self.app_context.metadata_layer = None
+            return
+        layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
+        # Register as the current search-metadata layer BEFORE adding it to the project, so
+        # the AOI-area monitor (which reacts to layersAdded) recognizes and skips it.
+        self.app_context.metadata_layer = layer
+        if template_group_name:
+            target_group = self.ensure_template_group(template_group_name)
+            self.app_context.project.addMapLayer(layer, addToLegend=False)
+            # Append (bottom) so the search-results footprints sit below the AOI/processing
+            # subgroups rather than on top of them.
+            target_group.addLayer(layer)
+        else:
+            self.result_loader.add_layer(layer=layer)
+        # Selecting a footprint on the map selects the matching table row (and triggers preview).
+        self.metadataLayerReady.emit(layer)
+        self.app_context.search_footprints = {
+            feature["local_index"]: feature for feature in layer.getFeatures()
+        }

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtWidgets import QPushButton, QWidget
 
+from ..helpers import utc_date_from_iso
 from ...dialogs.main_dialog import MainDialog
 from ...schema.catalog import ProductType
 from ...schema.template import SearchParams
@@ -121,6 +122,58 @@ class SearchView(QObject):
         tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
         if tab is not None:
             self.dlg.tabWidget.setCurrentWidget(tab)
+
+    # ---------- showing what a template searches for ----------
+
+    def apply_search_params(self, search_params) -> None:
+        """Populate the filter widgets from a template's stored ``searchParams`` (web parity: the
+        user can see what the template searches for). The widgets stay editable — changing them
+        affects the current search view only, never the template. Fields the template does not
+        carry leave the corresponding widgets untouched.
+
+        Deliberately not the same as `apply_baseline`, which restores the *fetched* parameters:
+        this one skips an empty ``productTypes`` (a template that names none is not a template
+        that wants neither box ticked) and always rewrites the provider combo, where the baseline
+        leaves an absent provider list alone.
+        """
+        if not search_params:
+            return
+        if isinstance(search_params, dict):
+            search_params = SearchParams.from_dict(search_params)
+
+        date_from = utc_date_from_iso(search_params.acquisitionDateFrom)
+        if date_from is not None:
+            self.dlg.metadataFrom.setDate(date_from)
+        date_to = utc_date_from_iso(search_params.acquisitionDateTo)
+        if date_to is not None:
+            self.dlg.metadataTo.setDate(date_to)
+        if search_params.maxCloudCover is not None:
+            self.dlg.maxCloudCover.setValue(int(round(search_params.maxCloudCover)))
+        if search_params.minAoiIntersectionPercent is not None:
+            self.dlg.minIntersection.setValue(int(round(search_params.minAoiIntersectionPercent)))
+        if search_params.minOffNadirAngle is not None and search_params.maxOffNadirAngle is not None:
+            self.dlg.set_off_nadir_range(int(round(search_params.minOffNadirAngle)),
+                                         int(round(search_params.maxOffNadirAngle)))
+        if search_params.hideUnavailable is not None:
+            self.dlg.hideUnavailableResults.setChecked(bool(search_params.hideUnavailable))
+        product_types = [str(pt).upper() for pt in (search_params.productTypes or [])]
+        if product_types:
+            self.dlg.searchMosaicCheckBox.setChecked(ProductType.mosaic.upper() in product_types)
+            self.dlg.searchImageCheckBox.setChecked(ProductType.image.upper() in product_types)
+        self.apply_providers_to_combo(search_params.dataProviders)
+
+    def apply_providers_to_combo(self, data_providers: Optional[List[str]]) -> None:
+        """Mirror ``search_providers()``: check the combo items whose api-name is in
+        ``data_providers``; ``None``/empty means all providers were searched, shown as no checked
+        items ("Show all")."""
+        combo = self.dlg.searchProvidersCombo
+        combo.deselectAllOptions()
+        if not data_providers:
+            return
+        wanted = set(data_providers)
+        for index in range(combo.count()):
+            if combo.itemData(index) in wanted:
+                combo.setItemCheckState(index, Qt.Checked)
 
     # ---------- the results table ----------
 

--- a/mapflow/functional/view/template_view.py
+++ b/mapflow/functional/view/template_view.py
@@ -31,6 +31,12 @@ class TemplateView(QObject):
         """The 'Search / Plan search' button — disabled while a create request is in flight."""
         self.dlg.getMetadata.setEnabled(enabled)
 
+    def set_update_template_visible(self, visible: bool) -> None:
+        """The 'Update template' button. It sits on the search tab but is the template's own
+        control — saving the current filters into the open template only means anything while one
+        is open, so it is shown on enter and hidden on leave."""
+        self.dlg.updateTemplateSearch.setVisible(visible)
+
     def show_project_required(self, message: str) -> None:
         self.dlg.processingProblemsLabel.setPalette(self.dlg.alert_palette)
         self.dlg.processingProblemsLabel.setText(message)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -39,9 +39,7 @@ from .functional.controller.template_controller import TemplateController
 from .functional.service.template_service import TemplateService
 from .functional.view.template_view import TemplateView
 from .functional.service.aoi_service import AoiService
-from .functional.service.local_filter_service import (FilterCriteria,
-                                                      LocalFilterService,
-                                                      utc_date_from_iso)
+from .functional.service.local_filter_service import FilterCriteria, LocalFilterService
 from .functional.service.preview_service import PreviewService
 from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
@@ -58,14 +56,12 @@ from .http import (Http,
                    get_error_report_body)
 # Schema
 from .schema import (BillingType,
-                     ImageCatalogResponseSchema,
                      ImagerySearchParams,
                      MyImageryParams,
                      ProviderReturnSchema,
                      UserDefinedParams)
 from .schema.catalog import ProductType
 from .schema.project import MapflowProject, UserRole
-from .schema.template import SearchParams
 from .schema.workflow_def import WorkflowDef
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
@@ -89,9 +85,6 @@ logger = logging.getLogger(__name__)
 class Mapflow(QObject):
     """This class represents the plugin. It is instantiated by QGIS."""
 
-    # The AOI id the in-template search results are currently filtered by (None = all).
-    # Class-level default so the check is safe before on_template_opened sets it.
-    _template_search_aoi_filter = None
     # Guards against the ``metadataTableFilled`` -> ``apply_local_filter`` -> ``fill_metadata_table``
     # -> ``metadataTableFilled`` re-entrancy: the local filter re-fills the table itself, so the
     # nested fill must not trigger another filter pass.
@@ -340,7 +333,8 @@ class Mapflow(QObject):
                                                 processing_service=self.processing_service,
                                                 plugin_dir=self.plugin_dir,
                                                 aoi_service=self.aoi_service,
-                                                result_loader=self.result_loader)
+                                                result_loader=self.result_loader,
+                                                search_service=self.search_service)
         self.template_view = TemplateView(dlg=self.dlg, iface=self.iface, config=self.config)
         self.template_controller = TemplateController(
             template_service=self.template_service,
@@ -355,7 +349,9 @@ class Mapflow(QObject):
             update_search_button=self.dlg.updateTemplateSearch,
             exclude_action=self.dlg.exclude_from_search_action,
             processings_table=self.dlg.processingsTable,
-            see_processings_action=self.dlg.see_processings_action)
+            see_processings_action=self.dlg.see_processings_action,
+            see_search_results_action=self.dlg.see_search_results_action,
+            selection_sync=self.sync_layer_selection_with_table)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -413,11 +409,8 @@ class Mapflow(QObject):
         self.dlg.processingsTable.cellDoubleClicked.connect(self.load_results)
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
         self.processing_service.connect_processings_pagination()
-        # In-template navigation: the search/filter side of entering or leaving a template. The
-        # map-layer side (aoiDetails redraw, 'No AOI' group, selected-AOI Area) is TemplateController's.
-        self.processing_service.templateOpened.connect(self.on_template_opened)
-        self.processing_service.templateClosed.connect(self.on_template_closed)
-        self.dlg.processingsTable.itemSelectionChanged.connect(self.filter_search_by_selected_aoi)
+        # Entering and leaving a template is TemplateController's entirely — it owns the layers,
+        # the search results and the view state they drive.
         # Processings ratings
         self.dlg.processingsTable.itemSelectionChanged.connect(self.enable_feedback)
         self.dlg.processingsTable.itemSelectionChanged.connect(self.on_processings_selection_changed)
@@ -564,7 +557,6 @@ class Mapflow(QObject):
         self.dlg.save_result_action.triggered.connect(self.download_results_file)
         self.dlg.download_aoi_action.triggered.connect(self.download_aoi_file)
         self.dlg.see_details_action.triggered.connect(self.show_selected_details)
-        self.dlg.see_search_results_action.triggered.connect(self.show_template_search_results)
         self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
         self.dlg.processing_restart_action.triggered.connect(self.processing_service.restart_processing)
         self.dlg.processing_duplicate_action.triggered.connect(self.check_dir_and_duplicate_processing)
@@ -717,188 +709,6 @@ class Mapflow(QObject):
         if self.dlg.processingProblemsLabel.text() == planned_reason:
             self.dlg.processingProblemsLabel.clear()
 
-    def _template_single_data_provider(self, template) -> Optional[str]:
-        """The template's sole search data provider, used to backfill an image's providerName
-        when the backend returns it null. ``None`` when the template searches zero or several
-        providers (then we cannot attribute an image to one)."""
-        if not template:
-            return None
-        search_params = getattr(template, "searchParams", None)
-        if isinstance(search_params, SearchParams):
-            providers = search_params.dataProviders
-        elif isinstance(search_params, dict):
-            providers = search_params.get("dataProviders")
-        else:
-            providers = None
-        providers = [p for p in (providers or []) if p]
-        return providers[0] if len(providers) == 1 else None
-
-    def get_selected_template_callback(self, response: QNetworkReply, template=None):
-        """Render a template's search results in the search table.
-
-        ``template`` is passed explicitly because inside the in-template view the table
-        selection points at AOIs/processings, not the template row.
-        """
-        response_json = json.loads(response.readAll().data())
-        if not response_json.get("images"):
-            self.dlg.metadataTable.clearContents()
-            self.dlg.metadataTable.setRowCount(0)
-            self.app_context.open_template_results_id = None
-            self.alert(self.tr("No images was found"), QMessageBox.Information)
-            return
-        if template is None:
-            template = self.processing_service.selected_template()
-        template_group_name = str(template.name) if template else None
-        # Mark these results as belonging to this template, so a "Start" runs a planned processing.
-        self.app_context.open_template_results_id = str(template.id) if template else None
-        response_data = ImageCatalogResponseSchema(**response_json)
-        images = response_data.images
-        geoms = response_data.as_geojson()
-        # Template search images may omit per-image providerName; without it a planned
-        # processing (and its cost) cannot resolve `dataProvider` and the backend rejects the
-        # request. Backfill from the template's own searchParams.dataProviders when it searches
-        # a single provider (multi-provider templates rely on the backend providing it).
-        template_provider = self._template_single_data_provider(template)
-        for position, feature in enumerate(geoms.get("features", ())):
-            props = feature.setdefault("properties", {})
-            props["local_index"] = position
-            if not props.get("providerName") and template_provider:
-                props["providerName"] = template_provider
-        # Footprints must keep the real providerName/productType so that a planned
-        # processing started from these results can resolve its source params (dataProvider).
-        self._store_template_search_footprints(geoms, template_group_name=template_group_name)
-        # Retain the raw results (for the instant local filter) and the template's own params as
-        # the widen (!) baseline; template results are filtered client-side, not server-side.
-        self.app_context.search_result_geojson = geoms
-        self.app_context.search_baseline_filters = self._template_filter_baseline(template)
-        # Built-in Qt column sorting stays OFF: search order is server-driven (regular search) or
-        # local-filter-driven (templates); only SEARCH_SORT_FIELDS headers re-sort, server-side.
-        self.dlg.fill_metadata_table(geoms, sort=False)
-        # Keep the image DTOs (they carry isNew) keyed by id so mark-seen reads truth.
-        self.template_service.store_template_images(images)
-        # New images are flagged with an icon in the leftmost column (not by editing text).
-        self.template_controller.apply_new_image_markers()
-        # Toggle/wire the search pager for the template results (T6).
-        self.search_service.update_pager(response_data.total, response_data.limit, response_data.offset)
-
-    def _store_template_search_footprints(self,
-                                          geoms: dict,
-                                          template_group_name: Optional[str] = None) -> None:
-        """Build the template search-results footprint layer.
-
-        Two responsibilities, mirroring a regular imagery search:
-        * populate ``app_context.search_footprints`` (QgsFeatures keyed by ``local_index``)
-          so a planned processing started from these results resolves its source params
-          (``dataProvider`` comes from the footprint ``providerName``; otherwise the
-          backend rejects creation with HTTP 400);
-        * add the styled footprint layer to the map under the template's group so the
-          user can preview image footprints and request imagery previews.
-        """
-        self.app_context.search_footprints = {}
-        provider = self.search_service.imagery_search_provider
-        if not provider:
-            return
-        filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
-        if not filename:
-            return
-        # Drop the previous footprint layer so repeated searches don't stack duplicates.
-        if getattr(self.app_context, 'metadata_layer', None) is not None:
-            try:
-                self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
-            except (AttributeError, RuntimeError):
-                pass
-        layer = QgsVectorLayer(filename, f"{provider.name} metadata", "ogr")
-        if not layer.isValid():
-            self.app_context.metadata_layer = None
-            return
-        layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
-        # Register as the current search-metadata layer BEFORE adding it to the project, so
-        # the AOI-area monitor (which reacts to layersAdded) recognizes and skips it.
-        self.app_context.metadata_layer = layer
-        if template_group_name:
-            target_group = self.template_service.ensure_template_group(template_group_name)
-            self.app_context.project.addMapLayer(layer, addToLegend=False)
-            # Append (bottom) so the search-results footprints sit below the AOI/processing
-            # subgroups rather than on top of them.
-            target_group.addLayer(layer)
-        else:
-            self.result_loader.add_layer(layer=layer)
-        # Selecting a footprint on the map selects the matching table row (and triggers preview).
-        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
-            self.sync_layer_selection_with_table)
-        self.app_context.search_footprints = {
-            feature["local_index"]: feature for feature in layer.getFeatures()
-        }
-
-    def _aoi_ids_from_template(self, template) -> List[str]:
-        """Extract AOI IDs from template searchParams.aoiDetails features."""
-        search_params = template.searchParams or {}
-        if isinstance(search_params, dict):
-            aoi_details = search_params.get("aoiDetails", {})
-        else:
-            aoi_details = search_params.aoiDetails
-
-        if not aoi_details:
-            return []
-
-        ids = []
-        for feature in aoi_details.get("features", []):
-            aoi_id = feature.get("id") or feature.get("properties", {}).get("id")
-            if aoi_id:
-                ids.append(str(aoi_id))
-        return ids
-
-    def show_template_search_results(self):
-        """Menu action: fill the imagery-search table with the selected template's results."""
-        template = self.processing_service.selected_template()
-        if not template or self.processing_service.selected_processing():
-            return
-        # Explicit "See search results" action: bring the imagery-search tab to front.
-        self._load_template_search(template, switch_tab=True)
-
-    def _load_template_search(self, template, aoi_ids=None, switch_tab=False, offset=0):
-        """Fill the imagery-search table with the template's search results.
-
-        ``aoi_ids`` restricts the results to specific AOIs (S7: filter by selected AOI);
-        when ``None`` all of the template's AOIs are used. ``switch_tab`` brings the
-        imagery-search tab to front — only the explicit menu action does so; entering a
-        template or filtering by AOI must not steal focus from the processings tab.
-        ``offset`` selects the results page: entering a template or changing the AOI filter
-        resets to the first page (offset 0); the search pager passes a page offset (T6).
-        """
-        if not template:
-            return
-        if switch_tab:
-            imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
-            if imagery_search_tab:
-                self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
-
-        self.search_service.page_offset = max(0, offset)
-        if aoi_ids is None:
-            aoi_ids = self._aoi_ids_from_template(template)
-        # Template results are fetched WITHOUT date/cloud server-side filters: those (and the
-        # intersection %) are applied instantly on the client (apply_local_filter). Persisting
-        # them to the template is done separately via the "Update template" button. Only the
-        # selected-AOI scoping (aoi_ids) stays server-side (it decides which AOIs to search).
-        self.processing_service.api.get_template_images(
-            template_id=template.id,
-            callback=lambda response: self.get_selected_template_callback(response, template),
-            limit=self.search_service.page_limit,
-            offset=self.search_service.page_offset,
-            aoi_ids=aoi_ids or None,
-            sort_by=self.search_service.sort_by,
-            sort_order=self.search_service.sort_order,
-        )
-
-    def _load_template_search_page(self, offset: int):
-        """Re-fetch the active template's search results at ``offset``, preserving the current
-        AOI filter — the search pager's next/prev inside a template (T6)."""
-        template = self.processing_service.active_template
-        if not template:
-            return
-        aoi_ids = list(self._template_search_aoi_filter) if self._template_search_aoi_filter else None
-        self._load_template_search(template, aoi_ids=aoi_ids, offset=offset)
-
     # ==================== AOI edit/draw/add sessions ==================== #
     def add_aoi_from_layer_dialog(self):
         """Add AOI(s) from existing polygon layer(s) chosen in a multi-select dialog."""
@@ -913,26 +723,6 @@ class Mapflow(QObject):
         if not selected_ids:
             return
         self.aoi_service.add_aois_from_layers(selected_ids)
-
-    def filter_search_by_selected_aoi(self):
-        """S7: inside a template, selecting one or more AOIs filters the imagery-search
-        results (table and footprint layer) to images intersecting any of the selected AOIs;
-        de-selecting all AOIs (or selecting a processing) restores all of the template's
-        results."""
-        if not self.processing_service.in_template_mode:
-            return
-        template = self.processing_service.active_template
-        if not template:
-            return
-        selected_ids = frozenset(
-            str(aoi.id) for aoi in self.processing_service.selected_aois() if aoi and aoi.id
-        )
-        # Only reload when the effective filter actually changes (selection fires often).
-        current = self._template_search_aoi_filter or frozenset()
-        if selected_ids == current:
-            return
-        self._template_search_aoi_filter = selected_ids or None
-        self._load_template_search(template, aoi_ids=list(selected_ids) or None)
 
     def select_processing_in_table(self, processing_id: str):
         """Select processing row by ID and open processing details."""
@@ -1193,27 +983,6 @@ class Mapflow(QObject):
             "hide_unavailable": self.dlg.hideUnavailableResults.isChecked(),
         }
 
-    def _template_filter_baseline(self, template) -> Optional[dict]:
-        """Baseline (widen indicator + Reset filters) from a template's stored searchParams. A
-        field the template does not carry stays ``None`` so Reset leaves that widget untouched."""
-        sp = getattr(template, "searchParams", None)
-        if not sp:
-            return None
-        if isinstance(sp, dict):
-            sp = SearchParams.from_dict(sp)
-        return {
-            "date_from": utc_date_from_iso(sp.acquisitionDateFrom),
-            "date_to": utc_date_from_iso(sp.acquisitionDateTo),
-            "max_cloud_cover": sp.maxCloudCover,
-            "min_intersection": sp.minAoiIntersectionPercent,
-            "min_off_nadir": sp.minOffNadirAngle,
-            "max_off_nadir": sp.maxOffNadirAngle,
-            "product_types": ([str(pt).upper() for pt in sp.productTypes]
-                              if sp.productTypes is not None else None),
-            "data_providers": list(sp.dataProviders) if sp.dataProviders is not None else None,
-            "hide_unavailable": sp.hideUnavailable,
-        }
-
     def reset_filters(self):
         """Reset the filter widgets to the parameters the current results were fetched with — a
         regular search's request params, or the open template's search params. Only params that
@@ -1244,7 +1013,7 @@ class Mapflow(QObject):
             self.dlg.hideUnavailableResults.setChecked(bool(baseline["hide_unavailable"]))
         providers = baseline.get("data_providers")
         if providers is not None:
-            self._apply_search_providers_to_combo(providers)
+            self.search_view.apply_providers_to_combo(providers)
         # Re-filter once against the restored widgets (some setters above may not have changed a
         # value, so their change-signal would not have fired the filter).
         self.apply_local_filter()
@@ -1526,8 +1295,8 @@ class Mapflow(QObject):
         return provider_changed
 
     def replace_search_provider_index(self):
-        # The logic moved to SearchView; get_metadata and get_selected_template_callback still
-        # call this until they move to SearchController / TemplateController.
+        # The logic moved to SearchView; the regular-search paths still call this until they move
+        # to SearchController.
         self.search_view.ensure_search_provider(self.provider_service)
 
     def setup_metadata_search_dropdown(self):
@@ -1595,7 +1364,7 @@ class Mapflow(QObject):
         # Re-request the first page with the new sort — the template-images endpoint and
         # /catalog/meta take the same sort params, so both re-sort server-side.
         if self.processing_service.in_template_mode:
-            self._load_template_search_page(0)
+            self.template_controller.load_search_page(0)
         else:
             self.get_metadata()
 
@@ -2059,88 +1828,10 @@ class Mapflow(QObject):
         """Navigate into a template ('one step right').
 
         The actual hydration (the poll omits ``searchParams``) and state switch happen in
-        the service; map side-effects are handled by ``on_template_opened`` via signal.
+        the service; the layers, results and view state follow from ``templateOpened``, which
+        `TemplateController` listens to.
         """
         self.project_processing_controller.enter_template(template)
-
-    def on_template_opened(self, template):
-        """React to entering a template: fill the search results and mirror its params into the
-        filter widgets. The AOI/processing map layers are drawn by TemplateController's own
-        `templateOpened` listener."""
-        # Initial results are the whole template (no AOI filter applied yet).
-        self._template_search_aoi_filter = None
-        # Drop the previous view's results/baseline first, so the widget updates below (which
-        # fire the local filter) don't briefly compare against a stale baseline. The template's
-        # own results + baseline are set when its search response arrives.
-        self.app_context.search_result_geojson = None
-        self.app_context.search_baseline_filters = None
-        # "Update template" (save the current filters into the template) only makes sense while
-        # viewing a template. The widen (!) indicator manages its own visibility. Template
-        # results are filtered client-side now (no server-side Filter button).
-        self.dlg.updateTemplateSearch.setVisible(True)
-        self.apply_search_params_to_ui(getattr(template, "searchParams", None))
-        self._load_template_search(template)
-
-    def on_template_closed(self, template):
-        """React to leaving a template: clear the search table and view state. The template's map
-        group is dropped by TemplateController's own `templateClosed` listener."""
-        self.app_context.open_template_results_id = None
-        self._template_search_aoi_filter = None
-        self.app_context.search_result_geojson = None
-        self.app_context.search_baseline_filters = None
-        self.dlg.searchWidenWarning.setVisible(False)
-        self.dlg.updateTemplateSearch.setVisible(False)
-        # Drop the AOI-selection processing Area so it doesn't leak to the project view.
-        self.aoi_service.clear_processing_area_selection()
-        self.dlg.metadataTable.clearContents()
-        self.dlg.metadataTable.setRowCount(0)
-        # Clear the template search-results pagination so it is not preserved on re-open.
-        self.search_service.page_offset = 0
-        self.dlg.enable_search_pages(False)
-
-    def apply_search_params_to_ui(self, search_params):
-        """Populate the Imagery Search filters from a template's stored ``searchParams``
-        (web parity: the user can see what the template searches for). The widgets stay
-        editable — changing them affects the current search view only, never the template.
-        Fields the template does not carry leave the corresponding widgets untouched."""
-        if not search_params:
-            return
-        if isinstance(search_params, dict):
-            search_params = SearchParams.from_dict(search_params)
-
-        date_from = utc_date_from_iso(search_params.acquisitionDateFrom)
-        if date_from is not None:
-            self.dlg.metadataFrom.setDate(date_from)
-        date_to = utc_date_from_iso(search_params.acquisitionDateTo)
-        if date_to is not None:
-            self.dlg.metadataTo.setDate(date_to)
-        if search_params.maxCloudCover is not None:
-            self.dlg.maxCloudCover.setValue(int(round(search_params.maxCloudCover)))
-        if search_params.minAoiIntersectionPercent is not None:
-            self.dlg.minIntersection.setValue(int(round(search_params.minAoiIntersectionPercent)))
-        if search_params.minOffNadirAngle is not None and search_params.maxOffNadirAngle is not None:
-            self.dlg.set_off_nadir_range(int(round(search_params.minOffNadirAngle)),
-                                         int(round(search_params.maxOffNadirAngle)))
-        if search_params.hideUnavailable is not None:
-            self.dlg.hideUnavailableResults.setChecked(bool(search_params.hideUnavailable))
-        product_types = [str(pt).upper() for pt in (search_params.productTypes or [])]
-        if product_types:
-            self.dlg.searchMosaicCheckBox.setChecked(ProductType.mosaic.upper() in product_types)
-            self.dlg.searchImageCheckBox.setChecked(ProductType.image.upper() in product_types)
-        self._apply_search_providers_to_combo(search_params.dataProviders)
-
-    def _apply_search_providers_to_combo(self, data_providers: Optional[List[str]]):
-        """Mirror ``selected_search_providers``: check the combo items whose api-name is in
-        the template's ``dataProviders``; ``None``/empty means the template searched all
-        providers, shown as no checked items ("Show all")."""
-        combo = self.dlg.searchProvidersCombo
-        combo.deselectAllOptions()
-        if not data_providers:
-            return
-        wanted = set(data_providers)
-        for index in range(combo.count()):
-            if combo.itemData(index) in wanted:
-                combo.setItemCheckState(index, Qt.Checked)
 
     def load_results(self):
         # Check if it's a template first
@@ -2583,7 +2274,7 @@ class Mapflow(QObject):
         stays out of `SearchService` — it is coordination between two regions, and moves to
         `SearchController` / `TemplateController` rather than into either service."""
         if self.processing_service.in_template_mode:
-            self._load_template_search_page(offset)
+            self.template_controller.load_search_page(offset)
         else:
             self.get_metadata(offset=offset)
     

--- a/tests/qgis/test_search_sort.py
+++ b/tests/qgis/test_search_sort.py
@@ -47,7 +47,7 @@ def _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC", in_template=False, ro
     plugin.dlg.metadataTable.rowCount.return_value = rows
     plugin._update_search_sort_indicator = MagicMock()
     plugin.get_metadata = MagicMock()
-    plugin._load_template_search_page = MagicMock()
+    plugin.template_controller = MagicMock()
     return plugin
 
 
@@ -97,7 +97,7 @@ def test_template_mode_reloads_template_search_with_new_sort():
 
     # Template results re-fetch (first page) with the updated sort; the regular search is untouched.
     assert plugin.search_service.sort_by == "CLOUD_COVER"
-    plugin._load_template_search_page.assert_called_once_with(0)
+    plugin.template_controller.load_search_page.assert_called_once_with(0)
     plugin.get_metadata.assert_not_called()
 
 
@@ -107,7 +107,7 @@ def test_regular_mode_does_not_reload_template():
     plugin.on_metadata_header_clicked(_column("cloudCover"))
 
     plugin.get_metadata.assert_called_once()
-    plugin._load_template_search_page.assert_not_called()
+    plugin.template_controller.load_search_page.assert_not_called()
 
 
 def test_no_results_yet_does_not_search():

--- a/tests/qgis/test_template_aoi.py
+++ b/tests/qgis/test_template_aoi.py
@@ -3,9 +3,10 @@ the in-template table rows, AOI rename, and AOI-filtered search (spec 002_F)."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service import processing_service as ps_mod
 from mapflow.functional.service.processing_service import ProcessingService
-from mapflow.mapflow import Mapflow
+from mapflow.functional.service.template_service import TemplateService
 from mapflow.schema.processing import ProcessingParams
 from mapflow.schema.template import (
     AOI_NAME_MAX_LENGTH,
@@ -18,15 +19,15 @@ from mapflow.schema.template import (
 
 def test_template_single_data_provider_backfill_source():
     """providerName backfill source: the template's sole search data provider, else None."""
-    plugin = Mapflow.__new__(Mapflow)
+    service = TemplateService(app_context=MagicMock(), processing_service=MagicMock())
     single = SimpleNamespace(searchParams=SearchParams(dataProviders=["arcgis_world_imagery"]))
-    assert plugin._template_single_data_provider(single) == "arcgis_world_imagery"
+    assert service._single_data_provider(single) == "arcgis_world_imagery"
     several = SimpleNamespace(searchParams=SearchParams(dataProviders=["a", "b"]))
-    assert plugin._template_single_data_provider(several) is None
+    assert service._single_data_provider(several) is None
     none = SimpleNamespace(searchParams=SearchParams(dataProviders=None))
-    assert plugin._template_single_data_provider(none) is None
+    assert service._single_data_provider(none) is None
     as_dict = SimpleNamespace(searchParams={"dataProviders": ["mapbox"]})
-    assert plugin._template_single_data_provider(as_dict) == "mapbox"
+    assert service._single_data_provider(as_dict) == "mapbox"
 
 
 def test_refresh_template_view_polls_only_processings():
@@ -231,52 +232,46 @@ def test_rename_aoi_rejects_overlong_name(monkeypatch):
     assert alerts  # user was warned
 
 
+def _filter_service(selected_aois, aoi_filter=None, template=SimpleNamespace(id="t-1")):
+    processing_service = MagicMock()
+    processing_service.in_template_mode = True
+    processing_service.active_template = template
+    processing_service.selected_aois.return_value = selected_aois
+    service = TemplateService(app_context=MagicMock(), processing_service=processing_service)
+    service.search_aoi_filter = aoi_filter
+    service.load_search = MagicMock()
+    return service
+
+
 def test_filter_search_by_selected_aoi_passes_selected_aoi_ids():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = True
-    plugin._template_search_aoi_filter = None
     template = SimpleNamespace(id="t-1")
-    plugin.processing_service.active_template = template
-    plugin.processing_service.selected_aois.return_value = [SimpleNamespace(id="aoi-1")]
-    plugin._load_template_search = MagicMock()
+    service = _filter_service([SimpleNamespace(id="aoi-1")], template=template)
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_called_once_with(template, aoi_ids=["aoi-1"])
-    assert plugin._template_search_aoi_filter == frozenset({"aoi-1"})
+    service.load_search.assert_called_once_with(template, aoi_ids=["aoi-1"])
+    assert service.search_aoi_filter == frozenset({"aoi-1"})
 
 
 def test_filter_search_resets_to_all_when_aoi_deselected():
     """De-selecting all AOIs (or selecting a processing) restores the full template results."""
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = True
     template = SimpleNamespace(id="t-1")
-    plugin.processing_service.active_template = template
-    plugin.processing_service.selected_aois.return_value = []
-    plugin._template_search_aoi_filter = frozenset({"aoi-1"})  # previously filtered by an AOI
-    plugin._load_template_search = MagicMock()
+    # Previously filtered by an AOI.
+    service = _filter_service([], aoi_filter=frozenset({"aoi-1"}), template=template)
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_called_once_with(template, aoi_ids=None)
-    assert plugin._template_search_aoi_filter is None
+    service.load_search.assert_called_once_with(template, aoi_ids=None)
+    assert service.search_aoi_filter is None
 
 
 def test_filter_search_noop_when_filter_unchanged():
     """Selection churn that doesn't change the effective AOI filter must not reload."""
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = True
-    plugin.processing_service.active_template = SimpleNamespace(id="t-1")
-    plugin.processing_service.selected_aois.return_value = []
-    plugin._template_search_aoi_filter = None  # already showing all results
-    plugin._load_template_search = MagicMock()
+    service = _filter_service([], aoi_filter=None)  # already showing all results
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_not_called()
+    service.load_search.assert_not_called()
 
 
 def test_aoi_status_aggregates_processing_statuses():
@@ -359,11 +354,11 @@ def test_template_to_run_none_when_open_results_belong_to_other_template():
 
 
 def test_filter_search_by_selected_aoi_noop_outside_template_mode():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.processing_service = MagicMock()
-    plugin.processing_service.in_template_mode = False
-    plugin._load_template_search = MagicMock()
+    """The in-template check stays with the caller: the service has no view of navigation."""
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.processing_service = SimpleNamespace(in_template_mode=False)
 
-    plugin.filter_search_by_selected_aoi()
+    controller.filter_search_by_selected_aoi()
 
-    plugin._load_template_search.assert_not_called()
+    controller.template_service.filter_search_by_selected_aois.assert_not_called()

--- a/tests/qgis/test_template_errors_pagination.py
+++ b/tests/qgis/test_template_errors_pagination.py
@@ -7,9 +7,10 @@ from unittest.mock import MagicMock
 from mapflow.functional.service import processing_service as ps_mod
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.config import Config, ConfigColumns
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service.search_service import SearchService
+from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.search_view import SearchView
-from mapflow.mapflow import Mapflow
 
 
 def _search_service():
@@ -77,32 +78,41 @@ def test_template_error_text_falls_back_to_unknown_on_bad_body():
     assert service._template_error_text(response) == "Unknown server error"
 
 
+def _template_service(page_offset=0, page_limit=30):
+    search_service = _search_service()
+    search_service.page_offset = page_offset
+    search_service.page_limit = page_limit
+    return TemplateService(app_context=SimpleNamespace(open_template_results_id="x",
+                                                       search_result_geojson={},
+                                                       search_baseline_filters={}),
+                           processing_service=MagicMock(),
+                           search_service=search_service)
+
+
 def test_on_template_closed_resets_search_pagination():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(open_template_results_id="x")
-    plugin._template_search_aoi_filter = "aoi-1"
-    plugin.dlg = MagicMock()
-    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
-    plugin.search_service = _search_service()
-    plugin.search_service.page_offset = 60
-    plugin.aoi_service = MagicMock()
+    service = _template_service(page_offset=60)
+    service.search_aoi_filter = "aoi-1"
+    dlg = MagicMock()
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = service
+    controller.template_view = MagicMock()
+    controller.search_view = SearchView(dlg=dlg, config=MagicMock())
+    controller.aoi_service = MagicMock()
 
-    plugin.on_template_closed(None)
+    controller.on_template_closed(None)
 
-    assert plugin.search_service.page_offset == 0
-    plugin.dlg.enable_search_pages.assert_called_once_with(False)
+    assert service.search_service.page_offset == 0
+    assert service.search_aoi_filter is None
+    assert service.app_context.open_template_results_id is None
+    dlg.enable_search_pages.assert_called_once_with(False)
 
 
-def test_load_template_search_starts_from_first_page():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    plugin.search_service = _search_service()
-    plugin.search_service.page_offset = 30
-    plugin.search_service.page_limit = 30
-    plugin.processing_service = MagicMock()
-    plugin._aoi_ids_from_template = MagicMock(return_value=[])
+def test_load_search_starts_from_first_page():
+    service = _template_service(page_offset=30, page_limit=30)
+    service._aoi_ids_from_template = MagicMock(return_value=[])
 
-    plugin._load_template_search(SimpleNamespace(id="t-1"))
+    service.load_search(SimpleNamespace(id="t-1"))
 
-    assert plugin.search_service.page_offset == 0
-    assert plugin.processing_service.api.get_template_images.call_args.kwargs["offset"] == 0
+    assert service.search_service.page_offset == 0
+    kwargs = service.processing_service.api.get_template_images.call_args.kwargs
+    assert kwargs["offset"] == 0

--- a/tests/qgis/test_template_search_footprints.py
+++ b/tests/qgis/test_template_search_footprints.py
@@ -1,11 +1,15 @@
 """QGIS-tier tests for the footprint layer built from template search results.
 
 Two behaviours are covered:
-* ``get_selected_template_callback`` populates ``app_context.search_footprints`` so a
+* `TemplateService.search_results_callback` populates ``app_context.search_footprints`` so a
   planned processing started from template results carries a ``dataProvider`` (regression:
   the source params used to omit it and the backend rejected creation with HTTP 400);
 * the styled footprint layer is added to the map under the template's layer-tree group so
   the user can preview image footprints and request imagery previews.
+
+The rendered page reaches the table as `searchResultsReady` rather than by the service touching
+a widget (`spec/007_architecture.md` § Layer rules), so "the table was filled with X" is asserted
+as "X was emitted", which is the same claim one layer out.
 """
 import json
 import os
@@ -17,9 +21,9 @@ from qgis.core import QgsProject
 from mapflow import mapflow as mapflow_module
 from mapflow.config import Config, ConfigColumns
 from mapflow.model.provider.default import ImagerySearchProvider
+from mapflow.functional.service import template_service as template_service_module
 from mapflow.functional.service.search_service import SearchService
 from mapflow.functional.service.template_service import TemplateService
-from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
 PLUGIN_DIR = os.path.dirname(mapflow_module.__file__)
@@ -46,46 +50,50 @@ def _image(image_id="4805123", product_type="Image", provider_name="orbview", is
     }
 
 
-def _plugin_with_search_provider(tmp_path, template_name="Template A"):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.alert = MagicMock()
-    plugin.dlg = MagicMock()
-    plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
-    # fill_metadata_table is mocked, so no real rows exist -> the marker pass is a no-op.
-    plugin.dlg.metadataTable.rowCount.return_value = 0
-    plugin.plugin_dir = PLUGIN_DIR
-    plugin.result_loader = MagicMock()
-    plugin.provider_service = SimpleNamespace(
+def _service_with_search_provider(tmp_path, template_name="Template A"):
+    """A real TemplateService over a real SearchService: these tests assert on the footprints it
+    stores and where it puts the layer, so neither is mocked."""
+    result_loader = MagicMock()
+    provider_service = SimpleNamespace(
         providers=[ImagerySearchProvider(proxy="https://example.com/rest")]
     )
     template = SimpleNamespace(name=template_name, id="tpl-test") if template_name else None
-    plugin.processing_service = SimpleNamespace(selected_template=lambda: template)
     settings = MagicMock()
     settings.value.return_value = None  # no custom layerGroup -> falls back to plugin_name
-    plugin.app_context = SimpleNamespace(
+    app_context = SimpleNamespace(
         temp_dir=str(tmp_path),
         search_footprints={},
         project=QgsProject(),
         settings=settings,
         plugin_name="Mapflow",
         metadata_layer=None,
+        open_template_results_id=None,
+        search_result_geojson=None,
+        search_baseline_filters=None,
     )
-    # Real service: these tests assert on the footprints it stores and where it puts the layer.
-    plugin.search_service = SearchService(iface=MagicMock(),
-                                          app_context=plugin.app_context,
-                                          http=MagicMock(),
-                                          plugin_dir=PLUGIN_DIR,
-                                          config=Config,
-                                          config_search_columns=ConfigColumns(),
-                                          result_loader=plugin.result_loader,
-                                          provider_service=plugin.provider_service)
-    plugin.search_service.metadataLayerReady.connect(lambda _layer: None)
-    # The image DTO map moved to TemplateService; the marker refresh to TemplateController.
-    plugin.template_service = TemplateService(app_context=plugin.app_context,
-                                              processing_service=MagicMock())
-    plugin.template_controller = MagicMock()
-    return plugin
+    search_service = SearchService(iface=MagicMock(),
+                                   app_context=app_context,
+                                   http=MagicMock(),
+                                   plugin_dir=PLUGIN_DIR,
+                                   config=Config,
+                                   config_search_columns=ConfigColumns(),
+                                   result_loader=result_loader,
+                                   provider_service=provider_service)
+    service = TemplateService(app_context=app_context,
+                              processing_service=SimpleNamespace(
+                                  selected_template=lambda: template, api=MagicMock()),
+                              plugin_dir=PLUGIN_DIR,
+                              aoi_service=MagicMock(),
+                              result_loader=result_loader,
+                              search_service=search_service)
+    return service
+
+
+def _rendered(service):
+    """The GeoJSON pages the service handed to the table, in order."""
+    pages = []
+    service.searchResultsReady.connect(pages.append)
+    return pages
 
 
 def _response(payload):
@@ -95,45 +103,47 @@ def _response(payload):
 
 
 def test_template_callback_populates_search_footprints_with_provider_name(tmp_path):
-    plugin = _plugin_with_search_provider(tmp_path)
+    service = _service_with_search_provider(tmp_path)
+    pages = _rendered(service)
 
-    plugin.get_selected_template_callback(_response({"images": [_image()], "total": 1}))
+    service.search_results_callback(_response({"images": [_image()], "total": 1}))
 
-    footprints = plugin.app_context.search_footprints
+    footprints = service.app_context.search_footprints
     assert set(footprints) == {0}
     assert footprints[0].attribute("providerName") == "orbview"
-    plugin.dlg.fill_metadata_table.assert_called_once()
+    assert len(pages) == 1
 
 
 def test_template_callback_keeps_product_type_clean_for_new_images(tmp_path):
-    plugin = _plugin_with_search_provider(tmp_path)
+    service = _service_with_search_provider(tmp_path)
 
-    plugin.get_selected_template_callback(_response({"images": [_image(is_new=True)], "total": 1}))
+    service.search_results_callback(_response({"images": [_image(is_new=True)], "total": 1}))
 
     # The footprint productType stays the raw value (it feeds product-type / zoom
     # consistency checks during params building); the new-image state is an icon, not text.
-    assert plugin.app_context.search_footprints[0].attribute("productType") == "Image"
+    assert service.app_context.search_footprints[0].attribute("productType") == "Image"
 
 
 def test_template_callback_adds_footprint_layer_under_template_group(tmp_path):
-    plugin = _plugin_with_search_provider(tmp_path, template_name="Template A")
+    service = _service_with_search_provider(tmp_path, template_name="Template A")
 
-    plugin.get_selected_template_callback(_response({"images": [_image()], "total": 1}))
+    service.search_results_callback(_response({"images": [_image()], "total": 1}))
 
-    root = plugin.app_context.project.layerTreeRoot()
+    root = service.app_context.project.layerTreeRoot()
     template_group = root.findGroup("Template A")
     assert template_group is not None, "footprint layer must live under the template-named group"
     layers = template_group.findLayers()
     assert len(layers) == 1
     added_layer = layers[0].layer()
-    assert added_layer is plugin.app_context.metadata_layer
+    assert added_layer is service.app_context.metadata_layer
     assert added_layer.featureCount() == 1
 
 
 def test_template_callback_keeps_product_type_text_clean_and_stores_new_flag(tmp_path):
-    plugin = _plugin_with_search_provider(tmp_path)
+    service = _service_with_search_provider(tmp_path)
+    pages = _rendered(service)
 
-    plugin.get_selected_template_callback(_response({
+    service.search_results_callback(_response({
         "images": [
             _image(image_id="img-new", is_new=True),
             _image(image_id="img-seen", is_new=False),
@@ -141,12 +151,26 @@ def test_template_callback_keeps_product_type_text_clean_and_stores_new_flag(tmp
         "total": 2,
     }))
 
-    geoms = plugin.dlg.fill_metadata_table.call_args.args[0]
+    geoms = pages[0]
     # The "new" state is shown with an icon now, so the product-type text stays clean.
     assert [f["properties"]["productType"] for f in geoms["features"]] == ["Image", "Image"]
     # Image DTOs are stored by id and carry the authoritative isNew flag for mark-seen.
-    assert plugin.template_service.template_search_images["img-new"].isNew is True
-    assert plugin.template_service.template_search_images["img-seen"].isNew is False
+    assert service.template_search_images["img-new"].isNew is True
+    assert service.template_search_images["img-seen"].isNew is False
+
+
+def test_the_dtos_are_stored_before_the_page_is_rendered(tmp_path):
+    """The markers are drawn as part of rendering the page and read these DTOs, so a page
+    emitted before they are stored would come up with no 'new' icons at all."""
+    service = _service_with_search_provider(tmp_path)
+    seen_when_rendered = []
+    service.searchResultsReady.connect(
+        lambda _geoms: seen_when_rendered.append(dict(service.template_search_images)))
+
+    service.search_results_callback(
+        _response({"images": [_image(image_id="img-new", is_new=True)], "total": 1}))
+
+    assert "img-new" in seen_when_rendered[0]
 
 
 def test_monitor_skips_current_search_metadata_layer():
@@ -180,10 +204,17 @@ def test_monitor_skips_current_search_metadata_layer():
     )
 
 
-def test_template_callback_alerts_and_skips_when_no_images(tmp_path):
-    plugin = _plugin_with_search_provider(tmp_path)
+def test_template_callback_alerts_and_skips_when_no_images(tmp_path, monkeypatch):
+    service = _service_with_search_provider(tmp_path)
+    pages = _rendered(service)
+    emptied = []
+    service.searchResultsEmpty.connect(lambda: emptied.append(True))
+    alerts = []
+    monkeypatch.setattr(template_service_module, "alert_info", lambda *a, **k: alerts.append(a))
 
-    plugin.get_selected_template_callback(_response({"images": []}))
+    service.search_results_callback(_response({"images": []}))
 
-    plugin.alert.assert_called_once()
-    plugin.dlg.fill_metadata_table.assert_not_called()
+    assert len(alerts) == 1
+    assert emptied == [True]  # the table is emptied instead of being filled
+    assert pages == []
+    assert service.app_context.open_template_results_id is None

--- a/tests/qgis/test_template_search_multi_aoi.py
+++ b/tests/qgis/test_template_search_multi_aoi.py
@@ -1,23 +1,27 @@
 """QGIS-tier tests for filtering template search results by multiple selected AOIs
 (round-2 feedback 11; spec 002_F: selecting one or more AOI rows sends all their ids as
-``aoiIds`` on the template images request; deselecting all restores the full results)."""
+``aoiIds`` on the template images request; deselecting all restores the full results).
+
+Owners after the search extraction: `TemplateController` guards on being inside a template,
+`TemplateService` holds the current scope and decides whether it actually changed.
+"""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.mapflow import Mapflow
+from mapflow.functional.controller.template_controller import TemplateController
+from mapflow.functional.service.template_service import TemplateService
 
 
-def _plugin(selected_aois):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin._template_search_aoi_filter = None
+def _service(selected_aois):
     template = SimpleNamespace(id="tpl-1", name="T1")
-    plugin.processing_service = SimpleNamespace(
+    processing_service = SimpleNamespace(
         in_template_mode=True,
         active_template=template,
         selected_aois=lambda: selected_aois,
     )
-    plugin._load_template_search = MagicMock()
-    return plugin, template
+    service = TemplateService(app_context=MagicMock(), processing_service=processing_service)
+    service.load_search = MagicMock()
+    return service, template
 
 
 def _aoi(aoi_id):
@@ -25,49 +29,70 @@ def _aoi(aoi_id):
 
 
 def test_multiple_selected_aois_are_all_sent():
-    plugin, template = _plugin([_aoi("a1"), _aoi("a2")])
+    service, template = _service([_aoi("a1"), _aoi("a2")])
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_called_once()
-    _, kwargs = plugin._load_template_search.call_args
+    service.load_search.assert_called_once()
+    _, kwargs = service.load_search.call_args
     assert set(kwargs["aoi_ids"]) == {"a1", "a2"}
-    assert plugin._template_search_aoi_filter == frozenset({"a1", "a2"})
+    assert service.search_aoi_filter == frozenset({"a1", "a2"})
 
 
 def test_no_selection_restores_full_results():
-    plugin, template = _plugin([])
-    plugin._template_search_aoi_filter = frozenset({"a1"})
+    service, template = _service([])
+    service.search_aoi_filter = frozenset({"a1"})
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_called_once_with(template, aoi_ids=None)
-    assert plugin._template_search_aoi_filter is None
+    service.load_search.assert_called_once_with(template, aoi_ids=None)
+    assert service.search_aoi_filter is None
 
 
 def test_unchanged_selection_does_not_reload():
-    plugin, _ = _plugin([_aoi("a1"), _aoi("a2")])
-    plugin._template_search_aoi_filter = frozenset({"a1", "a2"})
+    service, _ = _service([_aoi("a1"), _aoi("a2")])
+    service.search_aoi_filter = frozenset({"a1", "a2"})
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_not_called()
+    service.load_search.assert_not_called()
 
 
 def test_reselection_order_independent():
     """Selecting the same AOIs in a different order must not trigger a reload."""
-    plugin, _ = _plugin([_aoi("a2"), _aoi("a1")])
-    plugin._template_search_aoi_filter = frozenset({"a1", "a2"})
+    service, _ = _service([_aoi("a2"), _aoi("a1")])
+    service.search_aoi_filter = frozenset({"a1", "a2"})
 
-    plugin.filter_search_by_selected_aoi()
+    service.filter_search_by_selected_aois()
 
-    plugin._load_template_search.assert_not_called()
+    service.load_search.assert_not_called()
+
+
+def test_no_active_template_is_noop():
+    service, _ = _service([_aoi("a1")])
+    service.processing_service.active_template = None
+
+    service.filter_search_by_selected_aois()
+
+    service.load_search.assert_not_called()
 
 
 def test_not_in_template_mode_is_noop():
-    plugin, _ = _plugin([_aoi("a1")])
-    plugin.processing_service.in_template_mode = False
+    """The in-template check stays with the caller: the service has no view of navigation."""
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.processing_service = SimpleNamespace(in_template_mode=False)
 
-    plugin.filter_search_by_selected_aoi()
+    controller.filter_search_by_selected_aoi()
 
-    plugin._load_template_search.assert_not_called()
+    controller.template_service.filter_search_by_selected_aois.assert_not_called()
+
+
+def test_in_template_mode_delegates_to_the_service():
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.processing_service = SimpleNamespace(in_template_mode=True)
+
+    controller.filter_search_by_selected_aoi()
+
+    controller.template_service.filter_search_by_selected_aois.assert_called_once()

--- a/tests/qgis/test_template_search_pagination.py
+++ b/tests/qgis/test_template_search_pagination.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from mapflow.config import Config, ConfigColumns
 from mapflow.functional.service.search_service import SearchService
+from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.search_view import SearchView
 from mapflow.mapflow import Mapflow
 
@@ -30,7 +31,6 @@ def _plugin(in_template_mode=True):
     plugin.dlg = MagicMock()
     plugin.search_view = SearchView(dlg=plugin.dlg, config=MagicMock())
     plugin.search_service = _service()
-    plugin._template_search_aoi_filter = None
     plugin.processing_service = SimpleNamespace(in_template_mode=in_template_mode, active_template=None)
     return plugin
 
@@ -88,61 +88,69 @@ def test_pager_hidden_when_results_exactly_fill_one_page():
     plugin.dlg.enable_search_pages.assert_called_once_with(False)
 
 
+# Which endpoint serves the page depends on where the results came from. That branch stays in
+# `mapflow.py` until the regular search moves too, so it is still asserted on the plugin — but the
+# template half now goes through `TemplateController`.
+
 def test_next_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
-    plugin._load_template_search_page = MagicMock()
+    plugin.template_controller = MagicMock()
     plugin.get_metadata = MagicMock()
     plugin.search_service.page_offset = 0
 
     plugin.show_search_next_page()
 
-    plugin._load_template_search_page.assert_called_once_with(5)
+    plugin.template_controller.load_search_page.assert_called_once_with(5)
     plugin.get_metadata.assert_not_called()
 
 
 def test_prev_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
-    plugin._load_template_search_page = MagicMock()
+    plugin.template_controller = MagicMock()
     plugin.get_metadata = MagicMock()
     plugin.search_service.page_offset = 10
 
     plugin.show_search_previous_page()
 
-    plugin._load_template_search_page.assert_called_once_with(5)
+    plugin.template_controller.load_search_page.assert_called_once_with(5)
 
 
 def test_next_page_outside_template_mode_uses_regular_search():
     plugin = _plugin(in_template_mode=False)
-    plugin._load_template_search_page = MagicMock()
+    plugin.template_controller = MagicMock()
     plugin.get_metadata = MagicMock()
     plugin.search_service.page_offset = 5
 
     plugin.show_search_next_page()
 
     plugin.get_metadata.assert_called_once_with(offset=10)
-    plugin._load_template_search_page.assert_not_called()
+    plugin.template_controller.load_search_page.assert_not_called()
 
 
-def test_load_template_search_page_preserves_aoi_filter_and_offset():
-    plugin = _plugin(in_template_mode=True)
-    template = SimpleNamespace(id="tpl-1")
-    plugin.processing_service.active_template = template
-    plugin._template_search_aoi_filter = frozenset({"a1", "a2"})
-    plugin._load_template_search = MagicMock()
+def _template_service(active_template=None, aoi_filter=None):
+    service = TemplateService(
+        app_context=MagicMock(),
+        processing_service=SimpleNamespace(active_template=active_template))
+    service.search_aoi_filter = aoi_filter
+    service.load_search = MagicMock()
+    return service
 
-    plugin._load_template_search_page(offset=10)
 
-    plugin._load_template_search.assert_called_once()
-    _, kwargs = plugin._load_template_search.call_args
+def test_load_search_page_preserves_aoi_filter_and_offset():
+    service = _template_service(active_template=SimpleNamespace(id="tpl-1"),
+                                aoi_filter=frozenset({"a1", "a2"}))
+
+    service.load_search_page(offset=10)
+
+    service.load_search.assert_called_once()
+    _, kwargs = service.load_search.call_args
     assert set(kwargs["aoi_ids"]) == {"a1", "a2"}
     assert kwargs["offset"] == 10
 
 
-def test_load_template_search_page_noop_without_active_template():
-    plugin = _plugin(in_template_mode=True)
-    plugin.processing_service.active_template = None
-    plugin._load_template_search = MagicMock()
+def test_load_search_page_noop_without_active_template():
+    service = _template_service(active_template=None)
 
-    plugin._load_template_search_page(offset=5)
+    service.load_search_page(offset=5)
 
-    plugin._load_template_search.assert_not_called()
+    service.load_search.assert_not_called()

--- a/tests/qgis/test_template_search_params_ui.py
+++ b/tests/qgis/test_template_search_params_ui.py
@@ -1,23 +1,23 @@
 """QGIS-tier tests for populating the Imagery Search filters from a template's
 ``searchParams`` (round-2 feedback 3, web parity: opening a template shows the search
 filters it was created with; the widgets stay editable and affect only the current
-search view, never the stored template)."""
+search view, never the stored template).
+
+Owners after the search extraction: the widget writes are `SearchView.apply_search_params`,
+and `TemplateController.on_template_opened` is what calls it when a template is entered.
+"""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from PyQt5.QtCore import QDate, Qt
 
-from mapflow.mapflow import Mapflow
+from mapflow.functional.controller.template_controller import TemplateController
+from mapflow.functional.view.search_view import SearchView
 from mapflow.schema.template import SearchParams
 
 
-def _plugin():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    # on_template_opened clears the retained results/baseline (so interim widget-set signals
-    # don't compare against a stale search baseline).
-    plugin.app_context = SimpleNamespace(search_result_geojson=None, search_baseline_filters=None)
-    return plugin
+def _view():
+    return SearchView(dlg=MagicMock(), config=MagicMock())
 
 
 def _search_params(**overrides):
@@ -34,96 +34,117 @@ def _search_params(**overrides):
     return SearchParams(**params)
 
 
-def _providers_combo(plugin, items):
-    combo = plugin.dlg.searchProvidersCombo
+def _providers_combo(view, items):
+    combo = view.dlg.searchProvidersCombo
     combo.count.return_value = len(items)
     combo.itemData.side_effect = lambda index: items[index]
     return combo
 
 
 def test_apply_search_params_sets_all_filter_widgets():
-    plugin = _plugin()
-    _providers_combo(plugin, ["providerA", "providerB"])
+    view = _view()
+    _providers_combo(view, ["providerA", "providerB"])
 
-    plugin.apply_search_params_to_ui(_search_params())
+    view.apply_search_params(_search_params())
 
-    plugin.dlg.metadataFrom.setDate.assert_called_once_with(QDate(2025, 1, 2))
-    plugin.dlg.metadataTo.setDate.assert_called_once_with(QDate(2025, 3, 4))
-    plugin.dlg.maxCloudCover.setValue.assert_called_once_with(42)
-    plugin.dlg.minIntersection.setValue.assert_called_once_with(17)
-    plugin.dlg.hideUnavailableResults.setChecked.assert_called_once_with(True)
-    plugin.dlg.searchImageCheckBox.setChecked.assert_called_once_with(True)
-    plugin.dlg.searchMosaicCheckBox.setChecked.assert_called_once_with(False)
+    view.dlg.metadataFrom.setDate.assert_called_once_with(QDate(2025, 1, 2))
+    view.dlg.metadataTo.setDate.assert_called_once_with(QDate(2025, 3, 4))
+    view.dlg.maxCloudCover.setValue.assert_called_once_with(42)
+    view.dlg.minIntersection.setValue.assert_called_once_with(17)
+    view.dlg.hideUnavailableResults.setChecked.assert_called_once_with(True)
+    view.dlg.searchImageCheckBox.setChecked.assert_called_once_with(True)
+    view.dlg.searchMosaicCheckBox.setChecked.assert_called_once_with(False)
 
 
 def test_apply_search_params_accepts_dict_payload():
-    plugin = _plugin()
-    _providers_combo(plugin, [])
+    view = _view()
+    _providers_combo(view, [])
 
-    plugin.apply_search_params_to_ui({"maxCloudCover": 55, "hideUnavailable": False})
+    view.apply_search_params({"maxCloudCover": 55, "hideUnavailable": False})
 
-    plugin.dlg.maxCloudCover.setValue.assert_called_once_with(55)
-    plugin.dlg.hideUnavailableResults.setChecked.assert_called_once_with(False)
-    plugin.dlg.metadataFrom.setDate.assert_not_called()
-    plugin.dlg.metadataTo.setDate.assert_not_called()
+    view.dlg.maxCloudCover.setValue.assert_called_once_with(55)
+    view.dlg.hideUnavailableResults.setChecked.assert_called_once_with(False)
+    view.dlg.metadataFrom.setDate.assert_not_called()
+    view.dlg.metadataTo.setDate.assert_not_called()
 
 
 def test_apply_search_params_none_is_noop():
-    plugin = _plugin()
+    view = _view()
 
-    plugin.apply_search_params_to_ui(None)
+    view.apply_search_params(None)
 
-    plugin.dlg.metadataFrom.setDate.assert_not_called()
-    plugin.dlg.maxCloudCover.setValue.assert_not_called()
-    plugin.dlg.hideUnavailableResults.setChecked.assert_not_called()
-    plugin.dlg.searchProvidersCombo.deselectAllOptions.assert_not_called()
+    view.dlg.metadataFrom.setDate.assert_not_called()
+    view.dlg.maxCloudCover.setValue.assert_not_called()
+    view.dlg.hideUnavailableResults.setChecked.assert_not_called()
+    view.dlg.searchProvidersCombo.deselectAllOptions.assert_not_called()
 
 
 def test_apply_search_params_missing_fields_leave_widgets_untouched():
-    plugin = _plugin()
-    _providers_combo(plugin, [])
+    view = _view()
+    _providers_combo(view, [])
 
-    plugin.apply_search_params_to_ui(SearchParams())
+    view.apply_search_params(SearchParams())
 
-    plugin.dlg.metadataFrom.setDate.assert_not_called()
-    plugin.dlg.metadataTo.setDate.assert_not_called()
-    plugin.dlg.maxCloudCover.setValue.assert_not_called()
-    plugin.dlg.minIntersection.setValue.assert_not_called()
-    plugin.dlg.hideUnavailableResults.setChecked.assert_not_called()
-    plugin.dlg.searchImageCheckBox.setChecked.assert_not_called()
-    plugin.dlg.searchMosaicCheckBox.setChecked.assert_not_called()
+    view.dlg.metadataFrom.setDate.assert_not_called()
+    view.dlg.metadataTo.setDate.assert_not_called()
+    view.dlg.maxCloudCover.setValue.assert_not_called()
+    view.dlg.minIntersection.setValue.assert_not_called()
+    view.dlg.hideUnavailableResults.setChecked.assert_not_called()
+    view.dlg.searchImageCheckBox.setChecked.assert_not_called()
+    view.dlg.searchMosaicCheckBox.setChecked.assert_not_called()
 
 
 def test_apply_search_params_checks_matching_providers_only():
-    plugin = _plugin()
-    combo = _providers_combo(plugin, ["providerA", "providerB"])
+    view = _view()
+    combo = _providers_combo(view, ["providerA", "providerB"])
 
-    plugin.apply_search_params_to_ui(_search_params(dataProviders=["providerB"]))
+    view.apply_search_params(_search_params(dataProviders=["providerB"]))
 
     combo.deselectAllOptions.assert_called_once()
     combo.setItemCheckState.assert_called_once_with(1, Qt.Checked)
 
 
 def test_apply_search_params_without_providers_clears_combo():
-    plugin = _plugin()
-    combo = _providers_combo(plugin, ["providerA", "providerB"])
+    view = _view()
+    combo = _providers_combo(view, ["providerA", "providerB"])
 
-    plugin.apply_search_params_to_ui(_search_params(dataProviders=None))
+    view.apply_search_params(_search_params(dataProviders=None))
 
     combo.deselectAllOptions.assert_called_once()
     combo.setItemCheckState.assert_not_called()
 
 
-def test_on_template_opened_populates_search_filters():
-    plugin = _plugin()
-    plugin.apply_search_params_to_ui = MagicMock()
-    plugin._load_template_search = MagicMock()
+def _controller():
+    controller = TemplateController.__new__(TemplateController)
+    controller.template_service = MagicMock()
+    controller.template_view = MagicMock()
+    controller.search_view = MagicMock()
+    controller.aoi_service = MagicMock()
+    return controller
+
+
+def test_on_template_opened_populates_search_filters_and_loads_results():
+    controller = _controller()
     search_params = _search_params()
     template = SimpleNamespace(id="tpl-1", name="T1", searchParams=search_params)
 
-    plugin.on_template_opened(template)
+    controller.on_template_opened(template)
 
-    plugin.apply_search_params_to_ui.assert_called_once_with(search_params)
-    plugin._load_template_search.assert_called_once_with(template)
-    # The AOI/processing layers are drawn by TemplateController's own templateOpened listener,
-    # not by on_template_opened (which now handles only the search/filter side).
+    controller.search_view.apply_search_params.assert_called_once_with(search_params)
+    controller.template_service.load_search.assert_called_once_with(template)
+    # Entering a template also draws its layers and shows the "Update template" button.
+    controller.template_service.load_template_layers.assert_called_once_with(template)
+    controller.template_view.set_update_template_visible.assert_called_once_with(True)
+
+
+def test_on_template_opened_clears_the_previous_views_results_first():
+    """Otherwise the widget writes below fire the local filter against a stale baseline."""
+    controller = _controller()
+    calls = []
+    controller.template_service.clear_search_state.side_effect = lambda: calls.append("clear")
+    controller.search_view.apply_search_params.side_effect = lambda _p: calls.append("apply")
+    controller.template_service.load_search.side_effect = lambda _t: calls.append("load")
+
+    controller.on_template_opened(SimpleNamespace(id="tpl-1", name="T1", searchParams=None))
+
+    assert calls == ["clear", "apply", "load"]


### PR DESCRIPTION
Area B/C of the templates layers+navigation step, and the last of the template half of mapflow.py for MR-1. The template's search request, the rendering of its results, the footprints layer, the selected-AOI scoping and the "show what this template searches for" widget writes all leave the god object.

The split follows the layer rules. TemplateService holds what is scoped to a template id — the request, the response parsing, the providerName backfill, the widen-indicator baseline, the AOI scope and the footprints layer — and reaches SearchService for the page size, the server-side sort and the pager, because a template's results are the same result set from another endpoint. SearchView takes the filter-widget writes, TemplateView the "Update template" button, and TemplateController the slots. The rendered page reaches the table as searchResultsReady rather than the service filling it, so the tests assert "this was emitted" — the same claim one layer out.

With the search half moved, everything left in on_template_opened/on_template_closed was a template concern, so both are gone from mapflow.py and folded into the TemplateController listeners the layers step added. Entering and leaving a template is now described in one place. Signal order is preserved: the controller's listener was already connected first, so layers are still drawn before the results load and the group is still removed before the table is cleared.

utc_date_from_iso moved to helpers.py. It parses searchParams dates, which the filter widgets need, but it lived in local_filter_service and a view may not import a service; helpers is what every layer may import. Its own docstring had already predicted the move.

Two near-misses worth recording. apply_search_params_to_ui and _apply_baseline_to_widgets look like the same function and are not: an empty productTypes list unticks both boxes in one and is skipped by the other, and a None provider list is left alone by one and rewritten by the other. They stay separate; only the provider-combo write is genuinely shared. And rendering a page nearly ran the local filter twice, because fill_metadata_table emits metadataTableFilled, which is already wired to apply_local_filter — the explicit call was removed and a comment left so it is not re-added.

The image DTOs are now stored before the page is emitted rather than after the table is filled, because drawing the new-image markers is part of rendering and reads them. A test pins that order, since getting it wrong would silently show no "new" icons.

## Manual test
Open a template (double-click, or the enter arrow): the imagery-search table fills with its results, the filter widgets show what the template searches for, "Update template" appears, and the footprint layer lands at the bottom of the template's group. Select AOI rows to scope the results to them, and deselect to get them all back. Page through results with the arrows and re-sort by clicking a sortable header — both must re-request the template endpoint, not a regular search. Right-click a template > "See search results" fills the table AND brings the imagery-search tab to front, which entering a template must not do. Leaving the template clears the table, the pager and the widen (!) warning, and drops the template's layer group. Regression surface: a template whose search returns nothing must clear the table and show "No images was found" rather than leaving stale rows; and selecting a footprint on the map must still select its table row.