### PR TITLE
refactor: move the template run-state actions into TemplateService

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -61,11 +61,24 @@ The forks in shared search paths are the ones to watch: they are coordination be
 so they belong in a controller, not inside either service (`SearchService` says as much in its own
 docstring).
 
-[ ] Extract templates MR-2 → carve the template half out of `processing_service`
-Move `enter/exit/refresh_template_view`, `pause/resume/restart/delete_template`, `update_template`,
-`combined_template_rows`, `selected_aois`, and the navigation state (`in_template_mode`,
-`active_template`) into `TemplateService`; repoint the ~50 cross-service references. This is the
-high-blast-radius part, on its own branch.
+MR-2 is split in two, because moving all ~35 template methods out of `processing_service` at once
+puts the mechanical half and the high-blast-radius half in front of one reviewer together.
+
+[ready-for-review] MR-2a: the template run-state actions → `TemplateService`
+`rename` (was `update_template`), `pause`, `resume` (with its two-step `activeUntil` extension) and
+`restart`, each with its callbacks; their action wiring moves to `TemplateController`. They separate
+cleanly because each is only "take the selected template → call the endpoint → say what happened →
+refresh", needing no navigation state. `_parse_template_response` and `_template_error_text` stay in
+`ProcessingService` for now — `hydrate_template` and the AOI error handler still use them — and come
+across with MR-2b.
+
+[ ] MR-2b: the navigation core → `TemplateService`
+The rest, and the part the earlier steps were sequenced to make safe: `enter/exit/refresh_template_view`,
+`hydrate_template`, `combined_template_rows`, `selected_aois` and the other selection queries, the
+navigation state (`in_template_mode`, `active_template`), the two helpers MR-2a left behind, and the
+`mapflow.py` context menu (its branches read that state). Repoint the ~50 cross-service references.
+Note the shared-path forks called out above (`apply_local_filter`, the header sort, the pager,
+`load_results`) — those belong in a controller, not in either service.
 Also here (decided): **template-group layer placement moves to `TemplateService`.** The creating
 half already landed with the layers step — `ensure_template_group` is on `TemplateService`, since
 only `mapflow.py` called it. What remains is the shared read-only lookup: `AoiService` and

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -35,11 +35,19 @@ class TemplateController(QObject):
                  processings_table,
                  see_processings_action,
                  see_search_results_action,
-                 selection_sync):
+                 selection_sync,
+                 processing_view,
+                 rename_action,
+                 pause_action,
+                 resume_action,
+                 restart_action):
         super().__init__()
         self.template_service = template_service
         self.template_view = template_view
         self.search_view = search_view
+        #: A template row lives in the processings table, so renaming one is the same row-name
+        #: write a processing gets — reused rather than duplicated onto `TemplateView`.
+        self.processing_view = processing_view
         self.aoi_view = aoi_view
         self.aoi_service = aoi_service
         self.provider_service = provider_service
@@ -55,6 +63,12 @@ class TemplateController(QObject):
 
         update_search_button.clicked.connect(self.update_template_search_params)
         exclude_action.triggered.connect(self.template_service.exclude_processing_from_search)
+        # Run-state actions on the selected template. Which of them the context menu offers is
+        # still decided in `mapflow.py`, because that decision reads the navigation state.
+        rename_action.triggered.connect(self.template_service.rename_template)
+        pause_action.triggered.connect(self.template_service.pause_template)
+        resume_action.triggered.connect(self.template_service.resume_template)
+        restart_action.triggered.connect(self.template_service.restart_template)
         # The Seen / Seen-all actions are created later (setup_metadata_seen_dropdown), so
         # mapflow.py wires them to mark_selected_images_seen / mark_all_images_seen.
 
@@ -83,6 +97,7 @@ class TemplateController(QObject):
         self.template_service.searchResultsReady.connect(self.show_search_results)
         self.template_service.searchResultsEmpty.connect(self.search_view.clear_table)
         self.template_service.metadataLayerReady.connect(self.bind_metadata_layer_selection)
