### PR TITLE
refactor: give the processings table's refresh a single owner

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -72,7 +72,15 @@ refresh", needing no navigation state. `_parse_template_response` and `_template
 `ProcessingService` for now — `hydrate_template` and the AOI error handler still use them — and come
 across with MR-2b.
 
-[ ] MR-2b: the navigation core → `TemplateService`
+[ready-for-review] MR-2b-1: give the processings table's refresh one owner
+Moving the navigation state would have made `ProcessingService` and `TemplateService` mutually
+dependent, because `get_processings`, `combined_processing_rows` and `start_processing_callback` all
+forked on `in_template_mode` and called template code. Those forks now live in
+`ProjectProcessingController`: services emit `refreshRequested` / `rerenderRequested` /
+`templateRehydrateRequested`, and the controller picks which of the table's two views to act on. No
+state moved, so nothing changed behaviourally — but MR-2b-2 becomes a move instead of a redesign.
+
+[ ] MR-2b-2: the navigation core → `TemplateService`
 The rest, and the part the earlier steps were sequenced to make safe: `enter/exit/refresh_template_view`,
 `hydrate_template`, `combined_template_rows`, `selected_aois` and the other selection queries, the
 navigation state (`in_template_mode`, `active_template`), the two helpers MR-2a left behind, and the

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -22,11 +22,16 @@ class ProjectProcessingController(QObject):
     def __init__(self, dlg: MainDialog,
                  processing_service: ProcessingService,
                  project_service: ProjectService,
+                 template_service,
                  app_context: AppContext):
         super().__init__()
         self.dlg = dlg
         self.processing_service = processing_service
         self.project_service = project_service
+        #: Subscribed to for "the table needs refreshing" after a template action. The in-template
+        #: view itself is still `ProcessingService`'s; when it moves, the branches in
+        #: `refresh_table` / `rerender_rows` point here instead.
+        self.template_service = template_service
         self.app_context = app_context
         
         self._setup_processing_bindings()
@@ -39,9 +44,40 @@ class ProjectProcessingController(QObject):
         """Processing-specific UI connections."""
         self.dlg.startProcessing.clicked.connect(self.processing_service.start_processing)
         self.dlg.processing_update_action.triggered.connect(self.update_processing)
-        self.processing_service.processing_fetch_timer.timeout.connect(
-            self.processing_service.get_processings
-        )
+        # The poll tick, and every action that wants the table refreshed, come here rather than
+        # going straight to a service: the table serves two views and picking between them is
+        # navigation, which is this controller's region.
+        self.processing_service.processing_fetch_timer.timeout.connect(self.refresh_table)
+        self.processing_service.refreshRequested.connect(self.refresh_table)
+        self.processing_service.rerenderRequested.connect(self.rerender_rows)
+        self.processing_service.templateRehydrateRequested.connect(self.rehydrate_template)
+        self.template_service.refreshRequested.connect(self.refresh_table)
+
+    # ==== WHICH VIEW THE PROCESSINGS TABLE IS SHOWING ==== #
+    #
+    # One table, two views: the project's processings+templates, or an open template's
+    # AOIs+processings. Both services would otherwise have to ask each other which is showing —
+    # `ProcessingService` needing `TemplateService` and vice versa — so the choice lives here
+    # instead, the way `SearchService` already leaves regular-vs-template search to a controller.
+
+    def refresh_table(self):
+        """Re-fetch whatever the table is showing."""
+        if self.processing_service.in_template_mode:
+            self.processing_service.refresh_template_view()
+        else:
+            self.processing_service.get_processings()
+
+    def rerender_rows(self):
+        """Re-render the rows already held, for a sort that needs no request."""
+        if self.processing_service.in_template_mode:
+            rows = self.processing_service.combined_template_rows()
+        else:
+            rows = self.processing_service.combined_processing_rows()
+        self.processing_service.view.update_processing_table(rows)
+
+    def rehydrate_template(self):
+        """A processing was started inside a template: re-hydrate so it binds to its AOI."""
+        self.processing_service.refresh_active_template()
     
     def _setup_project_bindings(self):
         """Project-specific UI connections."""

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -66,6 +66,16 @@ class ProcessingService(QObject):
     # Emitted (in template view) once the template's full processings list is loaded, so listeners
     # can set up the "No AOI" map group for processings not bound to any AOI.
     templateProcessingsLoaded = pyqtSignal(object)
