### PR TITLE
refactor: one footprints-layer builder, and one owner for template plaacement

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -67,22 +67,12 @@ default, `TemplateService` at wiring time) covering the three places the start p
 template is open — `template_to_run`, the start callback, and resolving the table selection to
 objects. It is duck-typed and never imported, so no cycle is possible; delete it when that step
 lands.
-[ ] Give template-group layer placement one owner
-Independent of the item above — this is about layers, not the start path, so it can be done at any
-point. Decided: **placement belongs to `TemplateService`.** The creating half already landed —
-`ensure_template_group` is there, since only `mapflow.py` called it. What remains is the shared
-read-only lookup: `AoiService` and `PreviewService` still call `layer_utils.find_template_group`
-themselves. They should instead emit the built layer and let `TemplateService` place it in the tree
-(where a layer sits is a template concern). The find/ensure split already removed the side-effect
-hazard; this removes the question.
-Same item, same reason (user's call when the search render moved): **there are two footprint-layer
-builders** — `TemplateService.store_search_footprints` and
-`SearchService.display_metadata_geojson_layer`. They differ only in where the layer is placed
-(template group vs. beside the AOI layer), how a failed save is reported, and how selection-sync is
-wired. `spec/007_architecture.md` gives "the footprints layer" to `SearchService`, so the merge is
-one shared builder that hands the layer back for placement. Kept out of the search-render MR
-deliberately: unifying them touches the working regular-search path, which is a behaviour risk that
-deserves its own review rather than riding along with an extraction.
+[ready-for-review] Give template-group layer placement one owner
+The two footprint-layer builders become one: `SearchService.build_metadata_layer` builds and
+registers the layer for both searches, and *where it goes* arrives as a `place` callable — beside
+the AOI layer for a regular search, inside the template group for a template's. `PreviewService`
+hands its preview layer to `TemplateService.place_preview_layer` instead of doing the tree surgery
+itself, so nothing but `TemplateService` reaches for a template group now.
 
 [ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
 [ ] Split auth from account status → `SessionService` + `AccountService`

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -35,7 +35,6 @@ class TemplateController(QObject):
                  processings_table,
                  see_processings_action,
                  see_search_results_action,
-                 selection_sync,
                  processing_view,
                  rename_action,
                  pause_action,
@@ -56,10 +55,6 @@ class TemplateController(QObject):
         self.processing_service = processing_service
         self.app_context = app_context
         self.iface = iface
-        #: Wires a rebuilt footprints layer's selection to the results table. Still owned by
-        #: `mapflow.py` (it serves the regular search too), so it arrives as a callable — the
-        #: same indirection `provider_service.selection_sync_callback` already uses.
-        self.selection_sync = selection_sync
 
         update_search_button.clicked.connect(self.update_template_search_params)
         exclude_action.triggered.connect(self.template_service.exclude_processing_from_search)
@@ -96,7 +91,6 @@ class TemplateController(QObject):
             lambda message: self.iface.messageBar().pushWarning(self.app_context.plugin_name, message))
         self.template_service.searchResultsReady.connect(self.show_search_results)
         self.template_service.searchResultsEmpty.connect(self.search_view.clear_table)
-        self.template_service.metadataLayerReady.connect(self.bind_metadata_layer_selection)
         self.template_service.templateRenamed.connect(self.show_renamed_template)
 
     def create_search_template(self, name_override: str = None) -> None:
@@ -281,11 +275,6 @@ class TemplateController(QObject):
         self.search_view.fill_table(geoms, sort=False)
         # New images are flagged with an icon in the leftmost column (not by editing text).
         self.apply_new_image_markers()
-
-    def bind_metadata_layer_selection(self, layer) -> None:
-        """Selecting a footprint on the map selects the matching table row (and triggers preview)."""
-        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
-            self.selection_sync)
 
     def show_renamed_template(self, template_id: str, new_name: str) -> None:
         """Put the new name in the template's row without waiting for the refreshed list."""

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple
 from PyQt5.QtCore import QObject
 from PyQt5.QtNetwork import QNetworkReply
 from osgeo import gdal, ogr