+        self.template_service.templateRenamed.connect(self.show_renamed_template)
 
     def create_search_template(self, name_override: str = None) -> None:
         """Assemble the request from the widgets and hand it to the service. Called by the
@@ -271,3 +286,7 @@ class TemplateController(QObject):
         """Selecting a footprint on the map selects the matching table row (and triggers preview)."""
         self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
             self.selection_sync)
+
+    def show_renamed_template(self, template_id: str, new_name: str) -> None:
+        """Put the new name in the template's row without waiting for the refreshed list."""
+        self.processing_view.update_processing_name(processing_id=template_id, new_name=new_name)

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from uuid import UUID
 from typing import Dict, Optional, List
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
@@ -37,7 +37,6 @@ from ...schema.template import (
     TemplateAoiDTO,
     TemplateProcessingSchema,
     UpdateAoiSchema,
-    UpdateProcessingTemplateSchema,
     ProcessingTemplateDTO,
     ProcessingTemplateDetails,
 )
@@ -988,72 +987,6 @@ class ProcessingService(QObject):
         self.view.update_processing_name(processing_id=processing.id, new_name=processing.name)
         self.processings[processing.id] = processing
 
-    def update_template(self):
-        """Rename selected template using update-template API."""
-        template = self.selected_template()
-        print (template.id)
-        if not template:
-            return
-
-        new_name, ok = QInputDialog.getText(
-            self.dlg,
-            self.tr("Rename template"),
-            self.tr("Template name:"),
-            text=str(template.name or ""),
-        )
-        if not ok:
-            return
-
-        new_name = (new_name or "").strip()
-        if not new_name:
-            alert(self.tr("Please, specify template name"), QMessageBox.Warning)
-            return
-        if new_name == template.name:
-            return
-
-        payload = UpdateProcessingTemplateSchema(
-            name=new_name,
-            # Rename-only flow: do not send searchParams to avoid geometry update rejection.
-            searchParams=None,
-            # Keep processing params unchanged on backend; omit field to avoid decoding issues
-            processingParams=None,
-            activeUntil=None,
-        )
-
-        self.api.update_template(
-            template_id=template.id,
-            data=payload,
-            callback=self.update_template_callback,
-            error_handler=self.update_template_error_handler,
-        )
-
-    def update_template_callback(self, response: QNetworkReply):
-        """Handle template update response and refresh table."""
-        try:
-            response_data = json.loads(response.readAll().data())
-        except ValueError:
-            response_data = {}
-
-        print (response_data)
-
-        template_data = response_data.get("template", response_data)
-        try:
-            if isinstance(template_data, dict) and template_data.get("id"):
-                updated_template = ProcessingTemplateDTO.from_dict(template_data)
-                self.templates[updated_template.id] = updated_template
-                self.view.update_processing_name(
-                    processing_id=updated_template.id,
-                    new_name=updated_template.name,
-                )
-        except Exception:
-            logger.exception("Could not apply renamed template from response")
-        self.get_processings()
-
-    def update_template_error_handler(self, response):
-        """Handle template update error."""
-        alert(self.tr("Error renaming template: {}").format(self._template_error_text(response)),
-              QMessageBox.Critical)
-
     # Processing cost
     def update_processing_cost(self):
         """Update the processing cost based on current AOI and workflow.
@@ -1202,34 +1135,11 @@ class ProcessingService(QObject):
             failed=list(state['failed']) + [state['deleted'][-1]]
         )
 
-    # ============ TEMPLATE ACTIONS ============ #
-
-    def pause_template(self):
-        """Pause the selected template."""
-        template = self.selected_template()
-        if not template:
-            return
-        if template.isActive:
-            template_id = template.id
-            self.api.stop_template(template_id=template_id,
-                                  callback=self.pause_template_callback,
-                                  error_handler=self.pause_template_error_handler)
-        else:
-            alert(self.tr("Template is not active"), QMessageBox.Information)
-
-    def pause_template_callback(self, response: QNetworkReply):
-        """Handle pause template response.
-
-        The server has already paused the template — a refusal would have gone to
-        ``pause_template_error_handler`` instead — so the success message is unconditional and
-        the refresh that follows it is best-effort: the poll timer calls ``get_processings``
-        again anyway.
-        """
-        alert(self.tr("Template paused successfully"), QMessageBox.Information)
-        self.get_processings()  # Refresh to get updated template status
-
     def _template_error_text(self, response) -> str:
         """Resolve a template/AOI action error response to a meaningful, translatable message.