+    #: "Re-fetch whatever list the processings table is showing." The table serves two views —
+    #: the project's processings and an open template's AOIs+processings — and which one is
+    #: showing is navigation state, so the choice is `ProjectProcessingController`'s, not this
+    #: service's. Everything that used to call `get_processings()` to mean "refresh" emits this.
+    refreshRequested = pyqtSignal()
+    #: Same, but after starting a processing inside a template: the template must be re-hydrated,
+    #: not merely re-fetched, or the new processing lands under "No AOI" (feedback 8.2).
+    templateRehydrateRequested = pyqtSignal()
+    #: "Re-render the rows already held", for a sort that needs no request.
+    rerenderRequested = pyqtSignal()
 
     # Class-level defaults so the mode check is safe even when callers (and tests)
     # construct the service without running __init__.
@@ -471,13 +481,12 @@ class ProcessingService(QObject):
             # In a template the new processing is shown grouped UNDER its AOI. That binding
             # lives in the template's aoiDetails, which the run response does not carry, so a
             # flat optimistic add would place the processing under the "No AOI" separator until
-            # the user re-entered the template (feedback 8.2). Re-hydrate the template instead
-            # (fresh aoiDetails binds the processing to its AOI) and refetch the template
-            # processings for the full row data. Template run responses also may not be a full
-            # ProcessingDTO, so we do not parse one here.
+            # the user re-entered the template (feedback 8.2). Re-hydrating is what binds it, so
+            # ask for that rather than a plain refresh. Template run responses also may not be a
+            # full ProcessingDTO, so we do not parse one here.
             if isinstance(response_data, dict) and response_data.get("name"):
                 self.view.clear_processing_name(response_data["name"])
-            self._refresh_active_template()
+            self.templateRehydrateRequested.emit()
             self.dlg.startProcessing.setEnabled(True)
             return
         new_processing = None
@@ -494,10 +503,10 @@ class ProcessingService(QObject):
             self.view.add_new_processing(new_processing)
         # Always refresh full list because template-started processings can affect
         # both processings and template status/counts in table.
-        self.get_processings()
+        self.refreshRequested.emit()
         self.dlg.startProcessing.setEnabled(True)
 
-    def _refresh_active_template(self):
+    def refresh_active_template(self):
         """Re-hydrate the active template's ``aoiDetails`` and its processings, then rebuild
         the grouped rows. Used after starting a template processing so the new processing is
         bound to its AOI instead of appearing under 'No AOI' (feedback 8.2)."""
@@ -556,19 +565,18 @@ class ProcessingService(QObject):
     def _on_combo_sort_changed(self):
         """Combo sort resets any header-click override and re-fetches."""
         self.view._header_sort_by = None
-        self.get_processings()
+        self.refreshRequested.emit()
 
     def _on_header_sort_changed(self):
-        """Re-render the table with current data using the header sort."""
-        self.view.update_processing_table(self.combined_processing_rows())
+        """Re-render the table with current data using the header sort. Both views sort, so this
+        asks for a re-render rather than rendering the project rows itself."""
+        self.rerenderRequested.emit()
 
     def get_processings(self):
+        """Fetch the *project's* processings. Not the entry point for "refresh the table" — that
+        is `refreshRequested`, because inside a template the same table shows something else and
+        choosing between the two is the controller's call."""
         if not self.app_context.current_project:
-            return
-        # While inside a template, the table shows that template's AOIs + processings.
-        # The poll timer calls this method, so redirect it to the template refresh.
-        if self.in_template_mode:
-            self.refresh_template_view()
             return
         # Clamp offset if it exceeds total
         try:
@@ -716,8 +724,8 @@ class ProcessingService(QObject):
         return (aoi.display_name or "").lower()
 
     def combined_processing_rows(self):
-        if self.in_template_mode:
-            return self.combined_template_rows()
+        """The *project* rows: its templates above its processings. The in-template rows are
+        `combined_template_rows`; which of the two the table wants is the controller's call."""
         sort_by, sort_order = self.view.sort_processings()
         reverse = sort_order == "DESC"
         templates = sorted(self.templates.values(), key=lambda t: self._sort_key(t, sort_by), reverse=reverse)
@@ -899,20 +907,24 @@ class ProcessingService(QObject):
     def is_no_aoi_processing(self, processing_id) -> bool:
         return str(processing_id) in self.no_aoi_processing_ids()
 
+    # Paging and filtering are project-list controls. They emit rather than fetch directly for the
+    # same reason everything else does: inside a template the table is showing something these do
+    # not page, and the controller is what knows that.
+
     def show_processings_next_page(self):
         self.processings_page_offset += self.processings_page_limit
-        self.get_processings()
+        self.refreshRequested.emit()
 
     def show_processings_previous_page(self):
         self.processings_page_offset -= self.processings_page_limit
         if self.processings_page_offset < 0:
             self.processings_page_offset = 0
-        self.get_processings()
+        self.refreshRequested.emit()
 
     def get_filtered_processings(self):
         """Reset to first page when filter text changes."""
         self.processings_page_offset = 0