-from qgis.core import (QgsCoordinateReferenceSystem, QgsFeature, QgsGeometry, QgsLayerTreeLayer,
+from qgis.core import (QgsCoordinateReferenceSystem, QgsFeature, QgsGeometry,
                        QgsRasterLayer, QgsRectangle, QgsVectorLayer)
 
 from .. import helpers
@@ -104,35 +104,10 @@ class PreviewService(QObject):
         self.result_loader.add_aoi_to_preview()
 
     def _relocate_to_template_group(self, layer) -> None:
-        """In the in-template view, move a freshly added preview layer into the template's
-        map group, above the search-results footprints and below the AOI subgroups, so the
-        precedence is AOIs (top) > previews > search results (bottom)."""
-        service = self.template_service
-        if not layer or not service.in_template_mode or not service.active_template:
-            return
-        settings = self.app_context.settings
-        mapflow_group_name = settings.value('layerGroup') or self.app_context.plugin_name
-        try:
-            template_group = layer_utils.find_template_group(
-                self.app_context.project, mapflow_group_name, str(service.active_template.name))
-            root = self.app_context.project.layerTreeRoot()
-            node = root.findLayer(layer.id())
-            if node is None or template_group is None:
-                return
-            footprints_layer = getattr(self.app_context, 'metadata_layer', None)
-            footprints_id = footprints_layer.id() if footprints_layer else None
-            children = template_group.children()
-            # Default to the bottom; otherwise insert directly above the footprints layer
-            # (which itself sits below the AOI/processing subgroups).
-            insert_index = len(children)
-            for i, child in enumerate(children):
-                if isinstance(child, QgsLayerTreeLayer) and child.layerId() == footprints_id:
-                    insert_index = i
-                    break
-            template_group.insertChildNode(insert_index, node.clone())
-            (node.parent() or root).removeChildNode(node)
-        except (AttributeError, RuntimeError):
-            return
+        """Inside a template, a preview belongs in that template's map group. Where among its
+        layers is `TemplateService`'s call, so the built layer is handed over rather than placed
+        from here (`spec/007_architecture.md`: where a layer sits is a template concern)."""
+        self.template_service.place_preview_layer(layer)
 
     def _move_layer_to_top(self, layer_id: str) -> bool:
         """Move an existing layer's tree node to the top of its parent group."""

--- a/mapflow/functional/service/search_service.py
+++ b/mapflow/functional/service/search_service.py
@@ -181,7 +181,9 @@ class SearchService(QObject):
             logger.exception("Unexpected error saving the search layer")
             alert(save_failed_message)
             return
-        self.display_metadata_geojson_layer(filename, f"{provider.name} metadata", aoi_layer)
+        self.build_metadata_layer(
+            filename, f"{provider.name} metadata",
+            place=lambda layer: self.place_beside_aoi_layer(layer, aoi_layer))
         # Retain the raw results so the instant local filter can reorder/re-render them without
         # a new request.
         self.app_context.search_result_geojson = geoms
@@ -190,27 +192,46 @@ class SearchService(QObject):
 
     # ---------- the footprints layer ----------
 
-    def display_metadata_geojson_layer(self, filename, layer_name, aoi_layer=None):
+    def build_metadata_layer(self, filename, layer_name, place=None):
+        """Build the search-results footprints layer from a saved file, and register it.
+
+        One builder for both searches. Where the layer *goes* is the only thing that differs — a
+        regular search puts it beside the AOI layer, a template's inside that template's group —
+        so placement arrives as ``place(layer)`` from the caller. `spec/007_architecture.md` gives
+        the footprints layer to this service; it does not give it an opinion about the template
+        layer tree.
+
+        Returns the layer, or None when the file will not open as one.
+        """
         self.remove_metadata_layer()
-        # Assigned (before add_layer) so the AOI-area monitor recognizes and skips it.
-        self.app_context.metadata_layer = QgsVectorLayer(filename, layer_name, 'ogr')
-        self.app_context.metadata_layer.loadNamedStyle(
-            os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
-        # Place search results just under the AOI layer, if that layer has a legend node.
-        # (A layer added with addToLegend=False has no tree node -> findLayer returns None;
-        # fall back to a plain add instead of dereferencing a missing parent.)
+        layer = QgsVectorLayer(filename, layer_name, 'ogr')
+        if not layer.isValid():
+            self.app_context.metadata_layer = None
+            return None
+        layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
+        # Assigned before the layer is added to the project, so the AOI-area monitor (which reacts
+        # to layersAdded) recognises and skips it.
+        self.app_context.metadata_layer = layer
+        (place or self.place_beside_aoi_layer)(layer)
+        self.app_context.search_footprints = {
+            feature['local_index']: feature for feature in layer.getFeatures()
+        }
+        self.metadataLayerReady.emit(layer)
+        return layer
+
+    def place_beside_aoi_layer(self, layer, aoi_layer=None) -> None:
+        """Put the footprints just under the AOI layer, if that layer has a legend node.
+
+        (A layer added with addToLegend=False has no tree node -> findLayer returns None; fall
+        back to a plain add instead of dereferencing a missing parent.)
+        """
         aoi_layer_tree = (self.app_context.project.layerTreeRoot().findLayer(aoi_layer.id())
                           if aoi_layer else None)
         if aoi_layer_tree is not None and aoi_layer_tree.parent() is not None:
             index = aoi_layer_tree.parent().children().index(aoi_layer_tree)
-            self.result_loader.add_layer(layer=self.app_context.metadata_layer, order=index + 1)
+            self.result_loader.add_layer(layer=layer, order=index + 1)
         else:
-            self.result_loader.add_layer(layer=self.app_context.metadata_layer)
-        self.app_context.search_footprints = {
-            feature['local_index']: feature
-            for feature in self.app_context.metadata_layer.getFeatures()
-        }
-        self.metadataLayerReady.emit(self.app_context.metadata_layer)
+            self.result_loader.add_layer(layer=layer)
 
     def remove_metadata_layer(self) -> None:
         try:

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -29,6 +29,7 @@ from PyQt5.QtNetwork import QNetworkReply
 from qgis.core import (QgsFeature,
                        QgsGeometry,
                        QgsLayerTreeGroup,
+                       QgsLayerTreeLayer,
                        QgsVectorLayer)
 
 from .. import layer_utils
@@ -73,9 +74,6 @@ class TemplateService(QObject):
     searchResultsReady = pyqtSignal(object)
     #: The template's search returned no images; the controller empties the table.
     searchResultsEmpty = pyqtSignal()
-    #: The search-results footprints layer was (re)built; the controller wires its selection to
-    #: the table.
-    metadataLayerReady = pyqtSignal(object)
     #: A template was renamed: (template id, new name). The controller updates its row's name
     #: cell straight away, so the rename shows before the refreshed list arrives.
     templateRenamed = pyqtSignal(str, str)
@@ -1327,30 +1325,51 @@ class TemplateService(QObject):
         filename = provider.save_search_layer(self.app_context.temp_dir, geoms)
         if not filename:
             return
-        # Drop the previous footprint layer so repeated searches don't stack duplicates.
-        if getattr(self.app_context, 'metadata_layer', None) is not None:
-            try:
-                self.app_context.project.removeMapLayer(self.app_context.metadata_layer)
-            except (AttributeError, RuntimeError):
-                pass
-        layer = QgsVectorLayer(filename, f"{provider.name} metadata", "ogr")
-        if not layer.isValid():
-            self.app_context.metadata_layer = None
+        # `SearchService` owns the footprints layer itself (spec/007 § Services); what is a
+        # template concern is only where the layer ends up in the tree, which is what `place` says.
+        # Wiring the layer's selection to the table is `SearchService.metadataLayerReady`'s job for
+        # both searches now; emitting a second signal here connected it twice, so one footprint
+        # click previewed twice.
+        self.search_service.build_metadata_layer(
+            filename, f"{provider.name} metadata",
+            place=lambda built: self.place_in_template_group(built, template_group_name))
+
+    def place_preview_layer(self, layer) -> None:
+        """Move a freshly added preview layer into the open template's group, above the
+        search-results footprints and below the AOI subgroups, so the precedence is
+        AOIs (top) > previews > search results (bottom). No-op outside a template."""
+        if not layer or not self.in_template_mode or not self.active_template:
             return
-        layer.loadNamedStyle(os.path.join(self.plugin_dir, 'static', 'styles', 'metadata.qml'))
-        # Register as the current search-metadata layer BEFORE adding it to the project, so
-        # the AOI-area monitor (which reacts to layersAdded) recognizes and skips it.
-        self.app_context.metadata_layer = layer
-        if template_group_name:
-            target_group = self.ensure_template_group(template_group_name)
-            self.app_context.project.addMapLayer(layer, addToLegend=False)
-            # Append (bottom) so the search-results footprints sit below the AOI/processing
-            # subgroups rather than on top of them.
-            target_group.addLayer(layer)
-        else:
+        try:
+            template_group = self.find_template_group(str(self.active_template.name))
+            root = self.app_context.project.layerTreeRoot()
+            node = root.findLayer(layer.id())
+            if node is None or template_group is None:
+                return
+            footprints_layer = getattr(self.app_context, 'metadata_layer', None)
+            footprints_id = footprints_layer.id() if footprints_layer else None
+            children = template_group.children()
+            # Default to the bottom; otherwise insert directly above the footprints layer
+            # (which itself sits below the AOI/processing subgroups).
+            insert_index = len(children)
+            for i, child in enumerate(children):
+                if isinstance(child, QgsLayerTreeLayer) and child.layerId() == footprints_id:
+                    insert_index = i
+                    break
+            template_group.insertChildNode(insert_index, node.clone())
+            (node.parent() or root).removeChildNode(node)
+        except (AttributeError, RuntimeError):
+            return
+
+    def place_in_template_group(self, layer, template_group_name: Optional[str] = None) -> None:
+        """Put a built layer inside the open template's group. Where a layer sits among a
+        template's layers is a template concern, so the services that build one hand it here
+        rather than reaching for the group themselves."""
+        if not template_group_name:
             self.result_loader.add_layer(layer=layer)
-        # Selecting a footprint on the map selects the matching table row (and triggers preview).
-        self.metadataLayerReady.emit(layer)
-        self.app_context.search_footprints = {
-            feature["local_index"]: feature for feature in layer.getFeatures()
-        }
+            return
+        target_group = self.ensure_template_group(template_group_name)
+        self.app_context.project.addMapLayer(layer, addToLegend=False)
+        # Append (bottom) so the search-results footprints sit below the AOI/processing
+        # subgroups rather than on top of them.
+        target_group.addLayer(layer)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -353,7 +353,6 @@ class Mapflow(QObject):
             processings_table=self.dlg.processingsTable,
             see_processings_action=self.dlg.see_processings_action,
             see_search_results_action=self.dlg.see_search_results_action,
-            selection_sync=self.sync_layer_selection_with_table,
             processing_view=self.processing_service.view,
             rename_action=self.dlg.template_rename_action,
             pause_action=self.dlg.template_pause_action,
@@ -1211,7 +1210,7 @@ class Mapflow(QObject):
         # We store the results in a temp folder, separate file for each provider
         geoms = self.app_context.search_provider.load_search_layer(self.app_context.temp_dir)
         if geoms:
-            self.search_service.display_metadata_geojson_layer(
+            self.search_service.build_metadata_layer(
                 os.path.join(self.app_context.temp_dir, self.app_context.search_provider.metadata_layer_name),
                 f"{self.app_context.search_provider.name} metadata")
             # Keep the restored results available to the instant local filter (fill below emits

--- a/tests/qgis/test_preview_dedup.py
+++ b/tests/qgis/test_preview_dedup.py
@@ -29,8 +29,7 @@ def service():
                              config=MagicMock(),
                              result_loader=MagicMock(),
                              processing_service=MagicMock(),
-        template_service=SimpleNamespace(in_template_mode=False,
-                                                                active_template=None))
+        template_service=MagicMock(in_template_mode=False, active_template=None))
     service.metadata_feature = MagicMock(return_value=MagicMock())  # feature exists
     service.preview_png = MagicMock()
     return service

--- a/tests/qgis/test_template_preview_layers.py
+++ b/tests/qgis/test_template_preview_layers.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 from qgis.core import QgsProject, QgsVectorLayer
 
 from mapflow.functional.service.preview_service import PreviewService
+from mapflow.functional.service.template_service import TemplateService
 
 
 def _mem_layer(name):
@@ -48,6 +49,15 @@ def test_move_layer_to_top_brings_node_first():
     assert root.children()[0].layerId() == second.id()
 
 
+def _template_service(app_context, in_template_mode=True, template_name="T1"):
+    """Placing a layer among a template's layers is TemplateService's call since the
+    layer-placement step; PreviewService just hands the built layer over."""
+    service = TemplateService(app_context=app_context, processing_service=MagicMock())
+    service.in_template_mode = in_template_mode
+    service.active_template = SimpleNamespace(name=template_name) if in_template_mode else None
+    return service
+
+
 def test_relocate_preview_places_it_above_footprints_inside_template_group():
     project = QgsProject()
     root = project.layerTreeRoot()
@@ -61,13 +71,11 @@ def test_relocate_preview_places_it_above_footprints_inside_template_group():
 
     settings = MagicMock()
     settings.value.return_value = "Mapflow"
-    service = _service(
+    service = _template_service(
         SimpleNamespace(project=project, settings=settings, plugin_name="Mapflow",
-                        metadata_layer=footprints),
-        template_service=SimpleNamespace(in_template_mode=True,
-                                         active_template=SimpleNamespace(name="T1")))
+                        metadata_layer=footprints))
 