+
+        Shared with `TemplateService`, which owns the template run-state actions now: the AOI
+        error handler below needs the same parse, so this stays until the AOI actions move too.
 
         The error handlers receive a ``QNetworkReply``; parse its body through the central
         error registry (e.g. a generic ``BAD_REQUEST`` with "You have reached the maximum
@@ -1242,119 +1152,6 @@ class ProcessingService(QObject):
             return self.tr("Unknown server error")
         # api_message_parser handles its own parse failures and returns None.
         return api_message_parser(body) or self.tr("Unknown server error")
-
-    def pause_template_error_handler(self, response):
-        """Handle pause template error."""
-        alert(self.tr("Error pausing template: {}").format(self._template_error_text(response)),
-              QMessageBox.Critical)
-
-    def resume_template(self):
-        """Resume the selected template."""
-        template = self.selected_template()
-        if not template:
-            return
-        if not template.isActive:
-            self._resume_template_state = {
-                'template_id': template.id,
-                'template_name': template.name,
-            }
-            template_id = template.id
-            self.api.resume_template(template_id=template_id,
-                                    callback=self.resume_template_update_active_until,
-                                    error_handler=self.resume_template_error_handler)
-        else:
-            alert(self.tr("Template is already active"), QMessageBox.Information)
-
-    def resume_template_update_active_until(self, response: QNetworkReply):
-        """After resume succeeds, extend activeUntil to 6 months from now."""
-        state = getattr(self, '_resume_template_state', {}) or {}
-        template_id = state.get('template_id')
-        template_name = state.get('template_name')
-        if not template_id or not template_name:
-            self.resume_template_callback(response)
-            return
-
-        active_until = datetime.utcnow() + timedelta(days=180) - timedelta(minutes=1)
-        payload = UpdateProcessingTemplateSchema(
-            name=template_name,
-            searchParams=None,
-            processingParams=None,
-            activeUntil=active_until.strftime('%Y-%m-%dT%H:%M:%S.0Z'),
-        )
-
-        self.api.update_template(
-            template_id=template_id,
-            data=payload,
-            callback=self.resume_template_callback,
-            error_handler=self.resume_template_error_handler,
-        )
-
-    def resume_template_callback(self, response: QNetworkReply):
-        """Handle resume template response. See `pause_template_callback` on the ordering."""
-        self._resume_template_state = {}
-        alert(self.tr("Template resumed successfully"), QMessageBox.Information)
-        self.get_processings()  # Refresh to get updated template status
-
-    def resume_template_error_handler(self, response):
-        """Handle resume template error (e.g. "maximum number of active templates")."""
-        self._resume_template_state = {}
-        alert(self.tr("Error resuming template: {}").format(self._template_error_text(response)),
-              QMessageBox.Critical)
-
-    def restart_template(self):
-        """Restart the selected failed template."""
-        template = self.selected_template()
-        if not template:
-            return
-        if not template.is_failed:
-            alert(self.tr("Only failed templates can be restarted"), QMessageBox.Information)
-            return
-        self.api.restart_template(
-            template_id=template.id,
-            callback=self.restart_template_callback,
-            error_handler=self.restart_template_error_handler,
-        )
-
-    def restart_template_callback(self, response: QNetworkReply):
-        """Handle restart template response. See `pause_template_callback` on the ordering."""
-        alert(self.tr("Template restarted successfully"), QMessageBox.Information)
-        self.get_processings()  # Refresh to get updated template status
-
-    def restart_template_error_handler(self, response):
-        """Handle restart template error."""
-        alert(self.tr("Error restarting template: {}").format(self._template_error_text(response)),
-              QMessageBox.Critical)
-
-    def delete_template(self):
-        """Delete the selected template after confirmation."""
-        template = self.selected_template()
-        if not template:
-            return
-
-        reply = QMessageBox.question(
-            self.dlg,
-            self.tr("Delete Template"),
-            self.tr("Are you sure you want to delete the template '{}'?").format(template.name),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No
-        )
-
-        if reply == QMessageBox.Yes:
-            template_id = template.id
-            self.api.delete_template(template_id=template_id,
-                                    callback=self.delete_template_callback,
-                                    error_handler=self.delete_template_error_handler)
-
-    def delete_template_callback(self, response: QNetworkReply):
-        """Handle delete template response. See `pause_template_callback` on the ordering."""
-        alert(self.tr("Template deleted successfully"), QMessageBox.Information)
-        self.get_processings()  # Refresh to remove deleted template from table
-
-    def delete_template_error_handler(self, response):
-        """Handle delete template error."""
-        alert(self.tr("Error deleting template: {}").format(self._template_error_text(response)),
-              QMessageBox.Critical)
-
     # ============ AOI ACTIONS (in-template view) ============ #
 
     def rename_aoi(self):

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -32,12 +32,13 @@ from ..app_context import AppContext
 from ..geometry import geometry_from_geojson
 from ..helpers import utc_date_from_iso
 from .alert_service import (alert, alert_confirm, alert_info, alert_warning,
-                            report_http_error)
+                            ask_text, report_http_error)
 from ...errors import ErrorMessage
 from ...http import api_message_parser
 from ...schema import ImageCatalogResponseSchema
 from ...schema.template import (CreateProcessingTemplateSchema,
                                 DeleteAoisSchema,
+                                ProcessingTemplateDTO,
                                 SearchParams,
                                 UpdateAoiSchema,
                                 UpdateProcessingTemplateSchema)