-        self.get_processings()
+        self.refreshRequested.emit()
 
     def update_local_processings(self, processings: List[ProcessingDTO]):
         """

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -70,6 +70,10 @@ class TemplateService(QObject):
     #: A template was renamed: (template id, new name). The controller updates its row's name
     #: cell straight away, so the rename shows before the refreshed list arrives.
     templateRenamed = pyqtSignal(str, str)
+    #: "Re-fetch whatever the processings table is showing", after an action that changed it.
+    #: Which view that is depends on navigation state, so the controller decides — see
+    #: `ProcessingService.refreshRequested`, which carries the same meaning from the other side.
+    refreshRequested = pyqtSignal()
 
     def __init__(self,
                  app_context: AppContext,
@@ -178,7 +182,7 @@ class TemplateService(QObject):
                 "The template has been created, but is inactive.\n\n"
                 "You have reached the maximum number of active planned processings. "
                 "Pause or delete another one before activating this template."))
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def create_search_template_error_handler(self, response: QNetworkReply):
         self.creationBusy.emit(False)
@@ -212,7 +216,7 @@ class TemplateService(QObject):
         alert_info(self.tr("Template updated."))
         # Re-hydrate so the open template / list reflects the new params.
         self.processing_service.aoi_changed_callback(response)
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def _template_update_error_handler(self, response: QNetworkReply):
         report_http_error(response,
@@ -702,7 +706,7 @@ class TemplateService(QObject):
                 self.templateRenamed.emit(str(updated_template.id), str(updated_template.name))
         except Exception:
             logger.exception("Could not apply renamed template from response")
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def rename_template_error_handler(self, response: QNetworkReply) -> None:
         alert(self.tr("Error renaming template: {}").format(self._error_text(response)))
@@ -721,7 +725,7 @@ class TemplateService(QObject):
 
     def pause_template_callback(self, response: QNetworkReply) -> None:
         alert_info(self.tr("Template paused successfully"))
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def pause_template_error_handler(self, response: QNetworkReply) -> None:
         alert(self.tr("Error pausing template: {}").format(self._error_text(response)))
@@ -769,7 +773,7 @@ class TemplateService(QObject):
     def resume_template_callback(self, response: QNetworkReply) -> None:
         self._resume_template_state = {}
         alert_info(self.tr("Template resumed successfully"))
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def resume_template_error_handler(self, response: QNetworkReply) -> None:
         """e.g. "maximum number of active templates"."""
@@ -791,7 +795,7 @@ class TemplateService(QObject):
 
     def restart_template_callback(self, response: QNetworkReply) -> None:
         alert_info(self.tr("Template restarted successfully"))
-        self.processing_service.get_processings()
+        self.refreshRequested.emit()
 
     def restart_template_error_handler(self, response: QNetworkReply) -> None:
         alert(self.tr("Error restarting template: {}").format(self._error_text(response)))

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -239,11 +239,6 @@ class Mapflow(QObject):
                                                     app_context=self.app_context,
                                                     timer_interval=self.config.PROCESSING_TABLE_REFRESH_INTERVAL * 1000)
         
-        self.project_processing_controller = ProjectProcessingController(dlg=self.dlg,
-                                                                        processing_service=self.processing_service,
-                                                                        project_service=self.project_service,
-                                                                        app_context=self.app_context)
-        
         # ========== 8. LOAD PROVIDERS FROM SETTINGS ==========
         # load providers from settings before initializing area calculator service
         errors = []
@@ -357,6 +352,15 @@ class Mapflow(QObject):
             pause_action=self.dlg.template_pause_action,
             resume_action=self.dlg.template_resume_action,
             restart_action=self.dlg.template_restart_action)
+
+        # After TemplateService: this controller owns the choice between the project list and the
+        # in-template view, so it subscribes to both services' refresh signals.
+        self.project_processing_controller = ProjectProcessingController(
+            dlg=self.dlg,
+            processing_service=self.processing_service,
+            project_service=self.project_service,
+            template_service=self.template_service,
+            app_context=self.app_context)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -1738,7 +1742,7 @@ class Mapflow(QObject):
         # Clear successfully uploaded review
         self.review_dialog.reviewComment.setText("")
         self.processing_service.processing_fetch_timer.start()
-        self.processing_service.get_processings()
+        self.project_processing_controller.refresh_table()
 
     def show_review_dialog(self):
         processing = self.processing_service.selected_processing()

--- a/tests/qgis/test_planned_processing_mode.py
+++ b/tests/qgis/test_planned_processing_mode.py
@@ -78,6 +78,13 @@ def _create_template_service():
     return service
 
 
+def _refresh_requests(service):
+    """The service asks for the table to be refreshed; the controller decides which view."""
+    asked = []
+    service.refreshRequested.connect(lambda: asked.append(True))
+    return asked
+
+
 def _response(body: bytes):
     response = MagicMock()
     response.readAll.return_value.data.return_value = body
@@ -98,12 +105,13 @@ def test_create_template_callback_warns_when_inactive(monkeypatch):
     alerts = []
     monkeypatch.setattr("mapflow.functional.service.template_service.alert_warning", lambda msg, icon=None: alerts.append(msg))
     plugin = _create_template_service()
+    asked = _refresh_requests(plugin)
 
     plugin.create_search_template_callback(_response(_template_body(is_active=False)))
 
     assert "inactive" in alerts[0].lower()
     assert "maximum number of active planned processings" in alerts[0].lower()
-    plugin.processing_service.get_processings.assert_called_once()
+    assert asked == [True]
 
 
 def test_create_template_callback_no_warning_when_active(monkeypatch):
@@ -111,11 +119,12 @@ def test_create_template_callback_no_warning_when_active(monkeypatch):
     alerts = []
     monkeypatch.setattr("mapflow.functional.service.template_service.alert_warning", lambda msg, icon=None: alerts.append(msg))
     plugin = _create_template_service()
+    asked = _refresh_requests(plugin)
 
     plugin.create_search_template_callback(_response(_template_body(is_active=True)))
 
     assert alerts == []
-    plugin.processing_service.get_processings.assert_called_once()
+    assert asked == [True]
 
 
 def test_create_template_callback_no_warning_when_response_unparseable(monkeypatch):
@@ -123,11 +132,12 @@ def test_create_template_callback_no_warning_when_response_unparseable(monkeypat
     alerts = []
     monkeypatch.setattr("mapflow.functional.service.template_service.alert_warning", lambda msg, icon=None: alerts.append(msg))
     plugin = _create_template_service()
+    asked = _refresh_requests(plugin)
 
     plugin.create_search_template_callback(_response(b'{}'))
 
     assert alerts == []
-    plugin.processing_service.get_processings.assert_called_once()
+    assert asked == [True]
 
 
 def test_provider_change_refreshes_start_button_text():

--- a/tests/qgis/test_processings_table_refresh.py
+++ b/tests/qgis/test_processings_table_refresh.py
@@ -1,0 +1,95 @@
+"""QGIS-tier tests for who decides what the processings table shows.
+
+One table, two views: the project's processings+templates, or an open template's AOIs+processings.
+Deciding between them is navigation, so it belongs to `ProjectProcessingController` rather than to
+either service — otherwise `ProcessingService` has to ask `TemplateService` which view is up while
+`TemplateService` is already asking `ProcessingService` for everything else, and the two end up
+mutually dependent (`spec/007_architecture.md` § Services, § Controllers).
+
+Services therefore *ask* for a refresh and the controller performs it. These tests pin the choice,
+and that one request produces exactly one fetch — the failure mode of routing every caller through
+a signal is that the table quietly refetches twice per action.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
+
+
+class _Asker(QObject):
+    """Stands in for a service that asks for the table to be refreshed."""
+    refreshRequested = pyqtSignal()
+    rerenderRequested = pyqtSignal()
+    templateRehydrateRequested = pyqtSignal()
+
+
+@pytest.fixture
+def controller():
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    # Needed for the connect tests below: a slot on an uninitialised QObject never fires.
+    QObject.__init__(controller)
+    controller.processing_service = MagicMock()
+    controller.processing_service.in_template_mode = False
+    controller.template_service = MagicMock()
+    return controller
+
+
+def test_outside_a_template_the_project_list_is_fetched(controller):
+    controller.refresh_table()
+
+    controller.processing_service.get_processings.assert_called_once()
+    controller.processing_service.refresh_template_view.assert_not_called()
+
+
+def test_inside_a_template_the_template_view_is_refreshed(controller):
+    controller.processing_service.in_template_mode = True
+
+    controller.refresh_table()
+
+    controller.processing_service.refresh_template_view.assert_called_once()
+    controller.processing_service.get_processings.assert_not_called()
+
+
+def test_a_sort_re_renders_the_rows_of_whichever_view_is_up(controller):
+    controller.rerender_rows()
+    assert controller.processing_service.combined_processing_rows.called
+    assert not controller.processing_service.combined_template_rows.called
+
+    controller.processing_service.reset_mock()
+    controller.processing_service.in_template_mode = True
+
+    controller.rerender_rows()
+    assert controller.processing_service.combined_template_rows.called
+    assert not controller.processing_service.combined_processing_rows.called
+
+
+def test_a_rehydrate_request_rebinds_the_template(controller):
+    controller.rehydrate_template()
+
+    controller.processing_service.refresh_active_template.assert_called_once()
+
+
+def test_one_request_produces_exactly_one_fetch(controller):
+    """The point of routing everything through a signal is a single owner, not a second fetch."""
+    asker = _Asker()
+    asker.refreshRequested.connect(controller.refresh_table)
+
+    asker.refreshRequested.emit()
+
+    controller.processing_service.get_processings.assert_called_once()
+
+
+def test_both_services_asking_are_served_by_the_same_owner(controller):
+    """A template action and a processing action must not take different refresh paths."""
+    from_processings = _Asker()
+    from_templates = _Asker()
+    from_processings.refreshRequested.connect(controller.refresh_table)
+    from_templates.refreshRequested.connect(controller.refresh_table)
+
+    from_processings.refreshRequested.emit()
+    from_templates.refreshRequested.emit()
+
+    assert controller.processing_service.get_processings.call_count == 2

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -3,6 +3,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+from PyQt5.QtCore import QObject
+
 from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service import processing_service as processing_service_module
 from mapflow.functional.service import template_service as template_service_module