-    service._relocate_to_template_group(preview)
+    service.place_preview_layer(preview)
 
     names = [c.name() for c in template_group.children()]
     # Order within the template group: AOI subgroup, preview, footprints.
@@ -81,8 +89,19 @@ def test_relocate_preview_noop_outside_template_mode():
     root = project.layerTreeRoot()
     preview = _add(project, root, _mem_layer("img-1 preview"))
 
-    service = _service(SimpleNamespace(project=project))
+    service = _template_service(SimpleNamespace(project=project), in_template_mode=False)
 
-    service._relocate_to_template_group(preview)
+    service.place_preview_layer(preview)
 
     assert root.children()[-1].layerId() == preview.id()
+
+
+def test_preview_service_hands_the_layer_to_the_template_service():
+    """The placement decision is not PreviewService's; it only passes the layer along."""
+    service = _service(SimpleNamespace(project=QgsProject()),
+                       template_service=MagicMock())
+    layer = object()
+
+    service._relocate_to_template_group(layer)
+
+    service.template_service.place_preview_layer.assert_called_once_with(layer)


### PR DESCRIPTION
Two near-identical builders existed: SearchService.display_metadata_geojson_layer for a regular search, TemplateService.store_search_footprints for a template's. They differed in exactly one thing that mattered — where the layer ends up in the tree — and in two that were accidents: only the template one checked that the file opened as a valid layer, and the two computed the footprint index and emitted their ready signal in opposite orders.

