### PR TITLE
refactor: move review and rating out of mapflow.py

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -67,7 +67,34 @@ default, `TemplateService` at wiring time) covering the three places the start p
 template is open — `template_to_run`, the start callback, and resolving the table selection to
 objects. It is duck-typed and never imported, so no cycle is possible; delete it when that step
 lands.
-[ ] Extract processing lifecycle: options, start, review, rating → existing processing service/controller
+
+Extract processing lifecycle: options, start, review, rating → existing processing service/controller.
+Split in three; ~35 methods in `mapflow.py`, which is 3× what lands cleanly in one MR.
+
+[ready-for-review] 2a: review and rating → `ProcessingService` / `ProcessingController`
+The whole review/rating panel leaves `mapflow.py`: the decisions and requests to the service, the
+widget reads to `ProcessingView`, the wiring and the `ReviewDialog` lifecycle to the controller.
+`ProcessingApi` gains `rate_processing`, `accept_processing` and `reject_processing` — these were
+the only processing endpoints called with a hand-built URL straight off `Http`, which is what had
+kept the code in `mapflow.py`.
+
+[ ] 2b: model options and processing-params assembly → `ProcessingController`
+`on_options_change`, `on_model_change`, `show_wd_options`, `save_options_settings`,
+`check_processing_ui`, `get_processing_params`, `show_processing_source`,
+`get_local_image_indices`, `get_search_providers`. The start panel's inputs; independent of 2a.
+
+[ ] 2c: start-button state, the context menu, and the `templates`-keyed queries
+`update_processing_options_menu` (the last large `self.dlg` block), `show_selected_details`,
+`on_processings_selection_changed`, `update_delete_button_state`,
+`update_start_processing_button_text/state`, `select_processing_in_table`, plus the
+`selected_template(s)` / `is_only_templates_selected` / `all_selected_templates_editable` /
+`template_to_run` cluster and the start fork in `handle_processing_submission`.
+**This is the step that deletes `ProcessingService.template_state`** (see the templates item above).
+Last of the three, and the highest blast radius.
+
+Not part of this item: `load_results`, `download_results_file`, `download_aoi_file` and
+`show_details` are `ResultService`'s, which Phase D names separately.
+
 [ ] Split auth from account status → `SessionService` + `AccountService`
 [ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction
 Acceptance for the phase: no `self.dlg.<widget>` access in `mapflow.py`, and the layering test's

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -1,3 +1,4 @@
+import json
 from typing import Callable, List, Optional, Union
 from uuid import UUID
 
@@ -98,6 +99,36 @@ class ProcessingApi(QObject):
                       error_handler_kwargs=error_handler_kwargs or {},
                       use_default_error_handler=False,
                       timeout=30)
