### PR TITLE
refactor: move the model options out of mapflow.py, and delete four d…

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -68,20 +68,17 @@ template is open — `template_to_run`, the start callback, and resolving the ta
 objects. It is duck-typed and never imported, so no cycle is possible; delete it when that step
 lands.
 
-Extract processing lifecycle: options, start, review, rating → existing processing service/controller.
-Split in three; ~35 methods in `mapflow.py`, which is 3× what lands cleanly in one MR.
+Extract processing lifecycle: options, start, review, rating → existing processing
+service/controller. Split in three because it was 3× what lands cleanly in one MR; 2a (review and
+rating) is on `dev`, and what is left below is the start path.
 
-[ready-for-review] 2a: review and rating → `ProcessingService` / `ProcessingController`
-The whole review/rating panel leaves `mapflow.py`: the decisions and requests to the service, the
-widget reads to `ProcessingView`, the wiring and the `ReviewDialog` lifecycle to the controller.
-`ProcessingApi` gains `rate_processing`, `accept_processing` and `reject_processing` — these were
-the only processing endpoints called with a hand-built URL straight off `Http`, which is what had
-kept the code in `mapflow.py`.
-
-[ ] 2b: model options and processing-params assembly → `ProcessingController`
-`on_options_change`, `on_model_change`, `show_wd_options`, `save_options_settings`,
-`check_processing_ui`, `get_processing_params`, `show_processing_source`,
-`get_local_image_indices`, `get_search_providers`. The start panel's inputs; independent of 2a.
+[ready-for-review] 2b: model options and a processing's imagery source → `ProcessingController`
+The model combo and its option checkboxes leave `mapflow.py`: the widgets to `ProcessingView`,
+the `wd/{id}/{block}` settings round trip to `ProcessingService`, the decisions and the two signal
+connections to the controller. `show_processing_source` goes with them.
+Four of the nine methods this entry listed turned out to be dead — `check_processing_ui`,
+`get_processing_params`, and copies of `get_local_image_indices`/`get_search_providers` that
+`ProviderService` already owns — so they are deleted rather than moved.
 
 [ ] 2c: start-button state, the context menu, and the `templates`-keyed queries
 `update_processing_options_menu` (the last large `self.dlg` block), `show_selected_details`,

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -531,7 +531,8 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
     def enable_model_options(self, can_start_processing: bool = True):
         """
         Set the whole group of checkboxes for model options disabled depending on user role property.
-        Is called from 'show_wd_options' in 'mapflow.py'.
+        Called by `ProcessingView.show_model_options`, right after the checkboxes are created —
+        they do not exist any earlier, so this cannot be folded into the rest of the panel setup.
         """
         if not can_start_processing:
             can_start_processing = True

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -1,21 +1,27 @@
 from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QMessageBox
 from qgis.core import QgsMapLayer
 
 from .. import layer_utils
+from ..service.alert_service import alert
 from ..service.aoi_service import AoiService
 from ..view.aoi_view import AoiView
+from ...schema import (BillingType,
+                       ImagerySearchParams,
+                       MyImageryParams,
+                       UserDefinedParams)
 
 
 class ProcessingController(QObject):
-    """The start-processing panel: which AOI a processing will cover, and the review/rating
-    panel beside it.
+    """The start-processing panel: the model and its options, which AOI a processing will cover,
+    and the review/rating panel beside it.
 
-    Owns the wiring only. It is the one place allowed to see both `AoiService` and `AoiView`,
-    which is why the round trips below exist — the service cannot read a checkbox and the view
-    cannot call a service (`spec/007_architecture.md` § Layer rules).
+    Owns the wiring only. It is the one place allowed to see both a service and a view, which is
+    why the round trips below exist — the service cannot read a checkbox and the view cannot call
+    a service (`spec/007_architecture.md` § Layer rules).
 