So the building collapses into SearchService.build_metadata_layer, which spec/007 already makes the owner of the footprints layer, and placement arrives as a `place` callable from the caller. The validity check survives into both paths, which is the one behavioural gain here: a regular search whose saved file will not open now leaves metadata_layer as None instead of registering a broken layer and reading features off it.

Removing the duplication exposed a latent bug. TemplateService emitted its own metadataLayerReady, and mapflow.py already connects SearchService's to the same handler — so once the template path went through the shared builder, both signals fired and the footprints layer's selectionChanged was wired twice. One click on a footprint would have synced and previewed twice, which is the same failure feedback 4.2 was about. TemplateService's signal is gone; SearchService's serves both paths, and TemplateController no longer needs the selection_sync callable it was handed for it.

PreviewService kept its own copy of the "insert above the footprints, below the AOI subgroups" tree surgery, reaching for the template group through layer_utils. That moves to TemplateService.place_preview_layer, so a preview is handed over rather than placed from outside. Nothing but TemplateService looks up a template group now.

One correction to the plan this came from: it said AoiService also reached for the group. It does not — it takes the group as an argument, resolved by TemplateController, which is already the shape the plan wanted. Only PreviewService was still doing it.

## Manual test
Run a regular imagery search: the footprints layer appears just under the AOI layer, and clicking a footprint on the map still selects its row in the results table and previews it exactly once — not twice. Switch the imagery provider back and forth to a provider you have already searched with: the saved results reload and their footprints layer comes back. Then open a template's search results: its footprints land at the bottom of the template's group, below the AOI subgroups, and clicking one behaves the same. Preview an image from inside a template: the preview sits above the footprints and below the AOI subgroups. Regression surface: a footprint click firing its preview twice (the bug this removes), and the footprints layer being placed at the root instead of in the template's group.