+
+    # ---- review and rating ----
+    #
+    # These three were the only processing endpoints called with a hand-built URL straight off
+    # `Http`, which is why the code around them could not leave `mapflow.py`.
+
+    def rate_processing(self,
+                        processing_id: Union[UUID, str],
+                        rating: int,
+                        feedback: str,
+                        callback: Callable,
+                        callback_kwargs: Optional[dict] = None) -> None:
+        self.http.put(path=f"processings/{processing_id}/rate",
+                      body=json.dumps({"rating": rating, "feedback": feedback}).encode(),
+                      callback=callback,
+                      callback_kwargs=callback_kwargs or {})
+
+    def accept_processing(self, processing_id: Union[UUID, str], callback: Callable) -> None:
+        """Approve a processing awaiting review."""
+        self.http.put(path=f"processings/{processing_id}/acceptation", callback=callback)
+
+    def reject_processing(self,
+                          processing_id: Union[UUID, str],
+                          comment: str,
+                          features,
+                          callback: Callable) -> None:
+        """Send a review back with a comment and the reviewer's corrections."""
+        self.http.put(path=f"processings/{processing_id}/rejection",
+                      body=json.dumps({"comment": comment, "features": features}).encode(),
+                      callback=callback)
 
     def get_processings(self, project_id: Union[UUID, str], request_body: ProcessingsRequest, callback: Callable):
         self.http.post(path=f"projects/{project_id}/processings/v2/page",

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -1,19 +1,21 @@
 from PyQt5.QtCore import QObject
 from qgis.core import QgsMapLayer
 
+from .. import layer_utils
 from ..service.aoi_service import AoiService
 from ..view.aoi_view import AoiView
 
 
 class ProcessingController(QObject):
-    """The start-processing panel: which AOI a processing will cover.
+    """The start-processing panel: which AOI a processing will cover, and the review/rating
+    panel beside it.
 
     Owns the wiring only. It is the one place allowed to see both `AoiService` and `AoiView`,
     which is why the round trips below exist — the service cannot read a checkbox and the view
     cannot call a service (`spec/007_architecture.md` § Layer rules).
 
-    Scope today is AOI selection. Model and options, provider selection, cost and the
-    start-button state join it as the later Phase C steps extract them.
+    Model and options, provider selection, cost and the start-button state join it as the later
+    Phase C steps extract them.
     """
 
     def __init__(self,
@@ -21,7 +23,16 @@ class ProcessingController(QObject):
                  aoi_service: AoiService,
                  aoi_view: AoiView,
                  add_layer_action,
-                 remove_layer_action):
+                 remove_layer_action,
+                 processing_service=None,
+                 processing_view=None,
+                 app_context=None,
+                 review_dialog=None,
+                 rating_submit_button=None,
+                 rating_combo=None,
+                 accept_button=None,
+                 review_button=None,
+                 processings_table=None):
         super().__init__()
         self.iface = iface
         self.aoi_service = aoi_service
@@ -29,10 +40,104 @@ class ProcessingController(QObject):
         # Owned by mapflow.py, which registers them with QGIS's layer context menu.
         self.add_layer_action = add_layer_action
         self.remove_layer_action = remove_layer_action
+        self.processing_service = processing_service
+        self.processing_view = processing_view
+        self.app_context = app_context
+        self.review_dialog = review_dialog
 
         self.aoi_service.aoiLayerRegistered.connect(self._on_aoi_layer_registered)
         self.aoi_service.aoiLayersChanged.connect(self.refresh_excepted_layers)
         self.aoi_service.currentAoiLayerChanged.connect(self.aoi_view.set_current_layer)
+
+        if processing_service is not None:
+            processing_service.ratingLoaded.connect(self.processing_view.set_rating_labels)
+            processing_service.reviewSubmitted.connect(self._on_review_submitted)
+        if rating_submit_button is not None:
+            rating_submit_button.clicked.connect(self.submit_rating)
+        if rating_combo is not None:
+            rating_combo.activated.connect(self.refresh_feedback_controls)
+        if accept_button is not None:
+            accept_button.clicked.connect(self.accept_processing)
+        if review_button is not None:
+            review_button.clicked.connect(self.show_review_dialog)
+        if review_dialog is not None:
+            review_dialog.accepted.connect(self.submit_review)
+        if processings_table is not None:
+            processings_table.itemSelectionChanged.connect(self.refresh_feedback_controls)
+            processings_table.cellClicked.connect(self.load_current_rating)
+
+    # ---------- review and rating ----------
+
+    def load_current_rating(self, *args) -> None:
+        self.processing_service.load_current_rating()
+
+    def submit_rating(self, *args) -> None:
+        """Which star and what feedback are widget reads, so they are gathered here and handed
+        over rather than looked up by the service."""
+        self.processing_service.submit_rating(self.processing_view.selected_rating(),
+                                              self.processing_view.rating_feedback())
+
+    def accept_processing(self, *args) -> None:
+        self.processing_service.accept_processing()
+
+    def show_review_dialog(self, *args) -> None:
+        """Open the review dialog, but only for a processing a review decision applies to. The
+        service answers that (and says why when it does not), so the check is not repeated here."""
+        processing = self.processing_service._reviewable_processing()
+        if processing is None:
+            return
+        self.review_dialog.setup(processing)
+        self.review_dialog.show()
+
+    def submit_review(self, *args) -> None:
+        """The comment and the reviewer's corrections live in the dialog, which a service may not
+        touch — so they are read here and passed as plain values."""
+        self.processing_service.reject_processing(
+            processing_id=self.review_dialog.processing.id,
+            comment=self.review_dialog.reviewComment.toPlainText(),
+            features=layer_utils.export_as_geojson(self.review_dialog.reviewLayerCombo.currentLayer()))
+
+    def _on_review_submitted(self) -> None:
+        self.review_dialog.reviewComment.setText("")
+
+    def refresh_feedback_controls(self, *args) -> None:
+        """Enable the rating or the review controls for the current selection — whichever this
+        account uses. 'Feedback' covers both: a 1-5 star rating for regular users, a review for
+        accounts with the review workflow enabled."""
+        processing = self.processing_service.selected_processing()
+        if processing is None:
+            self._set_feedback_enabled(status_ok=False, in_review=False)
+            return
+        self._set_feedback_enabled(status_ok=processing.status.is_ok,
+                                   in_review=processing.reviewStatus.is_in_review)
+        self.processing_view.enable_restart_action(
+            self.app_context.user_role.can_start_processing
+            and (processing.status.is_failed or processing.status.is_cancelled))
+
+    def _set_feedback_enabled(self, status_ok: bool, in_review: bool) -> None:
+        if self.app_context.review_workflow_enabled:
+            self.processing_view.enable_review(
+                status_ok and in_review,
+                self.tr("Only correctly finished processings with 'Review required' status "
+                        "can be reviewed"))
+            return
+        self.processing_view.enable_rating(
+            can_interact=status_ok and self.app_context.user_role.can_delete_rename_review_processing,
+            can_send=self.processing_view.rating_is_selected(),
+            reason=self._rating_blocked_reason(status_ok))
+
+    def _rating_blocked_reason(self, status_ok: bool) -> str:
+        role = self.app_context.user_role
+        if not role.can_delete_rename_review_processing:
+            return self.tr('Not enough rights to rate processing in a shared project ({})').format(
+                role.value)
+        if not status_ok:
+            if not self.processing_service.selected_processing():
+                return self.tr('Please select processing')
+            return self.tr("Only correctly finished processings (status OK) can be rated")
+        if not self.processing_view.rating_is_selected():
+            return self.tr("Please select rating to submit")
+        return ""
 
     # ---------- registry ----------
 

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -40,7 +40,7 @@ from ...schema.template import (
     ProcessingTemplateDTO,
     ProcessingTemplateDetails,
 )
-from ..service.alert_service import alert
+from ..service.alert_service import alert, alert_info
 from ..app_context import AppContext
 from ...model.provider import ImagerySearchProvider
 from ...config import Config
@@ -73,6 +73,12 @@ class ProcessingService(QObject):
     templateRehydrateRequested = pyqtSignal()
     #: "Re-render the rows already held", for a sort that needs no request.
     rerenderRequested = pyqtSignal()
+    #: A processing's stored rating arrived: (processing name, rating or 0, feedback). The
+    #: controller puts it in the rating panel; 0 means "rated but the server sent no score".
+    ratingLoaded = pyqtSignal(str, int, str)
+    #: A review was accepted or rejected, so the comment box should be cleared and the list
+    #: refreshed. The refresh itself goes through `refreshRequested` like every other.
+    reviewSubmitted = pyqtSignal()
 
     # Whether the last processings poll saw only final-state processings; combined with
     # template statuses to decide if the project poll can stop (see _apply_poll_timer_state).
@@ -809,6 +815,99 @@ class ProcessingService(QObject):
         self.save_processing(processing)
         self.view.update_processing_name(processing_id=processing.id, new_name=processing.name)
         self.processings[processing.id] = processing
+
+    # ============ REVIEW AND RATING ============ #
+    #
+    # `spec/007_architecture.md` gives both to this service. The widget reads (which star was
+    # picked, what the feedback box says) arrive as arguments and what the panel must show leaves
+    # as a signal, so nothing here touches a widget.
+
+    def load_current_rating(self) -> None:
+        """Fetch the selected processing's stored rating so the panel shows what was submitted
+        before. No-op without a selection."""
+        processing = self.selected_processing()
+        if not processing:
+            return
+        self.ratingLoaded.emit(str(processing.name or ""), 0, "")
+        self.api.get_processing(processing_id=processing.id,
+                                callback=self.load_current_rating_callback)
+
+    def load_current_rating_callback(self, response: QNetworkReply) -> None:
+        try:
+            response_data = json.loads(response.readAll().data())
+        except ValueError:
+            # Not JSON, or not decodable as UTF-8 (UnicodeDecodeError is a ValueError).
+            return
+        rating_json = response_data.get('rating')
+        if not rating_json:
+            return
+        self.ratingLoaded.emit(str(response_data.get('name') or ""),
+                               int(rating_json.get('rating') or 0),
+                               str(rating_json.get('feedback') or ""))
+
+    def _rateable_processing(self):
+        """The selected processing, if it can be rated at all. Alerts and returns None otherwise —
+        the reason is the same for rating and for review, so it is written once."""
+        processing = self.selected_processing()
+        if not processing:
+            return None
+        if not processing.status.is_ok:
+            alert(self.tr('Only finished processings can be rated'))
+            return None
+        return processing
+
+    def _reviewable_processing(self):
+        """The selected processing, if a review decision applies to it."""
+        processing = self._rateable_processing()
+        if processing is None:
+            return None
+        if not processing.reviewStatus.is_in_review:
+            alert(self.tr("Processing must be in `Review required` status"))
+            return None
+        return processing
+
+    def submit_rating(self, rating: int, feedback: str) -> None:
+        """Rate the selected processing. ``rating`` is already resolved from the combo by the
+        view; out-of-range means nothing was picked, so nothing is sent."""
+        processing = self._rateable_processing()
+        if processing is None:
+            return
+        if not 0 < rating <= 5:
+            return
+        self.api.rate_processing(processing_id=processing.id,
+                                 rating=rating,
+                                 feedback=feedback,
+                                 callback=self.submit_rating_callback,
+                                 callback_kwargs={'feedback': feedback})
+
+    def submit_rating_callback(self, response: QNetworkReply, feedback: str) -> None:
+        if feedback:
+            alert_info(self.tr("Thank you! Your rating and feedback are submitted!"))
+        else:
+            alert_info(self.tr("Thank you! Your rating is submitted!\n"
+                               "We would appreciate if you add feedback as well."))
+        self.load_current_rating()
+
+    def accept_processing(self) -> None:
+        """Approve the selected processing's review."""
+        processing = self._reviewable_processing()
+        if processing is None:
+            return
+        self.api.accept_processing(processing_id=processing.id,
+                                   callback=self.review_processing_callback)
+
+    def reject_processing(self, processing_id, comment: str, features) -> None:
+        """Send a review back. The comment and the reviewer's corrections are read off the review
+        dialog by the controller, since a dialog is not this service's to touch."""
+        self.api.reject_processing(processing_id=processing_id,
+                                   comment=comment,
+                                   features=features,
+                                   callback=self.review_processing_callback)
+
+    def review_processing_callback(self, response: QNetworkReply) -> None:
+        self.reviewSubmitted.emit()
+        self.processing_fetch_timer.start()
+        self.refreshRequested.emit()
 
     # Processing cost
     def update_processing_cost(self):

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -305,6 +305,34 @@ class ProcessingView:
         for row in rows:
             self.dlg.processingsTable.removeRow(row)
 
+    # ---------- the review / rating panel ----------
+
+    def set_rating_labels(self, processing_name: str, rating: int = 0, feedback: str = "") -> None:
+        """Show a processing's stored rating. ``rating`` 0 means none was submitted."""
+        self.dlg.set_processing_rating_labels(processing_name=processing_name,
+                                              current_rating=rating or None,
+                                              current_feedback=feedback or None)
+
+    def selected_rating(self) -> int:
+        """The star count the combo is on. The list is descending (None-5-4-3-2-1), so the index
+        is inverted; anything outside 1..5 means nothing was picked."""
+        return 6 - self.dlg.ratingComboBox.currentIndex()
+
+    def rating_is_selected(self) -> bool:
+        return 5 >= self.dlg.ratingComboBox.currentIndex() > 0
+
+    def rating_feedback(self) -> str:
+        return self.dlg.processingRatingFeedbackText.toPlainText()
+
+    def enable_rating(self, can_interact: bool, can_send: bool, reason: str) -> None:
+        self.dlg.enable_rating(can_interact=can_interact, can_send=can_send, reason=reason)
+
+    def enable_review(self, enabled: bool, reason: str = "") -> None:
+        self.dlg.enable_review(enabled, reason)
+
+    def enable_restart_action(self, enabled: bool) -> None:
+        self.dlg.enable_restart_action(enabled)
+
     def set_processing_cost(self, cost: int):
         self.dlg.processingProblemsLabel.setPalette(self.dlg.default_palette)
         self.dlg.processingProblemsLabel.setText(self.tr("Processing cost: {cost} credits").format(cost=cost))

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -321,7 +321,16 @@ class Mapflow(QObject):
             aoi_service=self.aoi_service,
             aoi_view=self.aoi_view,
             add_layer_action=self.add_layer_action,
-            remove_layer_action=self.remove_layer_action)
+            remove_layer_action=self.remove_layer_action,
+            processing_service=self.processing_service,
+            processing_view=self.processing_service.view,
+            app_context=self.app_context,
+            review_dialog=self.review_dialog,
+            rating_submit_button=self.dlg.ratingSubmitButton,
+            rating_combo=self.dlg.ratingComboBox,
+            accept_button=self.dlg.acceptButton,
+            review_button=self.dlg.reviewButton,
+            processings_table=self.dlg.processingsTable)
 
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
@@ -426,19 +435,10 @@ class Mapflow(QObject):
         self.processing_service.connect_processings_pagination()
         # Entering and leaving a template is TemplateController's entirely — it owns the layers,
         # the search results and the view state they drive.