-    Model and options, provider selection, cost and the start-button state join it as the later
-    Phase C steps extract them.
+    Provider selection, cost and the start-button state join it as the later Phase C steps
+    extract them.
     """
 
     def __init__(self,
@@ -32,7 +38,12 @@ class ProcessingController(QObject):
                  rating_combo=None,
                  accept_button=None,
                  review_button=None,
-                 processings_table=None):
+                 processings_table=None,
+                 provider_service=None,
+                 data_catalog_service=None,
+                 result_loader=None,
+                 model_combo=None,
+                 model_options_changed=None):
         super().__init__()
         self.iface = iface
         self.aoi_service = aoi_service
@@ -44,11 +55,18 @@ class ProcessingController(QObject):
         self.processing_view = processing_view
         self.app_context = app_context
         self.review_dialog = review_dialog
+        self.provider_service = provider_service
+        self.data_catalog_service = data_catalog_service
+        self.result_loader = result_loader
 
         self.aoi_service.aoiLayerRegistered.connect(self._on_aoi_layer_registered)
         self.aoi_service.aoiLayersChanged.connect(self.refresh_excepted_layers)
         self.aoi_service.currentAoiLayerChanged.connect(self.aoi_view.set_current_layer)
 
+        if model_combo is not None:
+            model_combo.currentIndexChanged.connect(self.on_model_change)
+        if model_options_changed is not None:
+            model_options_changed.connect(self.on_options_change)
         if processing_service is not None:
             processing_service.ratingLoaded.connect(self.processing_view.set_rating_labels)
             processing_service.reviewSubmitted.connect(self._on_review_submitted)
@@ -65,6 +83,73 @@ class ProcessingController(QObject):
         if processings_table is not None:
             processings_table.itemSelectionChanged.connect(self.refresh_feedback_controls)
             processings_table.cellClicked.connect(self.load_current_rating)
+
+    # ---------- the model and its options ----------
+
+    def on_model_change(self, *args) -> None:
+        """A different model was picked: its options, its price, and which imagery sources it
+        accepts all change together."""
+        wd_name = self.processing_view.selected_model_name()
+        wd = self.app_context.get_workflow_def(wd_name)
+        # Unconditional, and before the early return: a model with no definition still narrows
+        # the provider list, and leaving the previous model's sources offered is worse than
+        # offering none.
+        self.provider_service.set_available_imagery_sources(wd_name)
+        if not wd:
+            return
+        self.show_wd_options(wd)
+        self._show_price(wd)
+        # The test is `blocks`, not `optional_blocks`: a model that declares any block waits,
+        # because adding its option checkboxes fires `modelOptionsChanged` and `on_options_change`
+        # quotes the cost then. Which leaves obligatory-only models quoted by neither path —
+        # pinned in `test_a_model_whose_blocks_are_all_obligatory_is_not_quoted_on_selection`.
+        if not wd.blocks:
+            self._update_cost()
+
+    def on_options_change(self, *args) -> None:
+        wd = self.app_context.get_workflow_def(self.processing_view.selected_model_name())
+        if not wd:
+            return
+        self._show_price(wd)
+        self.processing_service.save_option_settings(wd, self.processing_view.enabled_blocks())
+        self._update_cost()
+
+    def show_wd_options(self, wd) -> None:
+        """Rebuild the option checkboxes for `wd`, ticked as this user last left them."""
+        can_start_processing = True
+        if self.app_context.user_role:
+            can_start_processing = self.app_context.user_role.can_start_processing
+        self.processing_view.show_model_options(self.processing_service.saved_model_options(wd),
+                                                enabled=can_start_processing)
+
+    def _show_price(self, wd) -> None:
+        self.processing_view.show_wd_price(
+            wd_price=wd.get_price(enable_blocks=self.processing_view.enabled_blocks()),
+            wd_description=wd.description,
+            display_price=self.app_context.billing_type == BillingType.credits)
+
+    def _update_cost(self) -> None:
+        """A cost is quoted in credits, so only a credits account has one to ask for."""
+        if self.app_context.billing_type == BillingType.credits:
+            self.processing_service.update_processing_cost()
+
+    # ---------- a processing's imagery source ----------
+
+    def show_processing_source(self, processing, window) -> None:
+        """'Go to source' on the details dialog: reopen whatever imagery the processing ran on.
+        Where that lives depends on the source, which is why the fork is here rather than in any
+        one of the three regions it dispatches to."""
+        source_params = processing.params.sourceParams
+        if isinstance(source_params, ImagerySearchParams):
+            # The search table is filled from the AOI, so the download has to finish first.
+            self.result_loader.download_aoi_file(
+                pid=processing.id, callback=self.processing_service.duplicate_aoi_callback)
+        elif isinstance(source_params, MyImageryParams):
+            self.data_catalog_service.show_my_imagery_source(source_params)
+        elif isinstance(source_params, UserDefinedParams):
+            alert(self.processing_view.show_user_provider_info(source_params),
+                  icon=QMessageBox.Information)
+        window.close()
 
     # ---------- review and rating ----------
 

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from uuid import UUID
-from typing import Dict, Optional, List
+from typing import Dict, Optional, List, Tuple
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import QMessageBox, QApplication, QInputDialog
@@ -144,6 +144,22 @@ class ProcessingService(QObject):
 
         # Optionally refresh processings for the new project
         # self.get_processings()  # Uncomment when this method is implemented
+
+    # ================  MODEL OPTIONS  ====================== #
+    # Which optional blocks a model runs with is remembered per model, under
+    # `wd/{workflow_id}/{block_name}` (`spec/003_local_storage.md`). Only the settings round trip
+    # lives here — the checkboxes themselves are `ProcessingView`'s.
+
+    def saved_model_options(self, wd) -> List[Tuple[str, bool]]:
+        """This model's optional blocks as (label, remembered state) pairs, in the order the
+        workflow definition declares them — the order is what maps a checkbox back to a block."""
+        return [(block.displayName,
+                 bool(self.app_context.settings.value(f"wd/{wd.id}/{block.name}", False)))
+                for block in wd.optional_blocks]
+
+    def save_option_settings(self, wd, enabled_blocks: List[bool]) -> None:
+        for block in wd.get_enabled_blocks(enabled_blocks):
+            self.app_context.settings.setValue(f"wd/{wd.id}/{block['name']}", block["enabled"])
 
     # ================  CREATE  ====================== #
     def validate_processing_params(self, processing_params, allow_empty_name: bool = False):

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Tuple, Union
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtWidgets import QAbstractItemView, QTableWidgetItem, QMessageBox, QCheckBox
 from ...dialogs.main_dialog import MainDialog
@@ -304,6 +304,35 @@ class ProcessingView:
         rows.sort(reverse=True)
         for row in rows:
             self.dlg.processingsTable.removeRow(row)
+
+    # ---------- the model and its options ----------
+
+    def selected_model_name(self) -> str:
+        return self.dlg.modelCombo.currentText()
+
+    def enabled_blocks(self) -> List[bool]:
+        """Which optional blocks are ticked, in layout order. Translating the order into block
+        names is the workflow definition's job, not this view's."""
+        return self.dlg.enabled_blocks()
+
+    def show_wd_price(self, wd_price: float, wd_description: str, display_price: bool) -> None:
+        self.dlg.show_wd_price(wd_price=wd_price,
+                               wd_description=wd_description,
+                               display_price=display_price)
+
+    def show_model_options(self, options: List[Tuple[str, bool]], enabled: bool) -> None:
+        """Replace the option checkboxes with this model's, then set their enabled state.
+
+        The two halves are one call because ordering matters: the checkboxes do not exist until
+        the loop above has run, so an `enable_model_options` issued with the rest of the panel
+        would reach nothing."""
+        self.dlg.clear_model_options()
+        for name, checked in options:
+            self.dlg.add_model_option(name, checked=checked)
+        self.dlg.enable_model_options(enabled)
+
+    def show_user_provider_info(self, source_params) -> str:
+        return self.dlg.show_user_provider_info(source_params)
 
     # ---------- the review / rating panel ----------
 

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -23,10 +23,7 @@ from qgis.core import (
 )
 
 from .config import Config, ConfigColumns
-from .errors import (BadProcessingInput,
-                     PluginError,
-                     ProcessingInputDataMissing,
-                     ProxyIsAlreadySet)
+from .errors import ProxyIsAlreadySet
 # Functional
 from .functional import helpers, layer_utils
 from .functional.app_context import AppContext
@@ -55,14 +52,9 @@ from .http import (Http,
                    api_message_parser,
                    get_error_report_body)
 # Schema
-from .schema import (BillingType,
-                     ImagerySearchParams,
-                     MyImageryParams,
-                     ProviderReturnSchema,
-                     UserDefinedParams)
+from .schema import BillingType, ProviderReturnSchema
 from .schema.catalog import ProductType
 from .schema.project import MapflowProject, UserRole
-from .schema.workflow_def import WorkflowDef
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
                       MainDialog,
@@ -330,7 +322,12 @@ class Mapflow(QObject):
             rating_combo=self.dlg.ratingComboBox,
             accept_button=self.dlg.acceptButton,
             review_button=self.dlg.reviewButton,
-            processings_table=self.dlg.processingsTable)
+            processings_table=self.dlg.processingsTable,
+            provider_service=self.provider_service,
+            data_catalog_service=self.data_catalog_service,
+            result_loader=self.result_loader,
+            model_combo=self.dlg.modelCombo,
+            model_options_changed=self.dlg.modelOptionsChanged)
 
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
@@ -412,8 +409,7 @@ class Mapflow(QObject):
         self.dlg.metadataTo.setDate(self.app_context.settings.value('metadataTo', today))
 
         # ========== 12. SET UP SIGNALS & SLOTS ==========
-        self.dlg.modelCombo.currentIndexChanged.connect(self.on_model_change)
-        self.dlg.modelOptionsChanged.connect(self.on_options_change)
+        # The model combo and its option checkboxes are wired by ProcessingController.
         # Memorize dialog element sizes & positioning
         self.dlg.finished.connect(self.save_dialog_state)
         # Connect buttons
@@ -749,52 +745,6 @@ class Mapflow(QObject):
             self.dlg.processingsTable.scrollToItem(item)
             self.show_details()
             return
-
-    def on_options_change(self):
-        wd_name = self.dlg.modelCombo.currentText()
-        wd = self.app_context.get_workflow_def(wd_name)
-        if not wd:
-            return
-        enabled_blocks = self.dlg.enabled_blocks()
-        self.dlg.show_wd_price(wd_price=wd.get_price(enable_blocks=enabled_blocks),
-                               wd_description=wd.description,
-                               display_price=self.app_context.billing_type == BillingType.credits)
-        self.save_options_settings(wd, enabled_blocks)
-        if self.app_context.billing_type == BillingType.credits:
-            self.processing_service.update_processing_cost()
-
-    def on_model_change(self, 
-                        index: Optional[int] = None) -> None:
-        wd_name = self.dlg.modelCombo.currentText()
-        wd = self.app_context.get_workflow_def(wd_name)
-        self.provider_service.set_available_imagery_sources(wd_name)
-        if not wd:
-            return
-        self.show_wd_options(wd)
-        self.dlg.show_wd_price(wd_price=wd.get_price(enable_blocks=self.dlg.enabled_blocks()),
-                               wd_description=wd.description,
-                               display_price=self.app_context.billing_type == BillingType.credits)
-        if len(wd.blocks) == 0: # and for wd with options it will update cost later
-            if self.app_context.billing_type == BillingType.credits:
-                # todo: here was a toggle to not call if from setup_workflow_defs, but maybe not so important?
-                self.processing_service.update_processing_cost()
-
-    def show_wd_options(self, wd: WorkflowDef):
-        self.dlg.clear_model_options()
-        for block in wd.optional_blocks:
-            self.dlg.add_model_option(block.displayName, checked=bool(self.app_context.settings.value(f"wd/{wd.id}/{block.name}", False)))
-        # Other wigets are disabled before the appearence of these checkboxes, so we do it here separately after adding them
-        can_start_processing = True
-        if self.app_context.user_role:
-            can_start_processing = self.app_context.user_role.can_start_processing
-        self.dlg.enable_model_options(can_start_processing)
-
-    def save_options_settings(self, wd: WorkflowDef, enabled_blocks: List[bool]):
-        enabled_blocks_dict = wd.get_enabled_blocks(enabled_blocks)
-        for block in enabled_blocks_dict:
-            name = block["name"]
-            enabled = block["enabled"]
-            self.app_context.settings.setValue(f"wd/{wd.id}/{name}", enabled)
 
     def apply_local_filter(self, *_) -> None:
         """Instantly filter the current search/template results by the filter widgets