@@ -420,7 +422,9 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
     service.processing_fetch_timer = MagicMock()
     service.processings = {}
     service.processings_history = MagicMock()
-    service.get_processings = MagicMock()
+    QObject.__init__(service)  # the refresh request is a signal now
+    asked = []
+    service.refreshRequested.connect(lambda: asked.append(True))
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"id": "proc-1", "name": "Run 1"}'
@@ -430,7 +434,7 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
             patch.object(processing_service_module.ProcessingDTO, "from_dict", return_value=mock_processing):
         service.start_processing_callback(response)
 
-    service.get_processings.assert_called_once()
+    assert asked == [True]
     service.view.add_new_processing.assert_called_once()
     service.dlg.startProcessing.setEnabled.assert_called_with(True)
 
@@ -443,7 +447,9 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
     service.processing_fetch_timer = MagicMock()
     service.processings = {}
     service.processings_history = MagicMock()
-    service.get_processings = MagicMock()
+    QObject.__init__(service)  # the refresh request is a signal now
+    asked = []
+    service.refreshRequested.connect(lambda: asked.append(True))
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"template": {"id": "tpl-1"}, "searchResults": []}'
@@ -451,7 +457,7 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
     with patch.object(processing_service_module, "alert"):
         service.start_processing_callback(response)
 