-        # Processings ratings
-        self.dlg.processingsTable.itemSelectionChanged.connect(self.enable_feedback)
         self.dlg.processingsTable.itemSelectionChanged.connect(self.on_processings_selection_changed)
-        self.dlg.ratingSubmitButton.clicked.connect(self.submit_processing_rating)
+        # Review and rating are ProcessingController's — it owns those handlers now.
         self.dlg.enable_rating(False, False)  # by default disabled
         self.dlg.enable_review(False)
-        # Processing feedback
-        self.dlg.ratingComboBox.activated.connect(self.enable_feedback)
-        self.dlg.processingsTable.cellClicked.connect(self.update_processing_current_rating)
-        # Processing review
-        self.dlg.acceptButton.clicked.connect(self.accept_processing)
-        self.dlg.reviewButton.clicked.connect(self.show_review_dialog)
-        self.review_dialog.accepted.connect(self.submit_review)
 
         # ========== 13. PROVIDERS ==========
         # searchImageryButton and the metadata table's double/cell-click previews are wired by
@@ -1677,162 +1677,6 @@ class Mapflow(QObject):
     def on_metadata_table_cell_clicked(self, row: int, column: int):
         """Keep click behavior passive; marking seen is handled by Seen actions only."""
         return
-
-    def update_processing_current_rating(self) -> None:
-        # reset labels:
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        pid = processing.id
-        p_name = processing.name
-
-        self.dlg.set_processing_rating_labels(processing_name=p_name)
-        self.http.get(
-            url=f'{self.server}/processings/{pid}/v2',
-            callback=self.update_processing_current_rating_callback
-        )
-
-    def update_processing_current_rating_callback(self, response: QNetworkReply) -> None:
-        response_data = json.loads(response.readAll().data())
-        p_name = response_data.get('name')
-        rating_json = response_data.get('rating')
-        if not rating_json:
-            return
-        rating = int(rating_json.get('rating'))
-        feedback = rating_json.get('feedback')
-        self.dlg.set_processing_rating_labels(processing_name=p_name,
-                                              current_rating=rating,
-                                              current_feedback=feedback)
-
-    def submit_processing_rating(self) -> None:
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        pid = processing.id
-        if not processing.status.is_ok:
-            self.alert(self.tr('Only finished processings can be rated'))
-            return
-        # Rating is descending: None-5-4-3-2-1
-        rating = 6 - self.dlg.ratingComboBox.currentIndex()
-        if not 0 < rating <= 5:
-            return
-        feedback_text = self.dlg.processingRatingFeedbackText.toPlainText()
-        body = {
-            'rating': rating,
-            'feedback': feedback_text
-        }
-        self.http.put(
-            url=f'{self.server}/processings/{pid}/rate',
-            body=json.dumps(body).encode(),
-            callback=self.submit_processing_rating_callback,
-            callback_kwargs={'feedback': feedback_text}
-        )
-
-    def accept_processing(self):
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        pid = processing.id
-        if not processing.status.is_ok:
-            self.alert(self.tr('Only finished processings can be rated'))
-            return
-        elif not processing.reviewStatus.is_in_review:
-            self.alert(self.tr("Processing must be in `Review required` status"))
-            return
-        self.http.put(
-            url=f'{self.server}/processings/{pid}/acceptation',
-            callback=self.review_processing_callback
-        )
-
-    def review_processing_callback(self, response: QNetworkReply):
-        # Clear successfully uploaded review
-        self.review_dialog.reviewComment.setText("")
-        self.processing_service.processing_fetch_timer.start()
-        self.project_processing_controller.refresh_table()
-
-    def show_review_dialog(self):
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        if not processing.status.is_ok:
-            self.alert(self.tr('Only finished processings can be rated'))
-            return
-        elif not processing.reviewStatus.is_in_review:
-            self.alert(self.tr("Processing must be in `Review required` status"))
-            return
-        self.review_dialog.setup(processing)
-        self.review_dialog.show()
-
-    def submit_review(self):
-        body = {"comment": self.review_dialog.reviewComment.toPlainText(),
-                "features": layer_utils.export_as_geojson(self.review_dialog.reviewLayerCombo.currentLayer())}
-        self.http.put(
-            url=f'{self.server}/processings/{self.review_dialog.processing.id}/rejection',
-            body=json.dumps(body).encode(),
-            callback=self.review_processing_callback
-        )
-
-    def submit_processing_rating_callback(self, response: QNetworkReply, feedback: str) -> None:
-        if not feedback:
-            self.alert(
-                self.tr(
-                    "Thank you! Your rating is submitted!\nWe would appreciate if you add feedback as well."
-                ),
-                QMessageBox.Information
-            )
-        else:
-            self.alert(
-                self.tr(
-                    "Thank you! Your rating and feedback are submitted!"
-                ),
-                QMessageBox.Information
-            )
-        self.update_processing_current_rating()
-
-    def enable_review_submit(self, status_ok: bool) -> None:
-        self.dlg.enable_review(status_ok,
-                               self.tr("Only correctly finished processings with 'Review required' status can be reviewed"))
-
-    def enable_rating_submit(self, status_ok: bool) -> None:
-        rating_selected = 5 >= self.dlg.ratingComboBox.currentIndex() > 0
-        if not self.app_context.user_role.can_delete_rename_review_processing:
-            reason = self.tr('Not enough rights to rate processing in a shared project ({})').format(self.app_context.user_role.value)
-        elif not status_ok:
-            if not self.processing_service.selected_processing():
-                reason = self.tr('Please select processing')
-            else:
-                reason = self.tr("Only correctly finished processings (status OK) can be rated")
-        elif not rating_selected and self.app_context.user_role.can_delete_rename_review_processing:
-            reason = self.tr("Please select rating to submit")
-        else:
-            reason = ""
-        self.dlg.enable_rating(can_interact=(status_ok and self.app_context.user_role.can_delete_rename_review_processing),
-                               can_send=rating_selected,
-                               reason=reason)
-
-    def enable_feedback(self) -> None:
-        """
-        By feedback we mean either rating (1-5 stars + message) for regular users
-        or review for users which have review workflow enabled
-        """
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            if self.app_context.review_workflow_enabled:
-                self.enable_review_submit(False)
-            else:
-                self.enable_rating_submit(False)
-            return
-        if self.app_context.review_workflow_enabled:
-            self.enable_review_submit(processing.status.is_ok and processing.reviewStatus.is_in_review)
-        else:
-            self.enable_rating_submit(processing.status.is_ok)
-        self.enable_restart_action(self.app_context.user_role.can_start_processing 
-                                   and (processing.status.is_failed 
-                                        or processing.status.is_cancelled))
-    
-    def enable_restart_action(self, enabled: bool):
-        self.dlg.enable_restart_action(enabled)
-            
 
     # =================== Results management ==================== #
     def _open_template(self, template):