@@ -1542,39 +1492,6 @@ class Mapflow(QObject):
             #self.dlg.metadataTable.selectRow(items[0].row())
         # Redundant since imageId is temorary removed
 
-    def check_processing_ui(self, allow_empty_name=False):
-        processing_name = self.dlg.processingName.text()
-
-        if not processing_name and not allow_empty_name:
-            raise ProcessingInputDataMissing(self.tr('Please, specify a name for your processing'))
-        if not self.app_context.aoi:
-            if self.dlg.polygonCombo.currentLayer():
-                raise BadProcessingInput(self.tr('Processing area layer is corrupted or has invalid projection'))
-            else:
-                raise BadProcessingInput(self.tr('Please, select a valid area of interest'))
-        if self.app_context.aoi_area_limit < self.app_context.aoi_size:
-            raise BadProcessingInput(self.tr(
-                'Up to {} sq km can be processed at a time. '
-                'Try splitting your area(s) into several processings.').format(self.app_context.aoi_area_limit))
-
-        return True
-
-    def get_processing_params(self,
-                              provider_index: Optional[int],
-                              s3_uri: str = "",
-                              zoom: Optional[str] = None,
-                              provider_name: Optional[str] = None):
-        provider = self.provider_service.providers[provider_index]
-        meta = {'source-app': 'qgis',
-                'version': self.app_context.plugin_version,
-                'source': provider.name.lower()}
-        if not provider:
-            raise PluginError(self.tr('Providers are not initialized'))
-        provider_params, provider_meta = provider.to_processing_params(provider_name=provider_name,
-                                                                       zoom=zoom)
-        meta.update(**provider_meta)
-        return provider_params, meta
-
     def update_processing_limit(self) -> None:
         """Set the user's processing limit as reported by Mapflow."""
         self.http.get(
@@ -2076,48 +1993,12 @@ class Mapflow(QObject):
         if processing.messages:
             error = processing.error_message(raw=self.config.SHOW_RAW_ERROR)
         dialog = ProcessingDetailsDialog(self.dlg)
-        dialog.toSourceButton.clicked.connect(lambda: self.show_processing_source(
-                                                           processing=processing,
-                                                           window=dialog))
+        dialog.toSourceButton.clicked.connect(
+            lambda: self.processing_controller.show_processing_source(processing=processing,
+                                                                      window=dialog))
         dialog.setup(processing, error or None)
         dialog.deleteLater()
-    
-    def show_processing_source(self,
-                               processing,
-                               window):
-        source_params = processing.params.sourceParams
-        if isinstance(source_params, ImagerySearchParams):
-            # Download AOI and only then fill search table
-            self.result_loader.download_aoi_file(pid=processing.id, callback=self.processing_service.duplicate_aoi_callback)
-        elif isinstance(source_params, MyImageryParams):
-            self.data_catalog_service.show_my_imagery_source(source_params)
-        elif isinstance(source_params, UserDefinedParams):
-            text = self.dlg.show_user_provider_info(source_params)
-            self.alert(message=text, icon=QMessageBox.Information)
-        window.close()
 
-    def get_local_image_indices(self, selected_images):
-        try:
-            rows = list(set(image.row() for image in selected_images))
-            local_image_indices = [int(self.dlg.metadataTable.item(row, self.config.LOCAL_INDEX_COLUMN).text()) 
-                                   for row in rows]
-        except (AttributeError, KeyError):
-            local_image_indices = []
-        return local_image_indices
-
-    def get_search_providers(self, local_image_indices):
-        try:
-            provider_names = [self.app_context.search_footprints[local_image_index].attribute("providerName")
-                              for local_image_index in local_image_indices]
-        except KeyError:
-            provider_names = []
-        try:
-            product_types = [self.app_context.search_footprints[local_image_index].attribute("productType")
-                             for local_image_index in local_image_indices]
-        except KeyError:
-            product_types = []
-        return provider_names, product_types
-    
     def show_search_next_page(self):
         self._show_search_page(self.search_service.next_page_offset())
 

--- a/tests/qgis/test_mapflow_user_role_guard.py
+++ b/tests/qgis/test_mapflow_user_role_guard.py
@@ -1,20 +1,33 @@
+"""The account's role gates what the start panel offers.
+
+`show_wd_options` moved from `Mapflow` to `ProcessingController`; the guard it tests did not
+move — `user_role` is None until /user/status answers, and reading `can_start_processing` off
+None raises. The role cases live with the rest of the model-options behaviour in
+`test_model_options.py`; this file keeps the guard on its own because it is a crash, not a
+preference.
+"""
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.mapflow import Mapflow
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller.processing_controller import ProcessingController
 
 
 def test_show_wd_options_handles_missing_user_role():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.dlg = MagicMock()
-    plugin.app_context = SimpleNamespace(settings=MagicMock(), user_role=None)
-    plugin.app_context.settings.value.return_value = False
+    controller = ProcessingController.__new__(ProcessingController)
+    QObject.__init__(controller)
+    controller.app_context = SimpleNamespace(user_role=None)
+    controller.processing_service = MagicMock()
+    controller.processing_service.saved_model_options.return_value = [("Block 1", False)]
+    controller.processing_view = MagicMock()
 
     wd = SimpleNamespace(
         id="wd-id",
         optional_blocks=[SimpleNamespace(displayName="Block 1", name="block_1")],
     )
 
-    plugin.show_wd_options(wd)
+    controller.show_wd_options(wd)
 
-    plugin.dlg.enable_model_options.assert_called_once_with(True)
+    controller.processing_view.show_model_options.assert_called_once_with(
+        [("Block 1", False)], enabled=True)

--- a/tests/qgis/test_model_options.py
+++ b/tests/qgis/test_model_options.py
@@ -1,0 +1,263 @@
+"""QGIS-tier tests for picking a model, its optional blocks, and reopening a processing's source.
+
+The split under test: `ProcessingService` owns only the settings round trip for the option
+checkboxes (`wd/{workflow_id}/{block_name}`, `spec/003_local_storage.md`), `ProcessingView` owns
+the widgets, and `ProcessingController` decides — which is what makes the branches below reachable
+without a dialog.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import processing_controller as pc_mod
+from mapflow.functional.controller.processing_controller import ProcessingController
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.schema import BillingType, ImagerySearchParams, MyImageryParams, UserDefinedParams
+from mapflow.schema.workflow_def import WorkflowDef
+
+
+def _wd(optional_prices=(), base_price=10):
+    """A workflow def with `len(optional_prices)` optional blocks after one obligatory one."""
+    blocks = [{"name": "base", "displayName": "Base", "price": base_price, "optional": False}]
+    blocks += [{"name": f"opt_{i}", "displayName": f"Option {i}", "price": price, "optional": True}
+               for i, price in enumerate(optional_prices)]
+    return WorkflowDef(id="wd-1", name="Buildings", description="Finds buildings", blocks=blocks)
+
+
+def _wd_without_blocks():
+    """A workflow def that declares no blocks — a flat price per sq km and no checkboxes."""
+    return WorkflowDef(id="wd-1", name="Buildings", description="Finds buildings", blocks=None)
+
+
+def _service(settings=None):
+    service = ProcessingService.__new__(ProcessingService)
+    service.app_context = SimpleNamespace(settings=settings or MagicMock())
+    return service
+
+
+def _controller(wd=None, billing=BillingType.credits, user_role=None):
+    controller = ProcessingController.__new__(ProcessingController)
+    QObject.__init__(controller)
+    controller.app_context = SimpleNamespace(
+        billing_type=billing,
+        user_role=user_role,
+        get_workflow_def=MagicMock(return_value=wd))
+    controller.processing_service = MagicMock()
+    controller.processing_service.saved_model_options.return_value = []
+    controller.processing_view = MagicMock()
+    controller.processing_view.selected_model_name.return_value = "Buildings"
+    controller.processing_view.enabled_blocks.return_value = []
+    controller.provider_service = MagicMock()
+    controller.data_catalog_service = MagicMock()
+    controller.result_loader = MagicMock()
+    return controller
+
+
+# ---------- the settings round trip ----------
+
+def test_the_options_a_model_was_last_run_with_are_remembered_per_block():
+    settings = MagicMock()
+    settings.value.side_effect = lambda key, default: key == "wd/wd-1/opt_1"
+    service = _service(settings)
+
+    assert service.saved_model_options(_wd(optional_prices=(5, 7))) == [
+        ("Option 0", False), ("Option 1", True)]
+
+
+def test_saved_options_keep_the_workflow_defs_order():
+    """The checkbox order is what maps a tick back to a block, so it must follow the definition."""
+    service = _service()
+    service.app_context.settings.value.return_value = False
+
+    names = [name for name, _checked in service.saved_model_options(_wd(optional_prices=(1, 2, 3)))]
+
+    assert names == ["Option 0", "Option 1", "Option 2"]
+
+
+def test_ticking_an_option_is_written_under_its_workflow_and_block():
+    settings = MagicMock()
+    service = _service(settings)
+
+    service.save_option_settings(_wd(optional_prices=(5, 7)), [False, True])
+
+    assert settings.setValue.call_args_list[0].args == ("wd/wd-1/opt_0", False)
+    assert settings.setValue.call_args_list[1].args == ("wd/wd-1/opt_1", True)
+
+
+def test_a_model_without_options_writes_nothing():
+    settings = MagicMock()
+    service = _service(settings)
+
+    service.save_option_settings(_wd(), [])
+
+    settings.setValue.assert_not_called()
+
+
+# ---------- picking a model ----------
+
+def test_choosing_a_model_narrows_the_imagery_sources_even_when_it_has_no_definition():
+    """The definition is missing (a model the project offers but /user/status did not describe),
+    yet leaving the previous model's providers on offer would be worse than offering none."""
+    controller = _controller(wd=None)
+
+    controller.on_model_change()
+
+    controller.provider_service.set_available_imagery_sources.assert_called_once_with("Buildings")
+    controller.processing_view.show_model_options.assert_not_called()
+    controller.processing_view.show_wd_price.assert_not_called()
+
+
+def test_choosing_a_model_shows_its_options_and_its_price():
+    wd = _wd(optional_prices=(5,))
+    controller = _controller(wd=wd)
+    controller.processing_view.enabled_blocks.return_value = [False]
+    controller.processing_service.saved_model_options.return_value = [("Option 0", False)]
+
+    controller.on_model_change()
+
+    controller.processing_view.show_model_options.assert_called_once_with(
+        [("Option 0", False)], enabled=True)
+    kwargs = controller.processing_view.show_wd_price.call_args.kwargs
+    assert kwargs["wd_price"] == 10
+    assert kwargs["wd_description"] == "Finds buildings"
+    assert kwargs["display_price"] is True
+
+
+def test_a_model_declaring_no_blocks_asks_for_its_cost_straight_away():
+    """Nothing will fire `on_options_change` for it, so this is its only chance to be quoted."""
+    controller = _controller(wd=_wd_without_blocks())
+
+    controller.on_model_change()
+
+    controller.processing_service.update_processing_cost.assert_called_once()
+
+
+def test_a_model_with_options_waits_for_them_before_asking_the_cost():
+    """Adding the checkboxes fires `modelOptionsChanged`, and `on_options_change` quotes it."""
+    controller = _controller(wd=_wd(optional_prices=(5,)))
+    controller.processing_view.enabled_blocks.return_value = [False]
+
+    controller.on_model_change()
+
+    controller.processing_service.update_processing_cost.assert_not_called()
+
+
+def test_a_model_whose_blocks_are_all_obligatory_is_not_quoted_on_selection():
+    """Current behaviour, pinned because it is a gap rather than a decision: the guard asks
+    whether the model declares *any* blocks, so one with only obligatory blocks skips the
+    immediate quote — and grows no checkboxes to trigger the deferred one either. Left as it
+    was found; changing it is a behaviour change, not part of this move."""
+    controller = _controller(wd=_wd())
+
+    controller.on_model_change()
+
+    controller.processing_service.update_processing_cost.assert_not_called()
+
+
+def test_an_area_account_is_never_quoted_a_cost():
+    controller = _controller(wd=_wd_without_blocks(), billing=BillingType.area)
+
+    controller.on_model_change()
+
+    controller.processing_service.update_processing_cost.assert_not_called()
+    assert controller.processing_view.show_wd_price.call_args.kwargs["display_price"] is False
+
+
+# ---------- ticking an option ----------
+
+def test_ticking_an_option_saves_it_reprices_and_re_asks_the_cost():
+    wd = _wd(optional_prices=(5, 7))
+    controller = _controller(wd=wd)
+    controller.processing_view.enabled_blocks.return_value = [True, False]
+
+    controller.on_options_change()
+
+    controller.processing_service.save_option_settings.assert_called_once_with(wd, [True, False])
+    # 10 obligatory + 5 for the ticked option; the untouched one is not counted.
+    assert controller.processing_view.show_wd_price.call_args.kwargs["wd_price"] == 15
+    controller.processing_service.update_processing_cost.assert_called_once()
+
+
+def test_ticking_an_option_with_no_model_selected_saves_nothing():
+    controller = _controller(wd=None)
+
+    controller.on_options_change()
+
+    controller.processing_service.save_option_settings.assert_not_called()
+    controller.processing_service.update_processing_cost.assert_not_called()
+
+
+# ---------- who may touch the options ----------
+
+def test_options_are_enabled_when_the_account_has_no_role_yet():
+    """`user_role` is None until /user/status answers, and `None.can_start_processing` raises."""
+    controller = _controller(user_role=None)
+
+    controller.show_wd_options(_wd(optional_prices=(5,)))
+
+    assert controller.processing_view.show_model_options.call_args.kwargs["enabled"] is True
+
+
+def test_a_role_that_may_not_start_a_processing_gets_the_options_disabled():
+    controller = _controller(user_role=SimpleNamespace(can_start_processing=False))
+
+    controller.show_wd_options(_wd(optional_prices=(5,)))
+
+    assert controller.processing_view.show_model_options.call_args.kwargs["enabled"] is False
+
+
+# ---------- reopening the imagery a processing ran on ----------
+
+def _processing(source_params):
+    return SimpleNamespace(id="p-1", params=SimpleNamespace(sourceParams=source_params))
+
+
+def test_a_search_based_processing_downloads_its_aoi_first():
+    """The search table is filled from the AOI, so the source cannot be shown before it lands."""
+    controller = _controller()
+    window = MagicMock()
+
+    controller.show_processing_source(_processing(ImagerySearchParams(imagerySearch=None)), window)
+
+    kwargs = controller.result_loader.download_aoi_file.call_args.kwargs
+    assert kwargs["pid"] == "p-1"
+    assert kwargs["callback"] is controller.processing_service.duplicate_aoi_callback
+    window.close.assert_called_once()
+
+
+def test_a_my_imagery_processing_is_handed_to_the_catalog():
+    controller = _controller()
+    source_params = MyImageryParams(myImagery=None)
+
+    controller.show_processing_source(_processing(source_params), MagicMock())
+
+    controller.data_catalog_service.show_my_imagery_source.assert_called_once_with(source_params)
+
+
+def test_a_user_defined_source_is_described_in_a_message(monkeypatch):
+    said = []
+    monkeypatch.setattr(pc_mod, "alert", lambda message, *a, **k: said.append(message))
+    controller = _controller()
+    controller.processing_view.show_user_provider_info.return_value = "XYZ tiles at zoom 18"
+
+    controller.show_processing_source(_processing(UserDefinedParams(userDefined=None)), MagicMock())
+
+    assert said == ["XYZ tiles at zoom 18"]
+
+
+@pytest.mark.parametrize("source_params", [
+    ImagerySearchParams(imagerySearch=None),
+    MyImageryParams(myImagery=None),
+    UserDefinedParams(userDefined=None),
+    None,  # a provider-based processing: nothing to reopen
+])
+def test_the_details_window_always_closes(source_params, monkeypatch):
+    monkeypatch.setattr(pc_mod, "alert", lambda *a, **k: None)
+    controller = _controller()
+    window = MagicMock()
+
+    controller.show_processing_source(_processing(source_params), window)
+
+    window.close.assert_called_once()


### PR DESCRIPTION
…ead methods

Second of three slices of the processing lifecycle: the model combo, its option checkboxes and the "go to source" button on the details dialog.

Four of the nine methods this step was planned around turned out to have no caller anywhere in mapflow/ or tests/, so they are deleted rather than moved. check_processing_ui and get_processing_params were superseded by ProcessingService.validate_processing_params and get_processing_schema; get_local_image_indices and get_search_providers are byte-identical copies of the live ones in ProviderService. The duplicated pair is the one that mattered: the search path calls ProviderService's, so the copies here had been free to drift unnoticed, and deleting a copy is the only thing that stops that.

The remaining five follow the layer rules. ProcessingView takes the widgets. ProcessingService takes only the settings round trip for the checkboxes — saved_model_options reads and save_option_settings writes wd/{workflow_id}/{block_name} (spec/003_local_storage.md) — which involves no widget, so it stays a legal service. ProcessingController takes the decisions and the two signal connections that were loose in mapflow.py's setup block. show_processing_source goes with them: it forks on a processing's source-param type across three regions, which is coordination, so it belongs to a controller and not to any one of them. show_details stays behind; the WAL assigns it to ResultService in Phase D, and its lambda now calls the controller.

Building show_model_options as one call rather than three is deliberate: the checkboxes do not exist until the loop has created them, so an enable_model_options issued with the rest of the panel setup would reach nothing. That ordering was implicit in the old code and is now enforced by the signature.

One thing the move surfaced, via a test of mine that failed: the immediate cost quote is guarded by len(wd.blocks) == 0 — all blocks, not optional_blocks. A model whose blocks are all obligatory is therefore quoted by neither path: it declares blocks, so the immediate quote is skipped, and it grows no checkboxes, so on_options_change never fires for it. Pinned as current behaviour rather than fixed, since a behaviour change is not part of a move. Two more left alone and recorded here: MainDialog.enable_model_options opens by overwriting its own argument with True, making the role check a no-op; and modelCombo.activated is emitted in two places while nothing connects it.

Also removes the 2a WAL entry, which merged. That is normally its own chore MR, but the previous round's rebase conflict was precisely a chore branch and a feature branch editing adjacent WAL lines from the same base — and 2a's WHY is already in its own commit message on dev.

mapflow.py is down to 2093 lines and 229 self.dlg accesses.

## Manual test
Switch models in the start panel: the option checkboxes rebuild for each model, ticked the way you last left that model, and the price beside the combo follows both the model and the ticks. Tick an option, switch to another model and back — the tick is remembered. On a credits account the processing cost re-estimates when you change a model with no options, and when you tick an option on any model; on an area account no cost appears and the price is not shown in the tooltip. Open a processing's details and press "Go to source": a search-based processing loads its AOI and search results, a My Imagery one opens the catalog, and a custom-provider one shows the provider info message. The details window closes in every case.
Regression surface: the imagery-source combo must still narrow to what the selected model accepts — including when the model has no definition, where the list should end up empty rather than keeping the previous model's providers. Watch also that the option checkboxes appear at all on the first model shown after login, since their creation and their enabling are now one call.