-    service.get_processings.assert_called_once()
+    assert asked == [True]
     service.view.add_new_processing.assert_not_called()
     service.dlg.startProcessing.setEnabled.assert_called_with(True)
 
@@ -486,9 +492,15 @@ def _rename_service(name="Old template"):
         activeUntil=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc),
     )
     processing_service = SimpleNamespace(
-        selected_template=lambda: template, api=MagicMock(),
-        get_processings=MagicMock(), templates={})
+        selected_template=lambda: template, api=MagicMock(), templates={})
     return TemplateService(app_context=MagicMock(), processing_service=processing_service)
+
+
+def _refresh_requests(service):
+    """The table refresh is a request now — the controller picks which view to refresh."""
+    asked = []
+    service.refreshRequested.connect(lambda: asked.append(True))
+    return asked
 
 
 def test_rename_template_uses_update_template_api_with_renamed_name(monkeypatch):
@@ -565,6 +577,7 @@ def _renamed_template_payload(name="New template"):
 def test_rename_callback_shows_the_new_name_before_the_list_refreshes():
     """The renamed row is updated straight away; the controller drives the view from this."""
     service = _rename_service()
+    refreshed = _refresh_requests(service)
     renamed = []
     service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
     response = MagicMock()
@@ -575,12 +588,13 @@ def test_rename_callback_shows_the_new_name_before_the_list_refreshes():
 
     assert renamed == [("tpl-1", "New template")]
     assert service.processing_service.templates["tpl-1"].name == "New template"
-    service.processing_service.get_processings.assert_called_once()
+    assert refreshed == [True]
 
 
 def test_rename_callback_accepts_the_wrapped_template_shape():
     """The endpoint may answer either bare or wrapped in a `template` key."""
     service = _rename_service()
+    refreshed = _refresh_requests(service)
     renamed = []
     service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
     response = MagicMock()
@@ -590,10 +604,12 @@ def test_rename_callback_accepts_the_wrapped_template_shape():
     service.rename_template_callback(response)
 
     assert renamed == [("tpl-1", "Wrapped")]
+    assert refreshed == [True]
 
 
 def test_rename_callback_survives_a_body_that_is_not_json():
     service = _rename_service()