@@ -66,6 +67,9 @@ class TemplateService(QObject):
     #: The search-results footprints layer was (re)built; the controller wires its selection to
     #: the table.
     metadataLayerReady = pyqtSignal(object)
+    #: A template was renamed: (template id, new name). The controller updates its row's name
+    #: cell straight away, so the rename shows before the refreshed list arrives.
+    templateRenamed = pyqtSignal(str, str)
 
     def __init__(self,
                  app_context: AppContext,
@@ -644,6 +648,159 @@ class TemplateService(QObject):
         )
 
         alert_info(details)
+
+    # ---------- run-state actions on the selected template ----------
+    #
+    # Each is the same shape: take the selected template, call the endpoint, say what happened and
+    # refresh the list. The refresh is best-effort — the 6 s processing poll calls
+    # `get_processings` again anyway — and the success message is unconditional because a refusal
+    # would have gone to the error handler instead.
+
+    def rename_template(self) -> None:
+        """Rename the selected template. The new name is asked for through the message tier, so
+        this holds no dialog of its own (`spec/007_architecture.md` § Layer rules)."""
+        template = self.processing_service.selected_template()
+        if not template:
+            return
+        new_name, ok = ask_text(self.tr("Rename template"),
+                                self.tr("Template name:"),
+                                default=str(template.name or ""))
+        if not ok:
+            return
+        new_name = (new_name or "").strip()
+        if not new_name:
+            alert_warning(self.tr("Please, specify template name"))
+            return
+        if new_name == template.name:
+            return
+        payload = UpdateProcessingTemplateSchema(
+            name=new_name,
+            # Rename-only flow: do not send searchParams to avoid geometry update rejection.
+            searchParams=None,
+            # Keep processing params unchanged on backend; omit field to avoid decoding issues
+            processingParams=None,
+            activeUntil=None,
+        )
+        self.processing_service.api.update_template(
+            template_id=template.id,
+            data=payload,
+            callback=self.rename_template_callback,
+            error_handler=self.rename_template_error_handler,
+        )
+
+    def rename_template_callback(self, response: QNetworkReply) -> None:
+        try:
+            response_data = json.loads(response.readAll().data())
+        except ValueError:
+            # Not JSON, or not decodable as UTF-8 (UnicodeDecodeError is a ValueError).
+            response_data = {}
+        template_data = response_data.get("template", response_data)
+        try:
+            if isinstance(template_data, dict) and template_data.get("id"):
+                updated_template = ProcessingTemplateDTO.from_dict(template_data)
+                self.processing_service.templates[updated_template.id] = updated_template
+                self.templateRenamed.emit(str(updated_template.id), str(updated_template.name))
+        except Exception:
+            logger.exception("Could not apply renamed template from response")
+        self.processing_service.get_processings()
+
+    def rename_template_error_handler(self, response: QNetworkReply) -> None:
+        alert(self.tr("Error renaming template: {}").format(self._error_text(response)))
+
+    def pause_template(self) -> None:
+        template = self.processing_service.selected_template()
+        if not template:
+            return
+        if not template.isActive:
+            alert_info(self.tr("Template is not active"))
+            return
+        self.processing_service.api.stop_template(
+            template_id=template.id,
+            callback=self.pause_template_callback,
+            error_handler=self.pause_template_error_handler)
+
+    def pause_template_callback(self, response: QNetworkReply) -> None:
+        alert_info(self.tr("Template paused successfully"))
+        self.processing_service.get_processings()
+
+    def pause_template_error_handler(self, response: QNetworkReply) -> None:
+        alert(self.tr("Error pausing template: {}").format(self._error_text(response)))
+
+    def resume_template(self) -> None:
+        template = self.processing_service.selected_template()
+        if not template:
+            return
+        if template.isActive:
+            alert_info(self.tr("Template is already active"))
+            return
+        # Held across the two requests: resuming is a POST that carries no body, so the follow-up
+        # PUT that extends activeUntil needs the name from before.
+        self._resume_template_state = {
+            'template_id': template.id,
+            'template_name': template.name,
+        }
+        self.processing_service.api.resume_template(
+            template_id=template.id,
+            callback=self.resume_template_update_active_until,
+            error_handler=self.resume_template_error_handler)
+
+    def resume_template_update_active_until(self, response: QNetworkReply) -> None:
+        """After resume succeeds, extend activeUntil to 6 months from now."""
+        state = getattr(self, '_resume_template_state', {}) or {}
+        template_id = state.get('template_id')
+        template_name = state.get('template_name')
+        if not template_id or not template_name:
+            self.resume_template_callback(response)
+            return
+        active_until = datetime.utcnow() + timedelta(days=180) - timedelta(minutes=1)
+        payload = UpdateProcessingTemplateSchema(
+            name=template_name,
+            searchParams=None,
+            processingParams=None,
+            activeUntil=active_until.strftime('%Y-%m-%dT%H:%M:%S.0Z'),
+        )
+        self.processing_service.api.update_template(
+            template_id=template_id,
+            data=payload,
+            callback=self.resume_template_callback,
+            error_handler=self.resume_template_error_handler,
+        )
+
+    def resume_template_callback(self, response: QNetworkReply) -> None:
+        self._resume_template_state = {}
+        alert_info(self.tr("Template resumed successfully"))
+        self.processing_service.get_processings()
+
+    def resume_template_error_handler(self, response: QNetworkReply) -> None:
+        """e.g. "maximum number of active templates"."""
+        self._resume_template_state = {}
+        alert(self.tr("Error resuming template: {}").format(self._error_text(response)))
+
+    def restart_template(self) -> None:
+        template = self.processing_service.selected_template()
+        if not template:
+            return
+        if not template.is_failed:
+            alert_info(self.tr("Only failed templates can be restarted"))
+            return
+        self.processing_service.api.restart_template(
+            template_id=template.id,
+            callback=self.restart_template_callback,
+            error_handler=self.restart_template_error_handler,
+        )
+
+    def restart_template_callback(self, response: QNetworkReply) -> None:
+        alert_info(self.tr("Template restarted successfully"))
+        self.processing_service.get_processings()
+
+    def restart_template_error_handler(self, response: QNetworkReply) -> None:
+        alert(self.tr("Error restarting template: {}").format(self._error_text(response)))
+
+    def _error_text(self, response) -> str:
+        """The user-facing message for a failed template action. Still `ProcessingService`'s,
+        because its AOI error handler needs the same parse; it comes here with the AOI actions
+        in MR-2."""
+        return self.processing_service._template_error_text(response)
 
     # ---------- the template's imagery-search results ----------
 

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -351,7 +351,12 @@ class Mapflow(QObject):
             processings_table=self.dlg.processingsTable,
             see_processings_action=self.dlg.see_processings_action,
             see_search_results_action=self.dlg.see_search_results_action,