--- a/tests/qgis/test_processing_review_rating.py
+++ b/tests/qgis/test_processing_review_rating.py
@@ -1,0 +1,286 @@
+"""QGIS-tier tests for rating a processing and reviewing one.
+
+These had no direct tests while they lived in `mapflow.py` — the move is what makes them testable,
+because the requests now go through `ProcessingApi` instead of a hand-built URL on `Http`, and the
+widget reads are `ProcessingView`'s.
+
+The split under test: `ProcessingService` decides whether a processing can be rated or reviewed and
+issues the request; `ProcessingController` gathers what lives in widgets (which star, what feedback,
+the review dialog's comment) and hands it over; `ProcessingView` writes to the panel.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller.processing_controller import ProcessingController
+from mapflow.functional.service import processing_service as ps_mod
+from mapflow.functional.service.processing_service import ProcessingService
+
+
+def _processing(is_ok=True, in_review=True, is_failed=False, is_cancelled=False):
+    return SimpleNamespace(
+        id="p-1",
+        name="Run 1",
+        status=SimpleNamespace(is_ok=is_ok, is_failed=is_failed, is_cancelled=is_cancelled),
+        reviewStatus=SimpleNamespace(is_in_review=in_review),
+    )
+
+
+def _service(processing=None):
+    service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the panel updates are signals
+    service.tr = lambda text: text
+    service.api = MagicMock()
+    service.processing_fetch_timer = MagicMock()
+    service.selected_processing = MagicMock(return_value=processing)
+    return service
+
+
+def _response(payload):
+    reply = MagicMock()
+    reply.readAll.return_value.data.return_value = (
+        payload if isinstance(payload, bytes) else json.dumps(payload).encode())
+    return reply
+
+
+@pytest.fixture
+def alerts(monkeypatch):
+    """Everything the service told the user, in order."""
+    said = []
+    monkeypatch.setattr(ps_mod, "alert", lambda message, *a, **k: said.append(message))
+    monkeypatch.setattr(ps_mod, "alert_info", lambda message, *a, **k: said.append(message))
+    return said
+
+
+# ---------- showing the rating a processing already has ----------
+
+def test_loading_a_rating_shows_the_name_before_the_request_answers():
+    """Otherwise the panel keeps the previous processing's name until the response lands."""
+    service = _service(_processing())
+    shown = []
+    service.ratingLoaded.connect(lambda name, rating, feedback: shown.append((name, rating, feedback)))
+
+    service.load_current_rating()
+
+    assert shown == [("Run 1", 0, "")]
+    assert service.api.get_processing.call_args.kwargs["processing_id"] == "p-1"
+
+
+def test_loading_a_rating_without_a_selection_asks_nothing():
+    service = _service(None)
+
+    service.load_current_rating()
+
+    service.api.get_processing.assert_not_called()
+
+
+def test_the_stored_rating_reaches_the_panel():
+    service = _service(_processing())
+    shown = []
+    service.ratingLoaded.connect(lambda name, rating, feedback: shown.append((name, rating, feedback)))
+
+    service.load_current_rating_callback(
+        _response({"name": "Run 1", "rating": {"rating": 4, "feedback": "good"}}))
+
+    assert shown == [("Run 1", 4, "good")]
+
+
+def test_an_unrated_processing_leaves_the_panel_alone():
+    service = _service(_processing())
+    shown = []
+    service.ratingLoaded.connect(lambda *a: shown.append(a))
+
+    service.load_current_rating_callback(_response({"name": "Run 1", "rating": None}))
+
+    assert shown == []
+
+
+def test_a_body_that_is_not_json_does_not_raise():
+    service = _service(_processing())
+
+    service.load_current_rating_callback(_response(b"not json"))  # must not raise
+
+
+# ---------- rating ----------
+
+def test_rating_a_finished_processing_sends_the_score_and_the_feedback():
+    service = _service(_processing())
+
+    service.submit_rating(4, "nice")
+
+    kwargs = service.api.rate_processing.call_args.kwargs
+    assert kwargs["processing_id"] == "p-1"
+    assert kwargs["rating"] == 4
+    assert kwargs["feedback"] == "nice"
+
+
+def test_an_unfinished_processing_cannot_be_rated(alerts):
+    service = _service(_processing(is_ok=False))
+
+    service.submit_rating(4, "")
+
+    service.api.rate_processing.assert_not_called()
+    assert alerts == ["Only finished processings can be rated"]
+
+
+def test_no_star_picked_sends_nothing(alerts):
+    """The combo's 'None' row resolves to 6, which is out of range."""
+    service = _service(_processing())
+
+    service.submit_rating(6, "")
+
+    service.api.rate_processing.assert_not_called()
+
+
+def test_the_thank_you_depends_on_whether_feedback_was_written(alerts):
+    service = _service(_processing())
+    service.load_current_rating = MagicMock()
+
+    service.submit_rating_callback(_response({}), feedback="")
+    service.submit_rating_callback(_response({}), feedback="useful")
+
+    assert "would appreciate" in alerts[0]
+    assert "rating and feedback are submitted" in alerts[1]
+    # The panel is refreshed so it shows what was just submitted.
+    assert service.load_current_rating.call_count == 2
+
+
+# ---------- review ----------
+
+def test_accepting_a_review_sends_the_acceptation():
+    service = _service(_processing())
+
+    service.accept_processing()
+
+    assert service.api.accept_processing.call_args.kwargs["processing_id"] == "p-1"
+
+
+def test_a_processing_not_awaiting_review_cannot_be_accepted(alerts):
+    service = _service(_processing(in_review=False))
+
+    service.accept_processing()
+
+    service.api.accept_processing.assert_not_called()
+    assert alerts == ["Processing must be in `Review required` status"]
+
+
+def test_rejecting_sends_the_comment_and_the_corrections():
+    service = _service(_processing())
+
+    service.reject_processing("p-1", comment="please redo", features={"type": "FeatureCollection"})
+
+    kwargs = service.api.reject_processing.call_args.kwargs
+    assert kwargs["comment"] == "please redo"
+    assert kwargs["features"] == {"type": "FeatureCollection"}
+
+
+def test_a_finished_review_clears_the_box_and_refreshes_the_list():
+    service = _service(_processing())
+    events = []
+    service.reviewSubmitted.connect(lambda: events.append("submitted"))
+    service.refreshRequested.connect(lambda: events.append("refresh"))
+
+    service.review_processing_callback(_response({}))
+
+    assert events == ["submitted", "refresh"]
+    service.processing_fetch_timer.start.assert_called_once()
+
+
+# ---------- the controller: widget reads and the enable/disable decision ----------
+
+def _controller(processing=None, review_workflow=False, can_review=True, can_start=True):
+    controller = ProcessingController.__new__(ProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.processing_service = MagicMock()
+    controller.processing_service.selected_processing.return_value = processing
+    controller.processing_view = MagicMock()
+    controller.processing_view.rating_is_selected.return_value = True
+    controller.review_dialog = MagicMock()
+    controller.app_context = SimpleNamespace(
+        review_workflow_enabled=review_workflow,
+        user_role=SimpleNamespace(can_delete_rename_review_processing=can_review,
+                                  can_start_processing=can_start,
+                                  value="contributor"))
+    return controller
+
+
+def test_the_controller_reads_the_star_and_the_feedback_off_the_panel():
+    controller = _controller(_processing())
+    controller.processing_view.selected_rating.return_value = 5
+    controller.processing_view.rating_feedback.return_value = "great"
+
+    controller.submit_rating()
+
+    controller.processing_service.submit_rating.assert_called_once_with(5, "great")
+
+
+def test_the_review_dialog_opens_only_for_a_reviewable_processing():
+    controller = _controller()
+    controller.processing_service._reviewable_processing.return_value = None
+
+    controller.show_review_dialog()
+
+    controller.review_dialog.show.assert_not_called()
+
+
+def test_the_review_dialog_opens_for_the_processing_the_service_approved():
+    controller = _controller()
+    processing = _processing()
+    controller.processing_service._reviewable_processing.return_value = processing
+
+    controller.show_review_dialog()
+
+    controller.review_dialog.setup.assert_called_once_with(processing)
+    controller.review_dialog.show.assert_called_once()
+
+
+def test_review_workflow_enables_the_review_controls_not_the_rating():
+    controller = _controller(_processing(), review_workflow=True)
+
+    controller.refresh_feedback_controls()
+
+    controller.processing_view.enable_review.assert_called_once()
+    assert controller.processing_view.enable_review.call_args.args[0] is True
+    controller.processing_view.enable_rating.assert_not_called()
+
+
+def test_without_the_review_workflow_the_rating_controls_are_used():
+    controller = _controller(_processing(), review_workflow=False)
+
+    controller.refresh_feedback_controls()
+
+    controller.processing_view.enable_rating.assert_called_once()
+    controller.processing_view.enable_review.assert_not_called()
+
+
+def test_a_role_without_review_rights_is_told_why_rating_is_blocked():
+    controller = _controller(_processing(), can_review=False)
+
+    controller.refresh_feedback_controls()
+
+    reason = controller.processing_view.enable_rating.call_args.kwargs["reason"]
+    assert "Not enough rights" in reason
+
+
+def test_no_selection_disables_the_controls_and_says_so():
+    controller = _controller(None)
+
+    controller.refresh_feedback_controls()
+
+    kwargs = controller.processing_view.enable_rating.call_args.kwargs
+    assert kwargs["can_interact"] is False
+    assert kwargs["reason"] == "Please select processing"
+    # Nothing to restart when nothing is selected.
+    controller.processing_view.enable_restart_action.assert_not_called()
+
+
+def test_a_failed_processing_offers_restart_to_a_role_that_may_start_one():
+    controller = _controller(_processing(is_ok=False, is_failed=True))
+
+    controller.refresh_feedback_controls()
+
+    controller.processing_view.enable_restart_action.assert_called_once_with(True)


### PR DESCRIPTION
First of three slices of the processing lifecycle; the panel that rates a finished processing and the one that accepts or rejects a review both leave the god object.

They could not leave before because of how they talked to the backend: rate, acceptation and rejection were the only processing endpoints called with a hand-built URL straight off Http rather than through ProcessingApi, so the logic was welded to mapflow.py's `self.server` and `self.http`. Giving them proper api methods is what makes the rest of the move a move.

The split follows the layer rules. ProcessingService decides whether a processing can be rated or reviewed at all — that reason is the same for both, so it is written once as _rateable_processing / _reviewable_processing instead of the four copies that were inline before — and issues the request. ProcessingView gets the widget reads and writes, including the descending rating combo whose index has to be inverted. ProcessingController gathers what only a widget knows (which star, what feedback, the review dialog's comment and correction layer) and hands it over, and owns the ReviewDialog lifecycle, since a service may not touch a dialog.

The enable/disable decision for the feedback controls moved to the controller rather than the service: it reads the account's role and whether the review workflow is on, then drives the view. It is a decision about widgets, made from state the controller can already see.

These had no direct tests — the suite stayed green through the whole move, which is exactly why it needed some. Twenty-one now cover them against the new owners, including the two guards that only existed as inline alerts ("only finished processings can be rated", "must be in Review required status"), the unrated-processing case, a response body that is not JSON, and the enable/disable matrix across roles and the review-workflow flag.

mapflow.py is down to 2212 lines and 241 self.dlg accesses.

## Manual test
Select a finished processing: the rating panel shows its name and any rating already submitted, and the star combo and Submit become available. Rate it with and without feedback — the thank-you message differs, and reselecting the processing shows the score you just gave. Try rating an unfinished one: it is refused with "Only finished processings can be rated". On an account with the review workflow enabled, select a processing in "Review required" and both Accept and Review work — Accept approves it, Review opens the dialog, and submitting a rejection sends the comment plus the correction layer and clears the comment box. On a shared project where your role cannot review, the rating controls are disabled with the reason naming the role. Regression surface: the processings list must still refresh after an accept or a reject, and the Restart action must still light up for a failed or cancelled processing when your role may start one.