+    refreshed = _refresh_requests(service)
     renamed = []
     service.templateRenamed.connect(lambda tid, name: renamed.append((tid, name)))
     response = MagicMock()
@@ -602,7 +618,7 @@ def test_rename_callback_survives_a_body_that_is_not_json():
     service.rename_template_callback(response)
 
     assert renamed == []
-    service.processing_service.get_processings.assert_called_once()  # still refreshes
+    assert refreshed == [True]  # still refreshes
 
 
 # ---------- pause / resume / restart ----------
@@ -610,8 +626,7 @@ def test_rename_callback_survives_a_body_that_is_not_json():
 def _run_state_service(is_active=True, is_failed=False):
     template = SimpleNamespace(id="tpl-1", name="T", isActive=is_active, is_failed=is_failed)
     processing_service = SimpleNamespace(
-        selected_template=lambda: template, api=MagicMock(),
-        get_processings=MagicMock(), templates={},
+        selected_template=lambda: template, api=MagicMock(), templates={},
         _template_error_text=lambda response: "boom")
     return TemplateService(app_context=MagicMock(), processing_service=processing_service)
 

--- a/tests/qgis/test_template_start_processing_refresh.py
+++ b/tests/qgis/test_template_start_processing_refresh.py
@@ -2,10 +2,17 @@
 (round-2 feedback 8.2). A template-started processing is grouped under its AOI via the
 template's aoiDetails, which the create response does not carry; the callback must
 re-hydrate the template (not do a flat optimistic add) so the new processing is bound to
-its AOI instead of showing under the 'No AOI' separator."""
+its AOI instead of showing under the 'No AOI' separator.
+
+The service no longer refreshes the table itself — it asks, and `ProjectProcessingController`
+decides which of the table's two views to refresh. So "it refreshed" is asserted here as "it
+asked", and the controller's own choice is covered in test_processings_table_refresh.py.
+"""
 import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject
 
 from mapflow.functional.service import processing_service as processing_service_module
 from mapflow.functional.service.processing_service import ProcessingService
@@ -19,6 +26,7 @@ def _response(payload):
 
 def _service(in_template_mode):
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the refresh requests are signals now
     service.tr = lambda text: text
     service.dlg = MagicMock()
     service.api = MagicMock()
@@ -28,33 +36,39 @@ def _service(in_template_mode):
     service.active_template = SimpleNamespace(id="tpl-1") if in_template_mode else None
     service.processings = {}
     service.processings_history = MagicMock()
-    service.get_processings = MagicMock()
     service._fetch_template_processings = MagicMock()
     service._reopen_template_callback = MagicMock()
     return service
 
 
+def _requests(service):
+    """What the service asked the controller for, in order."""
+    asked = []
+    service.refreshRequested.connect(lambda: asked.append("refresh"))
+    service.templateRehydrateRequested.connect(lambda: asked.append("rehydrate"))
+    return asked
+
+
 _PROCESSING = {"id": "p-1", "name": "Run 1", "status": "IN_PROGRESS"}
 
 
-def test_template_start_rehydrates_template_and_skips_flat_add():
+def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     service = _service(in_template_mode=True)
+    asked = _requests(service)
 
     with patch.object(processing_service_module, "alert"):
         service.start_processing_callback(_response(_PROCESSING))
 
-    # Re-hydrate aoiDetails (binds the new processing to its AOI) + refetch processings.
-    service.api.get_template.assert_called_once()
-    assert service.api.get_template.call_args.kwargs["template_id"] == "tpl-1"
-    service._fetch_template_processings.assert_called_once()
-    # No flat optimistic add / regular-list refresh in template mode.
+    # A plain refresh would refetch the rows without rebinding the new processing to its AOI.
+    assert asked == ["rehydrate"]
+    # No flat optimistic add in template mode.
     service.view.add_new_processing.assert_not_called()
-    service.get_processings.assert_not_called()
     service.dlg.startProcessing.setEnabled.assert_called_once_with(True)
 
 