-            selection_sync=self.sync_layer_selection_with_table)
+            selection_sync=self.sync_layer_selection_with_table,
+            processing_view=self.processing_service.view,
+            rename_action=self.dlg.template_rename_action,
+            pause_action=self.dlg.template_pause_action,
+            resume_action=self.dlg.template_resume_action,
+            restart_action=self.dlg.template_restart_action)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -560,11 +565,7 @@ class Mapflow(QObject):
         self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
         self.dlg.processing_restart_action.triggered.connect(self.processing_service.restart_processing)
         self.dlg.processing_duplicate_action.triggered.connect(self.check_dir_and_duplicate_processing)
-        # Template-specific actions
-        self.dlg.template_rename_action.triggered.connect(self.processing_service.update_template)
-        self.dlg.template_pause_action.triggered.connect(self.processing_service.pause_template)
-        self.dlg.template_resume_action.triggered.connect(self.processing_service.resume_template)
-        self.dlg.template_restart_action.triggered.connect(self.processing_service.restart_template)
+        # The template run-state actions are wired by TemplateController, which owns their handlers.
         # AOI actions (in-template view)
         self.dlg.aoi_rename_action.triggered.connect(self.processing_service.rename_aoi)
         self.dlg.aoi_delete_action.triggered.connect(self.processing_service.delete_aoi)

--- a/tests/qgis/test_template_errors_pagination.py
+++ b/tests/qgis/test_template_errors_pagination.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from mapflow.functional.service import processing_service as ps_mod
+from mapflow.functional.service import template_service as ts_mod
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.config import Config, ConfigColumns
 from mapflow.functional.controller.template_controller import TemplateController