-def test_regular_start_does_flat_add_and_no_template_refresh():
+def test_regular_start_does_flat_add_and_asks_for_a_plain_refresh():
     service = _service(in_template_mode=False)
+    asked = _requests(service)
     fake_dto = SimpleNamespace(id="p-1", name="Run 1", status="IN_PROGRESS")
 
     with patch.object(processing_service_module, "alert"), \
@@ -62,16 +76,26 @@ def test_regular_start_does_flat_add_and_no_template_refresh():
         service.start_processing_callback(_response(_PROCESSING))
 
     service.view.add_new_processing.assert_called_once_with(fake_dto)
-    service.get_processings.assert_called_once()
+    assert asked == ["refresh"]
     service.api.get_template.assert_not_called()
-    service._fetch_template_processings.assert_not_called()
+
+
+def test_rehydrate_re_fetches_the_template_and_its_processings():
+    """What the controller runs when the rehydrate request arrives."""
+    service = _service(in_template_mode=True)
+
+    service.refresh_active_template()
+
+    service.api.get_template.assert_called_once()
+    assert service.api.get_template.call_args.kwargs["template_id"] == "tpl-1"
+    service._fetch_template_processings.assert_called_once()
 
 
 def test_refresh_active_template_noop_without_active_template():
     service = _service(in_template_mode=True)
     service.active_template = None
 
-    service._refresh_active_template()
+    service.refresh_active_template()
 
     service.api.get_template.assert_not_called()
     service._fetch_template_processings.assert_not_called()


### PR DESCRIPTION
Groundwork for moving the template navigation state, and the reason that move can be a move rather than a redesign.

The processings table serves two views: the project's processings and templates, or an open template's AOIs and processings. ProcessingService decided between them itself — get_processings redirected to refresh_template_view, combined_processing_rows returned combined_template_rows, and start_processing_callback branched into a template re-hydrate. So the moment the navigation state moves to TemplateService, ProcessingService has to ask TemplateService which view is up, while TemplateService is already asking ProcessingService for nearly everything. That is a mutual dependency, and if either starts importing the other's type it is also an import cycle, which test_layering forbids.

So the choice moves out first. Services now emit refreshRequested, rerenderRequested or templateRehydrateRequested, and ProjectProcessingController answers them — it owns the processings table and already owns enter/exit_template, so "which view is showing" is its question. This is the same split SearchService already documents for regular-versus-template search: picking between two regions is a controller's job, not either service's.

Fourteen call sites that used to mean "refresh the table" by calling get_processings now say so instead. get_processings keeps only its literal meaning — fetch the project's processings — and its two remaining direct callers are the controller's own branch and setup_processings_table, which is the enter-the-project-view path.

_refresh_active_template became public as refresh_active_template: the controller calls it when a rehydrate is requested, and that call site is where MR-2b-2 will repoint to TemplateService.

Nothing moved state, so behaviour is unchanged. The risk this shape introduces is a double refresh if a caller both emits and the poll fires, so that is pinned rather than assumed: one request produces exactly one fetch, and both services' requests are served by the same owner.

ProjectProcessingController is now constructed after TemplateService, since it subscribes to it. Nothing used the controller during construction, only at runtime.

## Manual test
Nothing should look different — this is the same behaviour reached a different way, so the check is that none of it regressed. In the project list: page through processings, filter by name, change the sort combo and click a sortable column header, and start a processing — the table refreshes each time, and stops polling once everything is final. Enter a template: the table shows its AOIs and processings and keeps polling on the slower cadence; start a processing inside it and the new processing appears grouped under its AOI, not under "No AOI". Pause, resume, restart or rename a template from the project list, and create a planned search — each refreshes the list once. Leave the template and confirm the project list comes back and polls normally. Regression surface to watch: the table refetching twice per action (visible as a flicker or a doubled request), and the poll timer either not stopping when everything is final or not resuming when a template starts searching.