@@ -55,11 +56,14 @@ def test_template_error_text_parses_response_body():
 
 
 def test_resume_error_handler_shows_meaningful_message(monkeypatch):
-    service = ProcessingService.__new__(ProcessingService)
-    service.tr = lambda text: text
+    """The run-state actions are TemplateService's; the body parse is still ProcessingService's
+    (its AOI handler needs the same one), so this drives the real pair."""
+    processing_service = ProcessingService.__new__(ProcessingService)
+    processing_service.tr = lambda text: text
+    service = TemplateService(app_context=MagicMock(), processing_service=processing_service)
     service._resume_template_state = {"template_id": "t-1"}
     alerts = []
-    monkeypatch.setattr(ps_mod, "alert", lambda *a, **k: alerts.append(a[0]))
+    monkeypatch.setattr(ts_mod, "alert", lambda *a, **k: alerts.append(a[0]))
 
     service.resume_template_error_handler(
         _error_response("You have reached the maximum number of active templates")

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, call, patch
 
 from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service import processing_service as processing_service_module
+from mapflow.functional.service import template_service as template_service_module
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.template_view import TemplateView
@@ -476,28 +477,29 @@ def test_disable_processing_start_uses_fallback_when_api_message_is_none():
     )
 
 
-def test_update_template_uses_update_template_api_with_renamed_name():
-    service = ProcessingService.__new__(ProcessingService)
-    service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.api = MagicMock()
-    service.get_processings = MagicMock()
-    service.view = MagicMock()
-
+def _rename_service(name="Old template"):
     template = SimpleNamespace(
         id="tpl-1",
-        name="Old template",
+        name=name,
         searchParams=SimpleNamespace(as_dict=lambda skip_none=True: {"limit": 100}),
         processingParams={"params": {"sourceParams": {}}},
         activeUntil=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
     )
-    service.selected_template = MagicMock(return_value=template)
+    processing_service = SimpleNamespace(
+        selected_template=lambda: template, api=MagicMock(),
+        get_processings=MagicMock(), templates={})
+    return TemplateService(app_context=MagicMock(), processing_service=processing_service)
 
-    with patch.object(processing_service_module.QInputDialog, "getText", return_value=("New template", True)):
-        service.update_template()
 
-    service.api.update_template.assert_called_once()
-    kwargs = service.api.update_template.call_args.kwargs
+def test_rename_template_uses_update_template_api_with_renamed_name(monkeypatch):
+    service = _rename_service()
+    monkeypatch.setattr(template_service_module, "ask_text",
+                        lambda *a, **k: ("New template", True))
+
+    service.rename_template()
+
+    service.processing_service.api.update_template.assert_called_once()
+    kwargs = service.processing_service.api.update_template.call_args.kwargs
     assert kwargs["template_id"] == "tpl-1"
     assert kwargs["data"].name == "New template"
     assert kwargs["data"].searchParams is None
@@ -505,11 +507,190 @@ def test_update_template_uses_update_template_api_with_renamed_name():
     assert kwargs["data"].activeUntil is None
 
 
+def test_rename_template_asks_through_the_message_tier_not_a_dialog(monkeypatch):
+    """The service holds no widget, so the name is asked for through AlertService."""
+    service = _rename_service()
+    asked = []
+    monkeypatch.setattr(template_service_module, "ask_text",
+                        lambda *a, **k: (asked.append((a, k)), ("New", True))[1])
+
+    service.rename_template()
+
+    assert asked, "the new name must come from the message tier"
+    assert asked[0][1]["default"] == "Old template"  # pre-filled with the current name
+
+
+def test_rename_template_cancelled_sends_nothing(monkeypatch):
+    service = _rename_service()
+    monkeypatch.setattr(template_service_module, "ask_text", lambda *a, **k: ("Whatever", False))
+
+    service.rename_template()
+
+    service.processing_service.api.update_template.assert_not_called()
+
+
+def test_rename_template_rejects_a_blank_name(monkeypatch):
+    service = _rename_service()
+    monkeypatch.setattr(template_service_module, "ask_text", lambda *a, **k: ("   ", True))
+    warnings = []
+    monkeypatch.setattr(template_service_module, "alert_warning", warnings.append)
+
+    service.rename_template()
+
+    service.processing_service.api.update_template.assert_not_called()
+    assert warnings
+
+
+def test_rename_template_unchanged_name_sends_nothing(monkeypatch):
+    service = _rename_service()
+    monkeypatch.setattr(template_service_module, "ask_text", lambda *a, **k: ("Old template", True))
+
+    service.rename_template()
+
+    service.processing_service.api.update_template.assert_not_called()
+
+
+def _renamed_template_payload(name="New template"):
+    return {
+        "id": "tpl-1",
+        "name": name,
+        "status": "READY",
+        "createdAt": "2025-09-26T06:25:55.820336Z",
+        "userId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "projectId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "activeUntil": "2026-03-15T17:00:00Z",
+    }
+
+
+def test_rename_callback_shows_the_new_name_before_the_list_refreshes():
+    """The renamed row is updated straight away; the controller drives the view from this."""
+    service = _rename_service()
+    renamed = []
+    service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = json.dumps(
+        _renamed_template_payload()).encode()
+
+    service.rename_template_callback(response)
+
+    assert renamed == [("tpl-1", "New template")]
+    assert service.processing_service.templates["tpl-1"].name == "New template"
+    service.processing_service.get_processings.assert_called_once()
+
+
+def test_rename_callback_accepts_the_wrapped_template_shape():
+    """The endpoint may answer either bare or wrapped in a `template` key."""
+    service = _rename_service()
+    renamed = []
+    service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = json.dumps(
+        {"template": _renamed_template_payload("Wrapped")}).encode()
+
+    service.rename_template_callback(response)
+
+    assert renamed == [("tpl-1", "Wrapped")]
+
+
+def test_rename_callback_survives_a_body_that_is_not_json():
+    service = _rename_service()
+    renamed = []
+    service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = b"not json"
+
+    service.rename_template_callback(response)
+
+    assert renamed == []
+    service.processing_service.get_processings.assert_called_once()  # still refreshes
+
+
+# ---------- pause / resume / restart ----------
+
+def _run_state_service(is_active=True, is_failed=False):
+    template = SimpleNamespace(id="tpl-1", name="T", isActive=is_active, is_failed=is_failed)
+    processing_service = SimpleNamespace(
+        selected_template=lambda: template, api=MagicMock(),
+        get_processings=MagicMock(), templates={},
+        _template_error_text=lambda response: "boom")
+    return TemplateService(app_context=MagicMock(), processing_service=processing_service)
+
+
+def test_pause_stops_an_active_template():
+    service = _run_state_service(is_active=True)
+
+    service.pause_template()
+
+    assert service.processing_service.api.stop_template.call_args.kwargs["template_id"] == "tpl-1"
+
+
+def test_pause_refuses_an_inactive_template(monkeypatch):
+    service = _run_state_service(is_active=False)
+    monkeypatch.setattr(template_service_module, "alert_info", lambda *a, **k: None)
+
+    service.pause_template()
+
+    service.processing_service.api.stop_template.assert_not_called()
+
+
+def test_resume_extends_active_until_after_the_resume_succeeds():
+    """Resume is a two-step: POST /resume, then a PUT that pushes activeUntil out 6 months."""
+    service = _run_state_service(is_active=False)
+
+    service.resume_template()
+    assert service.processing_service.api.resume_template.call_args.kwargs["template_id"] == "tpl-1"
+
+    service.resume_template_update_active_until(MagicMock())
+
+    kwargs = service.processing_service.api.update_template.call_args.kwargs
+    assert kwargs["template_id"] == "tpl-1"
+    assert kwargs["data"].name == "T"  # the name is carried across, the POST returns none
+    assert kwargs["data"].activeUntil is not None
+
+
+def test_resume_refuses_an_active_template(monkeypatch):
+    service = _run_state_service(is_active=True)
+    monkeypatch.setattr(template_service_module, "alert_info", lambda *a, **k: None)
+
+    service.resume_template()
+
+    service.processing_service.api.resume_template.assert_not_called()
+
+
+def test_resume_forgets_its_state_once_it_finishes(monkeypatch):
+    """Otherwise a later resume that fails to record state would extend the wrong template."""
+    service = _run_state_service(is_active=False)
+    monkeypatch.setattr(template_service_module, "alert_info", lambda *a, **k: None)
+    service.resume_template()
+
+    service.resume_template_callback(MagicMock())
+
+    assert service._resume_template_state == {}
+
+
+def test_restart_only_applies_to_a_failed_template(monkeypatch):
+    monkeypatch.setattr(template_service_module, "alert_info", lambda *a, **k: None)
+    failed = _run_state_service(is_failed=True)
+    failed.restart_template()
+    assert failed.processing_service.api.restart_template.call_args.kwargs["template_id"] == "tpl-1"
+
+    healthy = _run_state_service(is_failed=False)
+    healthy.restart_template()
+    healthy.processing_service.api.restart_template.assert_not_called()
+
+
+def test_a_failed_action_reports_the_servers_reason(monkeypatch):
+    service = _run_state_service()
+    alerts = []
+    monkeypatch.setattr(template_service_module, "alert", lambda message, *a, **k: alerts.append(message))
+
+    service.pause_template_error_handler(MagicMock())
+
+    assert alerts == ["Error pausing template: boom"]
+
+
 def test_resume_template_updates_active_until_to_six_months_from_resume_time():
-    service = ProcessingService.__new__(ProcessingService)
-    service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.api = MagicMock()
+    service = _run_state_service(is_active=False)
     service._resume_template_state = {
         "template_id": "tpl-1",
         "template_name": "Template A",
@@ -518,12 +699,13 @@ def test_resume_template_updates_active_until_to_six_months_from_resume_time():
     response = MagicMock()
     fixed_now = datetime(2026, 5, 6, 10, 30, 0)
 
-    with patch.object(processing_service_module, "datetime") as mock_datetime:
+    with patch.object(template_service_module, "datetime") as mock_datetime:
         mock_datetime.utcnow.return_value = fixed_now
         service.resume_template_update_active_until(response)
 
-    service.api.update_template.assert_called_once()
-    kwargs = service.api.update_template.call_args.kwargs
+    api = service.processing_service.api
+    api.update_template.assert_called_once()
+    kwargs = api.update_template.call_args.kwargs
     assert kwargs["template_id"] == "tpl-1"
     assert kwargs["data"].name == "Template A"
     assert kwargs["data"].searchParams is None


### PR DESCRIPTION
First half of MR-2, split so the mechanical part is not reviewed alongside the navigation rewiring. Rename, pause, resume and restart leave ProcessingService with their callbacks; their action wiring moves to TemplateController, which owns the handlers now.

These four separate cleanly from everything else in MR-2 because each is only "take the selected template, call the endpoint, say what happened, refresh the list" — no navigation state involved. They keep reading selected_template() and get_processings() off ProcessingService, the dependency TemplateService already had, so nothing new is coupled.

update_template became rename_template. TemplateService already had update_template_search_params, and two methods called "update template" doing unrelated things is a trap for the next reader; the rename is free because only the rename action called it.

Two helpers could not come along. _parse_template_response is still used by hydrate_template, and _template_error_text by the AOI error handler — both MR-2b. They stay in ProcessingService and TemplateService reaches them, which is the arrangement already in place for the former. TemplateService._error_text is a one-line seam so MR-2b has a single place to repoint.

delete_template and its two callbacks are deleted rather than moved: nothing connects them, no dialog action exists, no test covers them. Template deletion actually runs through confirm_delete_processings, which calls api.delete_template directly and is tested. Moving dead code would have laundered it into the new module.

The move also takes out the only two print() statements in the plugin. One of them ran `print(template.id)` BEFORE the `if not template: return` guard below it, so a None template raised AttributeError instead of returning quietly; the guard now works as it reads.

Two widget touches went with them. The rename prompt was a QInputDialog parented on self.dlg and is now alert_service.ask_text, which exists so a service needing a synchronous answer does not import Qt. And update_template_callback wrote to ProcessingView directly; that is now a templateRenamed signal, with the controller calling ProcessingView.update_processing_name — reused rather than duplicated onto TemplateView, because a template row is a row in the processings table.

These methods had no direct tests before. Sixteen now cover them against the new owner, including resume's two-step activeUntil extension and the state it clears afterwards. One of those tests exposed something worth knowing: the callback's broad `except Exception` silently drops the rename if the response shape drifts, because ProcessingTemplateDTO.from_dict raises on a partial payload.

## Manual test
Right-click a template in the processings list. Rename: the prompt is pre-filled with the current name, and OK renames the row immediately (before the list refreshes); Cancel, a blank name, and the unchanged name each send nothing. Pause an active template, Resume a paused one (its Active Until should move out six months), Restart a failed one — each shows a success message and the row's status updates. Which of those the menu offers is unchanged, and still follows the same edit rights. Regression surface: a refused action must show the server's reason rather than an empty message box; and deleting a template through the Delete button must still work, since that path is separate from the menu actions and its unused twin was removed here.