### PR TITLE
refactor: give the processings table's actions an owner, and delete t…

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -44,53 +44,32 @@ navigation state — and it took several MRs: create/update-search-params/exclud
 gating; the seen-markers cluster; the map layers and their navigation slots; the search request,
 results, footprints and AOI scoping; the run-state actions; one owner for the processings table's
 refresh; and finally the in-template view with its navigation state.
-**`ProcessingService` now references nothing on `TemplateService`** apart from the seam below.
-
-[ ] Finish the split: the `templates`-keyed queries, the context menu, and the seam
-The templates extraction stopped here on purpose, not by omission. `selected_template(s)`,
-`is_only_templates_selected`, `all_selected_templates_editable` and `template_to_run` read
-`ProcessingService.templates` — the project's template dict, which its own project fetch fills —
-and `template_to_run` is what `handle_processing_submission` forks the start path on. Moving them
-means moving that fork, so they belong with **"Extract processing lifecycle: options, start, review,
-rating"** below rather than with templates.
-
-What that leaves in `mapflow.py`, all of it reading those queries:
-* the processings-table **context menu** (`update_processing_options_menu`, ~`mapflow.py:588-660`) —
-  its template branch reads `selected_template` and the run-state gating;
-* `show_selected_details`, `update_delete_button_state`, `load_results`/`_open_template`, and the
-  plan-mode branch of the Search button.
-The in-template forks in `apply_local_filter`, the header sort and the pager now read
-`template_service` directly and are fine where they are.
-
-Until that step, `ProcessingService.template_state` is a documented read-only seam (a null object by
-default, `TemplateService` at wiring time) covering the three places the start path asks whether a
-template is open — `template_to_run`, the start callback, and resolving the table selection to
-objects. It is duck-typed and never imported, so no cycle is possible; delete it when that step
-lands.
+**`ProcessingService` now references nothing on `TemplateService`** — the last seam is gone (2c).
 
 Extract processing lifecycle: options, start, review, rating → existing processing
 service/controller. Split in three because it was 3× what lands cleanly in one MR; 2a (review and
-rating) is on `dev`, and what is left below is the start path.
+rating) and 2b (model options) are on `dev`.
 
-[ready-for-review] 2b: model options and a processing's imagery source → `ProcessingController`
-The model combo and its option checkboxes leave `mapflow.py`: the widgets to `ProcessingView`,
-the `wd/{id}/{block}` settings round trip to `ProcessingService`, the decisions and the two signal
-connections to the controller. `show_processing_source` goes with them.
-Four of the nine methods this entry listed turned out to be dead — `check_processing_ui`,
-`get_processing_params`, and copies of `get_local_image_indices`/`get_search_providers` that
-`ProviderService` already owns — so they are deleted rather than moved.
+[ready-for-review] 2c: the table's actions, the start button, and the `template_state` seam
+The processings table's context menu, its Delete button and the details dialog go to
+`ProjectProcessingController`; the Start button's text and state to `ProcessingController`.
+`on_processings_selection_changed` dissolves — each controller subscribes to
+`itemSelectionChanged` itself, rather than one poking the other.
+`ProcessingService.template_state` is **deleted**: what it reached for is now pushed, as
+`TemplateService.templateOpened`/`templateClosed` and a new `visibleProcessingsChanged`.
+`select_processing_in_table` was dead and is deleted.
 
-[ ] 2c: start-button state, the context menu, and the `templates`-keyed queries
-`update_processing_options_menu` (the last large `self.dlg` block), `show_selected_details`,
-`on_processings_selection_changed`, `update_delete_button_state`,
-`update_start_processing_button_text/state`, `select_processing_in_table`, plus the
-`selected_template(s)` / `is_only_templates_selected` / `all_selected_templates_editable` /
-`template_to_run` cluster and the start fork in `handle_processing_submission`.
-**This is the step that deletes `ProcessingService.template_state`** (see the templates item above).
-Last of the three, and the highest blast radius.
+[ ] Move the start fork out of `ProcessingService`
+`handle_processing_submission` still forks on `template_to_run()`, and `template_to_run` still
+lives in the service because `planned_processing_selection_error` calls it and is itself called
+from `update_processing_cost` — service-internal, on no path a controller drives. Moving the fork
+means moving the cost estimate with it, which is its own step. Nothing is blocked on it: the seam
+that made this urgent is already gone.
 
-Not part of this item: `load_results`, `download_results_file`, `download_aoi_file` and
-`show_details` are `ResultService`'s, which Phase D names separately.
+Still in `mapflow.py` from this area: `load_results`, `download_results_file` and
+`download_aoi_file`, which are `ResultService`'s — Phase D names them separately. (`show_details`
+was listed with them, but it is a processings-table action rather than result loading, so it went
+to `ProjectProcessingController` with the rest of the table's actions in 2c.)
 
 [ ] Split auth from account status → `SessionService` + `AccountService`
 [ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -1,27 +1,21 @@
 from PyQt5.QtCore import QObject
-from PyQt5.QtWidgets import QMessageBox
 from qgis.core import QgsMapLayer
 
 from .. import layer_utils
-from ..service.alert_service import alert
 from ..service.aoi_service import AoiService
 from ..view.aoi_view import AoiView
-from ...schema import (BillingType,
-                       ImagerySearchParams,
-                       MyImageryParams,
-                       UserDefinedParams)
+from ...schema import BillingType
 
 
 class ProcessingController(QObject):
     """The start-processing panel: the model and its options, which AOI a processing will cover,
-    and the review/rating panel beside it.
+    the Start button's text and state, and the review/rating panel beside it.
 
     Owns the wiring only. It is the one place allowed to see both a service and a view, which is
     why the round trips below exist — the service cannot read a checkbox and the view cannot call
     a service (`spec/007_architecture.md` § Layer rules).
 
-    Provider selection, cost and the start-button state join it as the later Phase C steps
-    extract them.
+    Provider selection and cost join it as the later Phase C steps extract them.
     """
 
     def __init__(self,
@@ -40,10 +34,9 @@ class ProcessingController(QObject):
                  review_button=None,
                  processings_table=None,
                  provider_service=None,
-                 data_catalog_service=None,
-                 result_loader=None,
                  model_combo=None,
-                 model_options_changed=None):
+                 model_options_changed=None,
+                 metadata_table=None):
         super().__init__()
         self.iface = iface
         self.aoi_service = aoi_service
@@ -56,8 +49,6 @@ class ProcessingController(QObject):
         self.app_context = app_context
         self.review_dialog = review_dialog
         self.provider_service = provider_service
-        self.data_catalog_service = data_catalog_service
-        self.result_loader = result_loader
 
         self.aoi_service.aoiLayerRegistered.connect(self._on_aoi_layer_registered)
         self.aoi_service.aoiLayersChanged.connect(self.refresh_excepted_layers)
@@ -83,6 +74,15 @@ class ProcessingController(QObject):
         if processings_table is not None:
             processings_table.itemSelectionChanged.connect(self.refresh_feedback_controls)
             processings_table.cellClicked.connect(self.load_current_rating)
+            # Which template a Start would run depends on the processings-table selection, so
+            # the button follows it. `ProjectProcessingController` subscribes to the same signal
+            # for the Delete button — two regions reading one widget signal is how they stay
+            # independent (`spec/007_architecture.md`: controllers must not call each other).
+            processings_table.itemSelectionChanged.connect(
+                self.update_start_processing_button_state)
+        if metadata_table is not None:
+            # The planned-processing gate counts selected search images.
+            metadata_table.itemSelectionChanged.connect(self.update_start_processing_button_state)
 
     # ---------- the model and its options ----------
 
@@ -133,23 +133,26 @@ class ProcessingController(QObject):
         if self.app_context.billing_type == BillingType.credits:
             self.processing_service.update_processing_cost()
 
-    # ---------- a processing's imagery source ----------
+    # ---------- the start button ----------
 
-    def show_processing_source(self, processing, window) -> None:
-        """'Go to source' on the details dialog: reopen whatever imagery the processing ran on.
-        Where that lives depends on the source, which is why the fork is here rather than in any
-        one of the three regions it dispatches to."""
-        source_params = processing.params.sourceParams
-        if isinstance(source_params, ImagerySearchParams):
-            # The search table is filled from the AOI, so the download has to finish first.
-            self.result_loader.download_aoi_file(
-                pid=processing.id, callback=self.processing_service.duplicate_aoi_callback)
-        elif isinstance(source_params, MyImageryParams):
-            self.data_catalog_service.show_my_imagery_source(source_params)
-        elif isinstance(source_params, UserDefinedParams):
-            alert(self.processing_view.show_user_provider_info(source_params),
-                  icon=QMessageBox.Information)
-        window.close()
+    def update_start_processing_button_state(self, *args) -> None:
+        """Render start button text and enforce planned-processing image selection gate."""
+        self.update_start_processing_button_text()
+        error = self.processing_service.planned_processing_selection_error()
+        if error:
+            self.processing_view.disable_processing_start(reason=error, clear_area=False)
+            return
+        # No gate error: re-enable the button and clear any planned-processing reason label.
+        self.processing_view.enable_processing_start(
+            clear_reason=self.tr("Select one or more images in search results "
+                                 "to start planned processing"))
+
+    def update_start_processing_button_text(self, *args) -> None:
+        # Mirror what the start action actually does: "Start planned processing" only when a
+        # template run would happen (template selected + imagery-search source + its results open).
+        self.processing_view.set_start_button_text(
+            self.tr("Start planned processing") if self.processing_service.template_to_run()
+            else self.tr("Start processing"))
 
     # ---------- review and rating ----------
 

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -5,35 +5,50 @@ from ..app_context import AppContext
 from ..service.alert_service import alert
 from ..service.processing_service import ProcessingService
 from ..service.project_service import ProjectService
+from ...config import config
 from ...dialogs import CreateProjectDialog, UpdateProjectDialog, MainDialog, UpdateProcessingDialog
+from ...dialogs.processing_details_dialog import ProcessingDetailsDialog
+from ...schema import ImagerySearchParams, MyImageryParams, UserDefinedParams
+from ...schema.project import UserRole
 
 
 class ProjectProcessingController(QObject):
     """
-    Controller that coordinates navigation and interactions between 
+    Controller that coordinates navigation and interactions between
     Projects and Processings views.
-    
+
     Responsibilities:
     - Wire UI events to service methods
     - Handle navigation between projects and processings views
     - Connect signals between services
+    - Own what the processings table offers for the current selection: its context menu, the
+      Delete button, and the details dialog
     """
-    
+
     def __init__(self, dlg: MainDialog,
                  processing_service: ProcessingService,
                  project_service: ProjectService,
                  template_service,
-                 app_context: AppContext):
+                 app_context: AppContext,
+                 aoi_service=None,
+                 data_catalog_service=None,
+                 result_loader=None,
+                 processing_view=None):
         super().__init__()
         self.dlg = dlg
         self.processing_service = processing_service
         self.project_service = project_service
-        #: Subscribed to for "the table needs refreshing" after a template action. The in-template
-        #: view itself is still `ProcessingService`'s; when it moves, the branches in
-        #: `refresh_table` / `rerender_rows` point here instead.
+        #: Subscribed to for "the table needs refreshing" after a template action, and asked which
+        #: view the table is showing — that choice is this controller's region.
         self.template_service = template_service
         self.app_context = app_context
-        
+        #: Read for `session_active`: no AOI action may start while another edit/draw session runs.
+        self.aoi_service = aoi_service
+        #: The two other places a processing's imagery source can be reopened from.
+        self.data_catalog_service = data_catalog_service
+        self.result_loader = result_loader
+        self.processing_view = processing_view
+
         self._setup_processing_bindings()
         self._setup_project_bindings()
         self._setup_navigation()
@@ -44,6 +59,12 @@ class ProjectProcessingController(QObject):
         """Processing-specific UI connections."""
         self.dlg.startProcessing.clicked.connect(self.processing_service.start_processing)
         self.dlg.processing_update_action.triggered.connect(self.update_processing)
+        self.dlg.options_menu.aboutToShow.connect(self.update_processing_options_menu)
+        self.dlg.see_details_action.triggered.connect(self.show_selected_details)
+        # The Delete button follows the selection for a contributor. `ProcessingController`
+        # subscribes to this same signal for the Start button: two regions reading one widget
+        # signal, rather than one controller calling the other (`spec/007_architecture.md`).
+        self.dlg.processingsTable.itemSelectionChanged.connect(self.update_delete_button_state)
         # The poll tick, and every action that wants the table refreshed, come here rather than
         # going straight to a service: the table serves two views and picking between them is
         # navigation, which is this controller's region.
@@ -57,6 +78,18 @@ class ProjectProcessingController(QObject):
         self.template_service.templateRowsChanged.connect(
             self.processing_service.view.update_processing_table)
         self.template_service.pollIntervalChanged.connect(self._set_poll_interval)
+        # `ProcessingService` turns a table selection into objects, so it needs to know which view
+        # the table is showing — but it must not reach into `TemplateService` to find out. The
+        # answer is pushed to it from here, which is the region that owns the choice.
+        self.template_service.templateOpened.connect(self.processing_service.set_open_template)
+        self.template_service.templateClosed.connect(self._on_template_closed)
+        self.template_service.visibleProcessingsChanged.connect(
+            self.processing_service.set_visible_processings)
+
+    def _on_template_closed(self, _closed=None):
+        """`templateClosed` carries the template that was closed, so it cannot be connected to
+        `set_open_template` directly — 'closed' has to arrive as None."""
+        self.processing_service.set_open_template(None)
 
     # ==== WHICH VIEW THE PROCESSINGS TABLE IS SHOWING ==== #
     #
@@ -212,6 +245,145 @@ class ProjectProcessingController(QObject):
 
         # Setup processings table for the project
         self.processing_service.setup_processings_table()
+
+    # ==== WHAT THE TABLE OFFERS FOR THE CURRENT SELECTION ==== #
+
+    def update_processing_options_menu(self):
+        """Render processing options menu depending on selected row type."""
+        menu = self.dlg.options_menu
+        menu.clear()
+
+        selected_template = self.processing_service.selected_template()
+        selected_processing = self.processing_service.selected_processing()
+
+        # In-template view: AOI add/rename/delete (only for AOI rows / empty selection;
+        # a selected processing row falls through to the normal processing actions below).
+        if self.template_service.in_template_mode and not selected_processing:
+            can_edit = self.app_context.can_edit_template(self.template_service.active_template)
+            selected_aoi = self.template_service.selected_aoi()
+            # No AOI action can start while another edit/draw session is running.
+            no_session = not self.aoi_service.session_active
+            if selected_aoi:
+                self.dlg.aoi_rename_action.setEnabled(can_edit and selected_aoi.can_rename)
+                menu.addAction(self.dlg.aoi_rename_action)
+                self.dlg.aoi_delete_action.setEnabled(can_edit and selected_aoi.can_rename)
+                menu.addAction(self.dlg.aoi_delete_action)
+                # Edit the selected AOI's geometry on the map (vertex editing, in place).
+                self.dlg.aoi_update_geometry_action.setEnabled(
+                    can_edit and selected_aoi.can_rename and no_session)
+                menu.addAction(self.dlg.aoi_update_geometry_action)
+            self.dlg.aoi_add_action.setEnabled(can_edit and no_session)
+            menu.addAction(self.dlg.aoi_add_action)
+            self.dlg.aoi_draw_action.setEnabled(can_edit and no_session)
+            menu.addAction(self.dlg.aoi_draw_action)
+            return
+
+        # In-template view, a processing row is backed by the v1 TemplateProcessingSchema
+        # (flat params, no ProcessingParams) — offer only the read-only result actions, not
+        # restart/duplicate which need v2 source params.
+        if self.template_service.in_template_mode and selected_processing:
+            menu.addAction(self.dlg.save_result_action)
+            menu.addAction(self.dlg.see_details_action)
+            # Subtract this processing's already-processed area from the template's AOIs (feature 3).
+            # This edits the open template's geometry, so it follows template-edit rights.
+            if self.app_context.can_edit_template(self.template_service.active_template):
+                menu.addAction(self.dlg.exclude_from_search_action)
+            return
+
+        # Template selection: only template details action.
+        if selected_template and not selected_processing:
+            menu.addAction(self.dlg.see_details_action)
+            menu.addAction(self.dlg.see_search_results_action)
+            menu.addAction(self.dlg.see_processings_action)
+            # A contributor may edit/control their OWN templates; maintainer+ may edit any.
+            can_edit_template = self.app_context.can_edit_template(selected_template)
+            if can_edit_template:
+                menu.addAction(self.dlg.template_rename_action)
+                # NB: "Update search parameters" is offered only from *inside* the template
+                # (below), where the filter widgets reflect the template (populated on open).
+                # In this project-list selection they hold unrelated values, so it is not shown.
+            # Add pause/resume/restart based on template status. Run-state control follows the
+            # same template-edit rights (maintainer+, or a contributor on their own template).
+            can_control = can_edit_template
+            # A FAILED template can still be isActive, so check FAILED first (mirrors
+            # ProcessingTemplateDTO.table_status precedence): it offers Restart, not Pause.
+            if selected_template.is_failed:
+                self.dlg.template_restart_action.setEnabled(can_control)
+                menu.addAction(self.dlg.template_restart_action)
+            elif selected_template.isActive:
+                self.dlg.template_pause_action.setEnabled(can_control)
+                menu.addAction(self.dlg.template_pause_action)
+            else:
+                self.dlg.template_resume_action.setEnabled(can_control)
+                menu.addAction(self.dlg.template_resume_action)
+            return
+
+        # Processing selection: show processing-related actions.
+        if not selected_processing:
+            return
+
+        menu.addAction(self.dlg.save_result_action)
+        menu.addAction(self.dlg.download_aoi_action)
+        menu.addAction(self.dlg.see_details_action)
+
+        if self.app_context.user_role.can_delete_rename_review_processing:
+            menu.addAction(self.dlg.processing_update_action)
+
+        if self.app_context.user_role.can_start_processing:
+            menu.addAction(self.dlg.processing_restart_action)
+            menu.addAction(self.dlg.processing_duplicate_action)
+
+    def update_delete_button_state(self, *args):
+        """Contributor-only: the Delete button follows the selection — enabled only when every
+        selected row is a template the contributor owns (they may delete their own templates but
+        never a processing). Other roles keep the fixed, role-based state from
+        ``enable_shared_project``, so this leaves them untouched."""
+        if self.app_context.user_role != UserRole.contributor:
+            return
+        can_delete = self.processing_service.all_selected_templates_editable()
+        self.dlg.deleteProcessings.setEnabled(can_delete)
+        self.dlg.deleteProcessings.setToolTip(
+            "" if can_delete
+            else self.tr("Contributors can only delete their own planned processings"))
+
+    # ==== THE DETAILS DIALOG ==== #
+
+    def show_selected_details(self, *args):
+        """Open details based on selected entity type."""
+        template = self.processing_service.selected_template()
+        if template and not self.processing_service.selected_processing():
+            self.template_service.show_template_details(template)
+            return
+        self.show_details()
+
+    def show_details(self):
+        processing = self.processing_service.selected_processing()
+        if not processing:
+            return
+        error = None
+        if processing.messages:
+            error = processing.error_message(raw=config.SHOW_RAW_ERROR)
+        dialog = ProcessingDetailsDialog(self.dlg)
+        dialog.toSourceButton.clicked.connect(
+            lambda: self.show_processing_source(processing=processing, window=dialog))
+        dialog.setup(processing, error or None)
+        dialog.deleteLater()
+
+    def show_processing_source(self, processing, window) -> None:
+        """'Go to source' on the details dialog: reopen whatever imagery the processing ran on.
+        Where that lives depends on the source, which is why the fork is here rather than in any
+        one of the three regions it dispatches to."""
+        source_params = processing.params.sourceParams
+        if isinstance(source_params, ImagerySearchParams):
+            # The search table is filled from the AOI, so the download has to finish first.
+            self.result_loader.download_aoi_file(
+                pid=processing.id, callback=self.processing_service.duplicate_aoi_callback)
+        elif isinstance(source_params, MyImageryParams):
+            self.data_catalog_service.show_my_imagery_source(source_params)
+        elif isinstance(source_params, UserDefinedParams):
+            alert(self.processing_view.show_user_provider_info(source_params),
+                  icon=QMessageBox.Information)
+        window.close()
 
     def update_processing(self):
         processing = self.processing_service.selected_processing()

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -51,13 +51,6 @@ from ...dialogs.error_message_widget import ErrorMessageWidget
 logger = logging.getLogger(__name__)
 
 
-class _NoOpenTemplate:
-    """No template is open: the processings table is showing the project list."""
-    in_template_mode = False
-    active_template = None
-    template_processings = {}
-
-
 class ProcessingService(QObject):
     """
     A service to store & query the mapflow processings.
@@ -85,16 +78,15 @@ class ProcessingService(QObject):
     _processings_all_final = True
     _default_poll_interval = Config.PROCESSING_TABLE_REFRESH_INTERVAL * 1000
 
-    #: What is open in the processings table, when it is not the project list. Set to
-    #: `TemplateService` at wiring time; a null object until then, so this service still works
-    #: (and constructs in tests) on its own.
+    #: The template the processings table is showing, or None for the project's own list, and the
+    #: processings that table resolves its row ids against. Both are *pushed* by
+    #: `ProjectProcessingController` off `TemplateService`'s signals — this service never asks for
+    #: them, and holds no reference to the service that sends them.
     #:
-    #: This is a read-only seam, not a collaborator: three places genuinely need to know whether a
-    #: template is open — `template_to_run`, the start callback, and resolving the table selection
-    #: to objects — and all three are part of the start path, which moves to a controller in the
-    #: "Extract processing lifecycle" step. It is deliberately duck-typed and never imported, so
-    #: nothing here depends on `TemplateService` as a type and no import cycle is possible.
-    template_state = _NoOpenTemplate()
+    #: Class-level so an instance built without `__init__` (as the tests do) still answers "no
+    #: template open" rather than raising.
+    _open_template = None
+    _visible_processings = None
 
     def __init__(self,
                  http: Http,
@@ -127,6 +119,17 @@ class ProcessingService(QObject):
         self._default_poll_interval = timer_interval
         self.processing_cost = 0
         self._delete_state = {}  # Store state for template deletion callback
+
+    # ---------- what the processings table is showing (pushed, never asked for) ----------
+
+    def set_open_template(self, template) -> None:
+        """The in-template view opened (a template) or closed (None)."""
+        self._open_template = template
+
+    def set_visible_processings(self, processings) -> None:
+        """The pool a table row id resolves against: an open template's, or None for this
+        service's own `processings`."""
+        self._visible_processings = processings
 
     def load_processing_history(self):
         """
@@ -297,8 +300,8 @@ class ProcessingService(QObject):
         the single source of truth shared by the start button text and the start action,
         so they never disagree.
         """
-        if self.template_state.in_template_mode:
-            template = self.template_state.active_template
+        if self._open_template is not None:
+            template = self._open_template
         else:
             template = self.selected_template()
             if not template or self.selected_processing():
@@ -496,7 +499,7 @@ class ProcessingService(QObject):
         )
         response_data = json.loads(response.readAll().data())
         self.processing_fetch_timer.start()  # start monitoring
-        if self.template_state.in_template_mode:
+        if self._open_template is not None:
             # In a template the new processing is shown grouped UNDER its AOI. That binding
             # lives in the template's aoiDetails, which the run response does not carry, so a
             # flat optimistic add would place the processing under the "No AOI" separator until
@@ -1080,8 +1083,7 @@ class ProcessingService(QObject):
     def selected_processings(self, limit=None) -> List[ProcessingDTO]:
         pids = self.view.selected_processing_ids(limit=limit)
         # In template view the table holds the template's processings, not the project's.
-        pool = (self.template_state.template_processings
-                if self.template_state.in_template_mode else self.processings)
+        pool = self.processings if self._visible_processings is None else self._visible_processings
         # limit None will give full selection
         selected_processings = [pool[pid] for pid in filter(lambda pid: pid in pids, pool)]
         return selected_processings

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -13,9 +13,11 @@ building.
 
 `ProcessingService` is still reached for the shared `api` client, the poll timer it owns, and its
 `templates` dict — the project's template list, which its own project fetch fills. The dependency
-runs one way only: `ProcessingService` never reaches back here, because the processings table's two
-views are chosen by `ProjectProcessingController` rather than by either service. The one exception
-is documented on `ProcessingService.template_state`, a read-only seam for the start path.
+runs one way only, with no exception: `ProcessingService` never reaches back here. What it needs to
+know about an open template — which one, and which processings the table is showing — is *pushed*
+to it, as `templateOpened`/`templateClosed` and `visibleProcessingsChanged`, wired by
+`ProjectProcessingController`. The processings table's two views are that controller's to choose,
+not either service's.
 """
 import json
 import logging
@@ -95,11 +97,17 @@ class TemplateService(QObject):
     templateRowsChanged = pyqtSignal(object)
     #: The in-template view polls on its own (slower) cadence; the controller applies it.
     pollIntervalChanged = pyqtSignal(int)
+    #: The processings the table is now resolving its row ids against — this template's while it
+    #: is open, `None` for the project's own. `ProcessingService` turns a table selection into
+    #: objects and so needs the pool, but must not reach in here for it (that reach was the
+    #: `template_state` seam); it is told instead, and holds a plain dict it does not interpret.
+    visibleProcessingsChanged = pyqtSignal(object)
 
     # Class-level defaults so the mode check is safe even when callers (and tests) construct the
     # service without running __init__.
     in_template_mode = False
     active_template = None
+    _template_processings = {}
 
     def __init__(self,
                  app_context: AppContext,
@@ -141,6 +149,21 @@ class TemplateService(QObject):
         #: The open template's rows — its AOIs keyed by table id, and its processings keyed by id.
         self.template_aois = {}
         self.template_processings = {}
+
+    @property
+    def template_processings(self):
+        return self._template_processings
+
+    @template_processings.setter
+    def template_processings(self, processings):
+        """Announce the pool on every assignment.
+
+        A property rather than an emit beside each assignment: there are four of them (construct,
+        enter, exit, and the fetch callback), and whoever adds a fifth would have to know to emit.
+        Silence there would leave `ProcessingService` resolving row ids against a stale dict —
+        selecting a row in the table and getting the wrong processing, or none."""
+        self._template_processings = processings
+        self.visibleProcessingsChanged.emit(processings if self.in_template_mode else None)
 
     # ---------- plan-search gating ----------
 

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -111,6 +111,17 @@ class ProcessingView:
     def disable_processing_start(self, reason: str, clear_area: bool):
         self.dlg.disable_processing_start(reason=reason, clear_area=clear_area)
 
+    def enable_processing_start(self, clear_reason: str = "") -> None:
+        """Re-enable Start, and clear the problems label only if it is still showing
+        `clear_reason`. Anything else in there was put by another check that has not been
+        re-run, and blanking it would hide a live reason the processing cannot start."""
+        self.dlg.startProcessing.setEnabled(True)
+        if clear_reason and self.dlg.processingProblemsLabel.text() == clear_reason:
+            self.dlg.processingProblemsLabel.clear()
+
+    def set_start_button_text(self, text: str) -> None:
+        self.dlg.startProcessing.setText(text)
+
     def create_table_items(self, processing: Union[ProcessingDTO, ProcessingTemplateDTO]):
         table_items = []
         set_color = False

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -54,7 +54,7 @@ from .http import (Http,
 # Schema
 from .schema import BillingType, ProviderReturnSchema
 from .schema.catalog import ProductType
-from .schema.project import MapflowProject, UserRole
+from .schema.project import MapflowProject
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
                       MainDialog,
@@ -62,7 +62,6 @@ from .dialogs import (ErrorMessageWidget,
                       ProviderDialog,
                       ReviewDialog)
 from .dialogs.icons import plugin_icon
-from .dialogs.processing_details_dialog import ProcessingDetailsDialog
 # Providers
 from .model.provider import (create_provider,
                               DefaultProvider,
@@ -324,10 +323,9 @@ class Mapflow(QObject):
             review_button=self.dlg.reviewButton,
             processings_table=self.dlg.processingsTable,
             provider_service=self.provider_service,
-            data_catalog_service=self.data_catalog_service,
-            result_loader=self.result_loader,
             model_combo=self.dlg.modelCombo,
-            model_options_changed=self.dlg.modelOptionsChanged)
+            model_options_changed=self.dlg.modelOptionsChanged,
+            metadata_table=self.dlg.metadataTable)
 
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
@@ -338,10 +336,8 @@ class Mapflow(QObject):
                                                 search_service=self.search_service)
         # TemplateService owns the in-template view, but AoiService and PreviewService are built
         # before it (it takes AoiService as a collaborator), so their back-links are set here.
-        # ProcessingService reads it only for "is a template open" — see its `template_state`.
         self.aoi_service.template_service = self.template_service
         self.preview_service.template_service = self.template_service
-        self.processing_service.template_state = self.template_service
 
         self.template_view = TemplateView(dlg=self.dlg, iface=self.iface, config=self.config)
         self.template_controller = TemplateController(
@@ -372,7 +368,11 @@ class Mapflow(QObject):
             processing_service=self.processing_service,
             project_service=self.project_service,
             template_service=self.template_service,
-            app_context=self.app_context)
+            app_context=self.app_context,
+            aoi_service=self.aoi_service,
+            data_catalog_service=self.data_catalog_service,
+            result_loader=self.result_loader,
+            processing_view=self.processing_service.view)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -430,8 +430,9 @@ class Mapflow(QObject):
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
         self.processing_service.connect_processings_pagination()
         # Entering and leaving a template is TemplateController's entirely — it owns the layers,
-        # the search results and the view state they drive.
-        self.dlg.processingsTable.itemSelectionChanged.connect(self.on_processings_selection_changed)
+        # the search results and the view state they drive. What the processings-table selection
+        # enables is split between the two controllers that own those widgets: the Start button is
+        # ProcessingController's, the Delete button and the context menu ProjectProcessingController's.
         # Review and rating are ProcessingController's — it owns those handlers now.
         self.dlg.enable_rating(False, False)  # by default disabled
         self.dlg.enable_review(False)
@@ -445,7 +446,6 @@ class Mapflow(QObject):
 
         self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
             self.sync_table_selection_with_image_id_and_layer)
-        self.dlg.metadataTable.itemSelectionChanged.connect(self.update_start_processing_button_state)
         self.app_context.meta_layer_table_connection = None
         self.dlg.getMetadata.clicked.connect(self.handle_metadata_button_click)
         self.dlg.metadataTable.cellClicked.connect(self.on_metadata_table_cell_clicked)
@@ -567,7 +567,8 @@ class Mapflow(QObject):
     def setup_options_menu_connections(self):
         self.dlg.save_result_action.triggered.connect(self.download_results_file)
         self.dlg.download_aoi_action.triggered.connect(self.download_aoi_file)
-        self.dlg.see_details_action.triggered.connect(self.show_selected_details)
+        # 'See details' and the menu's own aboutToShow are wired by ProjectProcessingController,
+        # which owns what the processings table offers for the current selection.
         self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
         self.dlg.processing_restart_action.triggered.connect(self.processing_service.restart_processing)
         self.dlg.processing_duplicate_action.triggered.connect(self.check_dir_and_duplicate_processing)
@@ -579,142 +580,7 @@ class Mapflow(QObject):
         self.dlg.aoi_update_geometry_action.triggered.connect(
             self.aoi_service.start_update_session)
         self.dlg.aoi_draw_action.triggered.connect(self.aoi_service.start_draw_session)
-        self.dlg.options_menu.aboutToShow.connect(self.update_processing_options_menu)
         self.dlg.saveOptionsButton.setMenu(self.dlg.options_menu)
-
-    def update_processing_options_menu(self):
-        """Render processing options menu depending on selected row type."""
-        menu = self.dlg.options_menu
-        menu.clear()
-
-        selected_template = self.processing_service.selected_template()
-        selected_processing = self.processing_service.selected_processing()
-
-        # In-template view: AOI add/rename/delete (only for AOI rows / empty selection;
-        # a selected processing row falls through to the normal processing actions below).
-        if self.template_service.in_template_mode and not selected_processing:
-            can_edit = self.app_context.can_edit_template(self.template_service.active_template)
-            selected_aoi = self.template_service.selected_aoi()
-            # No AOI action can start while another edit/draw session is running.
-            no_session = not self.aoi_service.session_active
-            if selected_aoi:
-                self.dlg.aoi_rename_action.setEnabled(can_edit and selected_aoi.can_rename)
-                menu.addAction(self.dlg.aoi_rename_action)
-                self.dlg.aoi_delete_action.setEnabled(can_edit and selected_aoi.can_rename)
-                menu.addAction(self.dlg.aoi_delete_action)
-                # Edit the selected AOI's geometry on the map (vertex editing, in place).
-                self.dlg.aoi_update_geometry_action.setEnabled(
-                    can_edit and selected_aoi.can_rename and no_session)
-                menu.addAction(self.dlg.aoi_update_geometry_action)
-            self.dlg.aoi_add_action.setEnabled(can_edit and no_session)
-            menu.addAction(self.dlg.aoi_add_action)
-            self.dlg.aoi_draw_action.setEnabled(can_edit and no_session)
-            menu.addAction(self.dlg.aoi_draw_action)
-            return
-
-        # In-template view, a processing row is backed by the v1 TemplateProcessingSchema
-        # (flat params, no ProcessingParams) — offer only the read-only result actions, not
-        # restart/duplicate which need v2 source params.
-        if self.template_service.in_template_mode and selected_processing:
-            menu.addAction(self.dlg.save_result_action)
-            menu.addAction(self.dlg.see_details_action)
-            # Subtract this processing's already-processed area from the template's AOIs (feature 3).
-            # This edits the open template's geometry, so it follows template-edit rights.
-            if self.app_context.can_edit_template(self.template_service.active_template):
-                menu.addAction(self.dlg.exclude_from_search_action)
-            return
-
-        # Template selection: only template details action.
-        if selected_template and not selected_processing:
-            menu.addAction(self.dlg.see_details_action)
-            menu.addAction(self.dlg.see_search_results_action)
-            menu.addAction(self.dlg.see_processings_action)
-            # A contributor may edit/control their OWN templates; maintainer+ may edit any.
-            can_edit_template = self.app_context.can_edit_template(selected_template)
-            if can_edit_template:
-                menu.addAction(self.dlg.template_rename_action)
-                # NB: "Update search parameters" is offered only from *inside* the template
-                # (below), where the filter widgets reflect the template (populated on open).
-                # In this project-list selection they hold unrelated values, so it is not shown.
-            # Add pause/resume/restart based on template status. Run-state control follows the
-            # same template-edit rights (maintainer+, or a contributor on their own template).
-            can_control = can_edit_template
-            # A FAILED template can still be isActive, so check FAILED first (mirrors
-            # ProcessingTemplateDTO.table_status precedence): it offers Restart, not Pause.
-            if selected_template.is_failed:
-                self.dlg.template_restart_action.setEnabled(can_control)
-                menu.addAction(self.dlg.template_restart_action)
-            elif selected_template.isActive:
-                self.dlg.template_pause_action.setEnabled(can_control)
-                menu.addAction(self.dlg.template_pause_action)
-            else:
-                self.dlg.template_resume_action.setEnabled(can_control)
-                menu.addAction(self.dlg.template_resume_action)
-            return
-
-        # Processing selection: show processing-related actions.
-        if not selected_processing:
-            return
-
-        menu.addAction(self.dlg.save_result_action)
-        menu.addAction(self.dlg.download_aoi_action)
-        menu.addAction(self.dlg.see_details_action)
-
-        if self.app_context.user_role.can_delete_rename_review_processing:
-            menu.addAction(self.dlg.processing_update_action)
-
-        if self.app_context.user_role.can_start_processing:
-            menu.addAction(self.dlg.processing_restart_action)
-            menu.addAction(self.dlg.processing_duplicate_action)
-
-    def show_selected_details(self):
-        """Open details based on selected entity type."""
-        template = self.processing_service.selected_template()
-        if template and not self.processing_service.selected_processing():
-            self.template_service.show_template_details(template)
-            return
-        self.show_details()
-
-    def on_processings_selection_changed(self):
-        """Refresh the Start button for the new processings-table selection (it resolves the
-        selected template/processing itself)."""
-        self.update_start_processing_button_state()
-        self.update_delete_button_state()
-
-    def update_delete_button_state(self):
-        """Contributor-only: the Delete button follows the selection — enabled only when every
-        selected row is a template the contributor owns (they may delete their own templates but
-        never a processing). Other roles keep the fixed, role-based state from
-        ``enable_shared_project``, so this leaves them untouched."""
-        if self.app_context.user_role != UserRole.contributor:
-            return
-        can_delete = self.processing_service.all_selected_templates_editable()
-        self.dlg.deleteProcessings.setEnabled(can_delete)
-        self.dlg.deleteProcessings.setToolTip(
-            "" if can_delete
-            else self.tr("Contributors can only delete their own planned processings"))
-
-    def update_start_processing_button_text(self):
-        # Mirror what the start action actually does: "Start planned processing" only when a
-        # template run would happen (template selected + imagery-search source + its results open).
-        if self.processing_service.template_to_run():
-            self.dlg.startProcessing.setText(self.tr("Start planned processing"))
-        else:
-            self.dlg.startProcessing.setText(self.tr("Start processing"))
-
-    def update_start_processing_button_state(self):
-        """Render start button text and enforce planned-processing image selection gate."""
-        self.update_start_processing_button_text()
-        error = self.processing_service.planned_processing_selection_error()
-        if error:
-            self.dlg.disable_processing_start(reason=error, clear_area=False)
-            return
-
-        # No gate error: re-enable the button and clear any planned-processing reason label.
-        self.dlg.startProcessing.setEnabled(True)
-        planned_reason = self.tr("Select one or more images in search results to start planned processing")
-        if self.dlg.processingProblemsLabel.text() == planned_reason:
-            self.dlg.processingProblemsLabel.clear()
 
     # ==================== AOI edit/draw/add sessions ==================== #
     def add_aoi_from_layer_dialog(self):
@@ -730,21 +596,6 @@ class Mapflow(QObject):
         if not selected_ids:
             return
         self.aoi_service.add_aois_from_layers(selected_ids)
-
-    def select_processing_in_table(self, processing_id: str):
-        """Select processing row by ID and open processing details."""
-        id_column_index = self.config.PROCESSING_TABLE_ID_COLUMN_INDEX
-        id_items = self.dlg.processingsTable.findItems(str(processing_id), Qt.MatchExactly)
-
-        for item in id_items:
-            if item.column() != id_column_index:
-                continue
-            row = item.row()
-            self.dlg.processingsTable.clearSelection()
-            self.dlg.processingsTable.selectRow(row)
-            self.dlg.processingsTable.scrollToItem(item)
-            self.show_details()
-            return
 
     def apply_local_filter(self, *_) -> None:
         """Instantly filter the current search/template results by the filter widgets
@@ -1028,8 +879,8 @@ class Mapflow(QObject):
         # button label depends on the data source: refresh it here (e.g. switching an open template
         # to My imagery must drop the "planned" wording). Text only — the enabled state is managed
         # by the validation above.
-        self.update_start_processing_button_text()
-    
+        self.processing_controller.update_start_processing_button_text()
+
     def on_zoom_change(self):
         """ Set chosen zoom and update cost (if it depends on zoom for provider).
         """
@@ -1984,20 +1835,6 @@ class Mapflow(QObject):
             # it is if the upgrade is not needed, we want to save it
             self.app_context.settings.setValue('latest_reported_version', server_version)
             self.version_ok = True
-
-    def show_details(self):
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        error = None
-        if processing.messages:
-            error = processing.error_message(raw=self.config.SHOW_RAW_ERROR)
-        dialog = ProcessingDetailsDialog(self.dlg)
-        dialog.toSourceButton.clicked.connect(
-            lambda: self.processing_controller.show_processing_source(processing=processing,
-                                                                      window=dialog))
-        dialog.setup(processing, error or None)
-        dialog.deleteLater()
 
     def show_search_next_page(self):
         self._show_search_page(self.search_service.next_page_offset())

--- a/tests/qgis/test_contributor_delete_templates.py
+++ b/tests/qgis/test_contributor_delete_templates.py
@@ -2,13 +2,16 @@
 
 The Delete button is recomputed on processings-table selection change and enabled only when
 every selected row is a template the contributor owns (``all_selected_templates_editable`` +
-``Mapflow.update_delete_button_state``). Other roles keep their fixed role-based state.
+``ProjectProcessingController.update_delete_button_state``). Other roles keep their fixed
+role-based state.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.mapflow import Mapflow
+from PyQt5.QtCore import QObject
+
 from mapflow.functional.app_context import AppContext
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.schema.project import UserRole
 
@@ -62,39 +65,40 @@ def test_editable_true_for_maintainer_even_on_others_template():
     assert svc.all_selected_templates_editable() is True
 
 
-# ---- Mapflow.update_delete_button_state ----------------------------------------------------
+# ---- ProjectProcessingController.update_delete_button_state --------------------------------
 
-def _plugin(user_role, editable):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.processing_service.all_selected_templates_editable.return_value = editable
-    plugin.app_context = SimpleNamespace(user_role=user_role)
-    return plugin
+def _controller(user_role, editable):
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.dlg = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.template_service = MagicMock()
+    controller.template_service.in_template_mode = False
+    controller.processing_service.all_selected_templates_editable.return_value = editable
+    controller.app_context = SimpleNamespace(user_role=user_role)
+    return controller
 
 
 def test_delete_enabled_for_contributor_on_own_templates():
-    plugin = _plugin(UserRole.contributor, editable=True)
-    plugin.update_delete_button_state()
-    plugin.dlg.deleteProcessings.setEnabled.assert_called_once_with(True)
-    plugin.dlg.deleteProcessings.setToolTip.assert_called_once_with("")
+    controller = _controller(UserRole.contributor, editable=True)
+    controller.update_delete_button_state()
+    controller.dlg.deleteProcessings.setEnabled.assert_called_once_with(True)
+    controller.dlg.deleteProcessings.setToolTip.assert_called_once_with("")
 
 
 def test_delete_disabled_for_contributor_on_processing_or_others_template():
-    plugin = _plugin(UserRole.contributor, editable=False)
-    plugin.update_delete_button_state()
-    plugin.dlg.deleteProcessings.setEnabled.assert_called_once_with(False)
+    controller = _controller(UserRole.contributor, editable=False)
+    controller.update_delete_button_state()
+    controller.dlg.deleteProcessings.setEnabled.assert_called_once_with(False)
     # A non-empty explanatory tooltip is set.
-    (tip,), _ = plugin.dlg.deleteProcessings.setToolTip.call_args
+    (tip,), _ = controller.dlg.deleteProcessings.setToolTip.call_args
     assert tip
 
 
 def test_delete_button_untouched_for_non_contributor():
     for role in (UserRole.maintainer, UserRole.owner, UserRole.readonly):
-        plugin = _plugin(role, editable=True)
-        plugin.update_delete_button_state()
-        plugin.dlg.deleteProcessings.setEnabled.assert_not_called()
-        plugin.dlg.deleteProcessings.setToolTip.assert_not_called()
+        controller = _controller(role, editable=True)
+        controller.update_delete_button_state()
+        controller.dlg.deleteProcessings.setEnabled.assert_not_called()
+        controller.dlg.deleteProcessings.setToolTip.assert_not_called()

--- a/tests/qgis/test_model_options.py
+++ b/tests/qgis/test_model_options.py
@@ -1,4 +1,4 @@
-"""QGIS-tier tests for picking a model, its optional blocks, and reopening a processing's source.
+"""QGIS-tier tests for picking a model and its optional blocks.
 
 The split under test: `ProcessingService` owns only the settings round trip for the option
 checkboxes (`wd/{workflow_id}/{block_name}`, `spec/003_local_storage.md`), `ProcessingView` owns
@@ -8,13 +8,11 @@ without a dialog.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import pytest
 from PyQt5.QtCore import QObject
 
-from mapflow.functional.controller import processing_controller as pc_mod
 from mapflow.functional.controller.processing_controller import ProcessingController
 from mapflow.functional.service.processing_service import ProcessingService
-from mapflow.schema import BillingType, ImagerySearchParams, MyImageryParams, UserDefinedParams
+from mapflow.schema import BillingType
 from mapflow.schema.workflow_def import WorkflowDef
 
 
@@ -50,8 +48,6 @@ def _controller(wd=None, billing=BillingType.credits, user_role=None):
     controller.processing_view.selected_model_name.return_value = "Buildings"
     controller.processing_view.enabled_blocks.return_value = []
     controller.provider_service = MagicMock()
-    controller.data_catalog_service = MagicMock()
-    controller.result_loader = MagicMock()
     return controller
 
 
@@ -207,57 +203,3 @@ def test_a_role_that_may_not_start_a_processing_gets_the_options_disabled():
 
     assert controller.processing_view.show_model_options.call_args.kwargs["enabled"] is False
 
-
-# ---------- reopening the imagery a processing ran on ----------
-
-def _processing(source_params):
-    return SimpleNamespace(id="p-1", params=SimpleNamespace(sourceParams=source_params))
-
-
-def test_a_search_based_processing_downloads_its_aoi_first():
-    """The search table is filled from the AOI, so the source cannot be shown before it lands."""
-    controller = _controller()
-    window = MagicMock()
-
-    controller.show_processing_source(_processing(ImagerySearchParams(imagerySearch=None)), window)
-
-    kwargs = controller.result_loader.download_aoi_file.call_args.kwargs
-    assert kwargs["pid"] == "p-1"
-    assert kwargs["callback"] is controller.processing_service.duplicate_aoi_callback
-    window.close.assert_called_once()
-
-
-def test_a_my_imagery_processing_is_handed_to_the_catalog():
-    controller = _controller()
-    source_params = MyImageryParams(myImagery=None)
-
-    controller.show_processing_source(_processing(source_params), MagicMock())
-
-    controller.data_catalog_service.show_my_imagery_source.assert_called_once_with(source_params)
-
-
-def test_a_user_defined_source_is_described_in_a_message(monkeypatch):
-    said = []
-    monkeypatch.setattr(pc_mod, "alert", lambda message, *a, **k: said.append(message))
-    controller = _controller()
-    controller.processing_view.show_user_provider_info.return_value = "XYZ tiles at zoom 18"
-
-    controller.show_processing_source(_processing(UserDefinedParams(userDefined=None)), MagicMock())
-
-    assert said == ["XYZ tiles at zoom 18"]
-
-
-@pytest.mark.parametrize("source_params", [
-    ImagerySearchParams(imagerySearch=None),
-    MyImageryParams(myImagery=None),
-    UserDefinedParams(userDefined=None),
-    None,  # a provider-based processing: nothing to reopen
-])
-def test_the_details_window_always_closes(source_params, monkeypatch):
-    monkeypatch.setattr(pc_mod, "alert", lambda *a, **k: None)
-    controller = _controller()
-    window = MagicMock()
-
-    controller.show_processing_source(_processing(source_params), window)
-
-    window.close.assert_called_once()

--- a/tests/qgis/test_planned_processing_mode.py
+++ b/tests/qgis/test_planned_processing_mode.py
@@ -53,21 +53,27 @@ def test_template_to_run_none_when_results_not_open():
     assert _service(template, data_provider=isp, open_id="other-template").template_to_run() is None
 
 
+def _start_button_controller():
+    from PyQt5.QtCore import QObject
+    from mapflow.functional.controller.processing_controller import ProcessingController
+    controller = ProcessingController.__new__(ProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.processing_service = MagicMock()
+    controller.processing_view = MagicMock()
+    return controller
+
+
 def test_start_button_text_follows_template_to_run():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
+    controller = _start_button_controller()
 
-    plugin.processing_service.template_to_run.return_value = SimpleNamespace(id="t1")
-    plugin.update_start_processing_button_text()
-    plugin.dlg.startProcessing.setText.assert_called_with("Start planned processing")
+    controller.processing_service.template_to_run.return_value = SimpleNamespace(id="t1")
+    controller.update_start_processing_button_text()
+    controller.processing_view.set_start_button_text.assert_called_with("Start planned processing")
 
-    plugin.processing_service.template_to_run.return_value = None
-    plugin.update_start_processing_button_text()
-    plugin.dlg.startProcessing.setText.assert_called_with("Start processing")
+    controller.processing_service.template_to_run.return_value = None
+    controller.update_start_processing_button_text()
+    controller.processing_view.set_start_button_text.assert_called_with("Start processing")
 
 
 def _create_template_service():
@@ -153,9 +159,9 @@ def test_provider_change_refreshes_start_button_text():
     plugin.app_context = SimpleNamespace(data_provider=None)
     plugin.toggle_imagery_search = MagicMock()
     plugin.area_calculator_service = MagicMock()
-    plugin.update_start_processing_button_text = MagicMock()
+    plugin.processing_controller = MagicMock()
 
     plugin.on_provider_change()
 
     assert plugin.app_context.data_provider is provider
-    plugin.update_start_processing_button_text.assert_called_once()
+    plugin.processing_controller.update_start_processing_button_text.assert_called_once()

--- a/tests/qgis/test_processings_table_actions.py
+++ b/tests/qgis/test_processings_table_actions.py
@@ -1,0 +1,212 @@
+"""QGIS-tier tests for what the processings table offers, and for the pool it resolves against.
+
+Two things moved into `ProjectProcessingController` here: the details dialog (with the "go to
+source" fork that reopens a processing's imagery), and the answer to "which view is the table
+showing", which `ProcessingService` used to reach into `TemplateService` for.
+
+That reach is what these pin. `ProcessingService` is now *told* — `set_open_template` and
+`set_visible_processings` — and the push comes from `TemplateService`'s own signals, so the tests
+below drive the real services and check that the selection resolves against the right pool.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import project_processing_controller as ppc_mod
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.functional.service.template_service import TemplateService
+from mapflow.schema import ImagerySearchParams, MyImageryParams, UserDefinedParams
+
+
+def _controller():
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.dlg = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.template_service = MagicMock()
+    controller.template_service.in_template_mode = False
+    controller.aoi_service = MagicMock()
+    controller.data_catalog_service = MagicMock()
+    controller.result_loader = MagicMock()
+    controller.processing_view = MagicMock()
+    controller.app_context = SimpleNamespace(user_role=None)
+    return controller
+
+
+def _processing(source_params):
+    return SimpleNamespace(id="p-1", params=SimpleNamespace(sourceParams=source_params))
+
+
+# ---------- reopening the imagery a processing ran on ----------
+
+def test_a_search_based_processing_downloads_its_aoi_first():
+    """The search table is filled from the AOI, so the source cannot be shown before it lands."""
+    controller = _controller()
+    window = MagicMock()
+
+    controller.show_processing_source(_processing(ImagerySearchParams(imagerySearch=None)), window)
+
+    kwargs = controller.result_loader.download_aoi_file.call_args.kwargs
+    assert kwargs["pid"] == "p-1"
+    assert kwargs["callback"] is controller.processing_service.duplicate_aoi_callback
+    window.close.assert_called_once()
+
+
+def test_a_my_imagery_processing_is_handed_to_the_catalog():
+    controller = _controller()
+    source_params = MyImageryParams(myImagery=None)
+
+    controller.show_processing_source(_processing(source_params), MagicMock())
+
+    controller.data_catalog_service.show_my_imagery_source.assert_called_once_with(source_params)
+
+
+def test_a_user_defined_source_is_described_in_a_message(monkeypatch):
+    said = []
+    monkeypatch.setattr(ppc_mod, "alert", lambda message, *a, **k: said.append(message))
+    controller = _controller()
+    controller.processing_view.show_user_provider_info.return_value = "XYZ tiles at zoom 18"
+
+    controller.show_processing_source(_processing(UserDefinedParams(userDefined=None)), MagicMock())
+
+    assert said == ["XYZ tiles at zoom 18"]
+
+
+@pytest.mark.parametrize("source_params", [
+    ImagerySearchParams(imagerySearch=None),
+    MyImageryParams(myImagery=None),
+    UserDefinedParams(userDefined=None),
+    None,  # a provider-based processing: nothing to reopen
+])
+def test_the_details_window_always_closes(source_params, monkeypatch):
+    monkeypatch.setattr(ppc_mod, "alert", lambda *a, **k: None)
+    controller = _controller()
+    window = MagicMock()
+
+    controller.show_processing_source(_processing(source_params), window)
+
+    window.close.assert_called_once()
+
+
+# ---------- which entity 'See details' opens ----------
+
+def test_a_selected_template_row_opens_the_template_details():
+    controller = _controller()
+    template = SimpleNamespace(id="t-1")
+    controller.processing_service.selected_template.return_value = template
+    controller.processing_service.selected_processing.return_value = None
+
+    controller.show_selected_details()
+
+    controller.template_service.show_template_details.assert_called_once_with(template)
+
+
+def test_a_processing_row_inside_a_template_opens_the_processing_details():
+    """Both are selected in the in-template view — the processing wins, or a processing's details
+    would be unreachable there."""
+    controller = _controller()
+    controller.processing_service.selected_template.return_value = SimpleNamespace(id="t-1")
+    controller.processing_service.selected_processing.return_value = None
+    controller.show_details = MagicMock()
+
+    controller.processing_service.selected_processing.return_value = SimpleNamespace(id="p-1")
+    controller.show_selected_details()
+
+    controller.show_details.assert_called_once()
+    controller.template_service.show_template_details.assert_not_called()
+
+
+# ---------- the pool a table row resolves against ----------
+
+def _processing_service(processings):
+    service = ProcessingService.__new__(ProcessingService)
+    # Required, not decoration: a signal connected to a bound method of an uninitialised QObject
+    # silently never fires, and every assertion below would then pass for the wrong reason.
+    QObject.__init__(service)
+    service.processings = processings
+    service.view = MagicMock()
+    return service
+
+
+def _template_service():
+    service = TemplateService(app_context=MagicMock(), processing_service=MagicMock())
+    return service
+
+
+def _push(template_service, processing_service):
+    """The wiring `ProjectProcessingController` sets up, without the rest of the controller."""
+    template_service.templateOpened.connect(processing_service.set_open_template)
+    template_service.templateClosed.connect(lambda *_: processing_service.set_open_template(None))
+    template_service.visibleProcessingsChanged.connect(processing_service.set_visible_processings)
+
+
+def test_without_a_template_the_selection_resolves_against_the_projects_processings():
+    service = _processing_service({"p-1": "project processing"})
+    service.view.selected_processing_ids.return_value = ["p-1"]
+
+    assert service.selected_processings() == ["project processing"]
+
+
+def test_an_open_template_switches_the_pool_the_selection_resolves_against():
+    processing_service = _processing_service({"p-1": "project processing"})
+    processing_service.view.selected_processing_ids.return_value = ["p-2"]
+    template_service = _template_service()
+    _push(template_service, processing_service)
+
+    template_service.in_template_mode = True
+    template_service.template_processings = {"p-2": "template processing"}
+
+    assert processing_service.selected_processings() == ["template processing"]
+
+
+def test_leaving_the_template_puts_the_pool_back():
+    processing_service = _processing_service({"p-1": "project processing"})
+    template_service = _template_service()
+    _push(template_service, processing_service)
+    template_service.in_template_mode = True
+    template_service.template_processings = {"p-2": "template processing"}
+
+    template_service.in_template_mode = False
+    template_service.template_processings = {}
+
+    processing_service.view.selected_processing_ids.return_value = ["p-1"]
+    assert processing_service.selected_processings() == ["project processing"]
+
+
+def test_processings_arriving_after_the_template_was_left_do_not_come_back_as_the_pool():
+    """The fetch is in flight when the user steps out; its callback still assigns. Announcing the
+    template's processings then would leave the project list resolving against them."""
+    processing_service = _processing_service({"p-1": "project processing"})
+    template_service = _template_service()
+    _push(template_service, processing_service)
+
+    template_service.in_template_mode = False  # already left
+    template_service.template_processings = {"p-2": "late arrival"}
+
+    processing_service.view.selected_processing_ids.return_value = ["p-1"]
+    assert processing_service.selected_processings() == ["project processing"]
+
+
+def test_opening_and_closing_a_template_tells_the_processing_service_which_one():
+    processing_service = _processing_service({})
+    template_service = _template_service()
+    _push(template_service, processing_service)
+    template = SimpleNamespace(id="t-1")
+
+    template_service.templateOpened.emit(template)
+    assert processing_service._open_template is template
+
+    template_service.templateClosed.emit(template)
+    assert processing_service._open_template is None
+
+
+def test_a_service_built_without_init_reports_no_open_template():
+    """The class-level defaults matter: plenty of callers (and tests) skip __init__."""
+    service = ProcessingService.__new__(ProcessingService)
+
+    assert service._open_template is None
+    assert service._visible_processings is None

--- a/tests/qgis/test_template_aoi.py
+++ b/tests/qgis/test_template_aoi.py
@@ -330,7 +330,7 @@ def test_template_to_run_uses_active_template_in_template_mode():
     from mapflow.model.provider import ImagerySearchProvider
     service = ProcessingService.__new__(ProcessingService)
     template = SimpleNamespace(id="t-1")
-    service.template_state = SimpleNamespace(in_template_mode=True, active_template=template)
+    service.set_open_template(template)
     service.app_context = SimpleNamespace(
         data_provider=ImagerySearchProvider(proxy="https://example"),
         open_template_results_id="t-1",
@@ -342,8 +342,7 @@ def test_template_to_run_uses_active_template_in_template_mode():
 def test_template_to_run_none_when_open_results_belong_to_other_template():
     from mapflow.model.provider import ImagerySearchProvider
     service = ProcessingService.__new__(ProcessingService)
-    service.template_state = SimpleNamespace(in_template_mode=True,
-                                             active_template=SimpleNamespace(id="t-1"))
+    service.set_open_template(SimpleNamespace(id="t-1"))
     service.app_context = SimpleNamespace(
         data_provider=ImagerySearchProvider(proxy="https://example"),
         open_template_results_id="other",

--- a/tests/qgis/test_template_pause_resume_permission.py
+++ b/tests/qgis/test_template_pause_resume_permission.py
@@ -6,129 +6,132 @@ templates (``template.userId == user_id``); readonly may control none. This mirr
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.mapflow import Mapflow
+from PyQt5.QtCore import QObject
+
 from mapflow.functional.app_context import AppContext
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
 from mapflow.schema.project import UserRole
 
 OWNER_ID = "user-1"
 OTHER_ID = "user-2"
 
 
-def _plugin_with_template(user_role, is_active=True, status="READY",
-                          template_user_id=OWNER_ID, user_id=OWNER_ID):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.processing_service.selected_template.return_value = SimpleNamespace(
+def _controller_with_template(user_role, is_active=True, status="READY",
+                              template_user_id=OWNER_ID, user_id=OWNER_ID):
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.dlg = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.template_service = MagicMock()
+    controller.aoi_service = MagicMock()
+    controller.processing_service.selected_template.return_value = SimpleNamespace(
         isActive=is_active, status=status, userId=template_user_id,
         is_failed=(status or "").upper() == "FAILED",
     )
-    plugin.processing_service.selected_processing.return_value = None
+    controller.processing_service.selected_processing.return_value = None
     # Selecting a template row happens in the processings list, not inside a template.
-    plugin.template_service.in_template_mode = False
+    controller.template_service.in_template_mode = False
     app_context = AppContext()
     app_context.user_role = user_role
     app_context.user_id = user_id
-    plugin.app_context = app_context
-    return plugin
+    controller.app_context = app_context
+    return controller
 
 
 def test_pause_disabled_for_contributor_on_others_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=True,
+    controller = _controller_with_template(UserRole.contributor, is_active=True,
                                    template_user_id=OTHER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_pause_action.setEnabled.assert_called_once_with(False)
+    controller.dlg.template_pause_action.setEnabled.assert_called_once_with(False)
 
 
 def test_pause_enabled_for_contributor_on_own_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=True,
+    controller = _controller_with_template(UserRole.contributor, is_active=True,
                                    template_user_id=OWNER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_pause_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_pause_action.setEnabled.assert_called_once_with(True)
 
 
 def test_pause_enabled_for_maintainer():
-    plugin = _plugin_with_template(UserRole.maintainer, is_active=True,
+    controller = _controller_with_template(UserRole.maintainer, is_active=True,
                                    template_user_id=OTHER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_pause_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_pause_action.setEnabled.assert_called_once_with(True)
 
 
 def test_resume_disabled_for_contributor_on_others_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=False, status="READY",
+    controller = _controller_with_template(UserRole.contributor, is_active=False, status="READY",
                                    template_user_id=OTHER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_resume_action.setEnabled.assert_called_once_with(False)
+    controller.dlg.template_resume_action.setEnabled.assert_called_once_with(False)
 
 
 def test_resume_enabled_for_contributor_on_own_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=False, status="READY",
+    controller = _controller_with_template(UserRole.contributor, is_active=False, status="READY",
                                    template_user_id=OWNER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_resume_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_resume_action.setEnabled.assert_called_once_with(True)
 
 
 def test_resume_enabled_for_owner():
-    plugin = _plugin_with_template(UserRole.owner, is_active=False, status="READY",
+    controller = _controller_with_template(UserRole.owner, is_active=False, status="READY",
                                    template_user_id=OTHER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_resume_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_resume_action.setEnabled.assert_called_once_with(True)
 
 
 def test_restart_disabled_for_contributor_on_others_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=False, status="FAILED",
+    controller = _controller_with_template(UserRole.contributor, is_active=False, status="FAILED",
                                    template_user_id=OTHER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_restart_action.setEnabled.assert_called_once_with(False)
+    controller.dlg.template_restart_action.setEnabled.assert_called_once_with(False)
 
 
 def test_restart_enabled_for_contributor_on_own_template():
-    plugin = _plugin_with_template(UserRole.contributor, is_active=False, status="FAILED",
+    controller = _controller_with_template(UserRole.contributor, is_active=False, status="FAILED",
                                    template_user_id=OWNER_ID)
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_restart_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_restart_action.setEnabled.assert_called_once_with(True)
 
 
 def test_failed_but_active_template_offers_restart_not_pause():
     # A FAILED template can still be isActive; it must offer Restart (not Pause), matching
     # table_status which prioritises FAILED over isActive.
-    plugin = _plugin_with_template(UserRole.owner, is_active=True, status="FAILED")
+    controller = _controller_with_template(UserRole.owner, is_active=True, status="FAILED")
 
-    plugin.update_processing_options_menu()
+    controller.update_processing_options_menu()
 
-    plugin.dlg.template_restart_action.setEnabled.assert_called_once_with(True)
-    plugin.dlg.template_pause_action.setEnabled.assert_not_called()
-    actions = [c.args[0] for c in plugin.dlg.options_menu.addAction.call_args_list]
-    assert plugin.dlg.template_restart_action in actions
-    assert plugin.dlg.template_pause_action not in actions
+    controller.dlg.template_restart_action.setEnabled.assert_called_once_with(True)
+    controller.dlg.template_pause_action.setEnabled.assert_not_called()
+    actions = [c.args[0] for c in controller.dlg.options_menu.addAction.call_args_list]
+    assert controller.dlg.template_restart_action in actions
+    assert controller.dlg.template_pause_action not in actions
 
 
 def test_rename_shown_for_contributor_on_own_template_only():
-    own = _plugin_with_template(UserRole.contributor, template_user_id=OWNER_ID)
+    own = _controller_with_template(UserRole.contributor, template_user_id=OWNER_ID)
     own.update_processing_options_menu()
     own_actions = [c.args[0] for c in own.dlg.options_menu.addAction.call_args_list]
     assert own.dlg.template_rename_action in own_actions
 
-    other = _plugin_with_template(UserRole.contributor, template_user_id=OTHER_ID)
+    other = _controller_with_template(UserRole.contributor, template_user_id=OTHER_ID)
     other.update_processing_options_menu()
     other_actions = [c.args[0] for c in other.dlg.options_menu.addAction.call_args_list]
     assert other.dlg.template_rename_action not in other_actions

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -96,72 +96,58 @@ def test_planned_processing_selection_error_requires_selected_metadata_rows():
     assert service.planned_processing_selection_error() is None
 
 
-def test_on_processings_selection_changed_sets_planned_start_button_text():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.processing_service.selected_template.return_value = SimpleNamespace(id="template-1")
-    plugin.processing_service.selected_processing.return_value = None
-    plugin.processing_service.planned_processing_selection_error.return_value = (
-        "Select one or more images in search results to start planned processing"
-    )
-
-    plugin.app_context = SimpleNamespace(user_role=None)  # non-contributor: delete-button update is a no-op
-    plugin.on_processings_selection_changed()
-
-    plugin.dlg.startProcessing.setText.assert_called_with("Start planned processing")
-    plugin.dlg.disable_processing_start.assert_called_once()
+PLANNED_REASON = "Select one or more images in search results to start planned processing"
 
 
-def test_on_processings_selection_changed_restores_default_start_button_text_without_template():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.dlg.processingProblemsLabel.text.return_value = (
-        "Select one or more images in search results to start planned processing"
-    )
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.processing_service.selected_template.return_value = None
-    plugin.processing_service.template_to_run.return_value = None
-    plugin.processing_service.planned_processing_selection_error.return_value = None
-
-    plugin.app_context = SimpleNamespace(user_role=None)  # non-contributor: delete-button update is a no-op
-    plugin.on_processings_selection_changed()
-
-    plugin.dlg.startProcessing.setText.assert_called_with("Start processing")
-    plugin.dlg.startProcessing.setEnabled.assert_called_with(True)
-    plugin.dlg.processingProblemsLabel.clear.assert_called_once()
-    plugin.dlg.disable_processing_start.assert_not_called()
+def _start_button_controller(template_to_run=None, gate_error=None):
+    """The Start button through a real `ProcessingView`, so the assertions stay on the widgets —
+    the surface that survives a move (`spec/007_architecture.md`)."""
+    from PyQt5.QtCore import QObject
+    from mapflow.functional.controller.processing_controller import ProcessingController
+    from mapflow.functional.view.processing_view import ProcessingView
+    controller = ProcessingController.__new__(ProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.processing_service = MagicMock()
+    controller.processing_service.template_to_run.return_value = template_to_run
+    controller.processing_service.planned_processing_selection_error.return_value = gate_error
+    controller.processing_view = ProcessingView(dlg=MagicMock())
+    controller.processing_view.dlg.processingProblemsLabel.text.return_value = PLANNED_REASON
+    return controller
 
 
-def test_on_processings_selection_changed_restores_default_when_processing_selected():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.dlg = MagicMock()
-    plugin.dlg.processingProblemsLabel.text.return_value = (
-        "Select one or more images in search results to start planned processing"
-    )
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.processing_service.selected_template.return_value = SimpleNamespace(id="template-1")
-    plugin.processing_service.selected_processing.return_value = SimpleNamespace(id="processing-1")
-    # A processing is also selected -> not a planned start.
-    plugin.processing_service.template_to_run.return_value = None
-    plugin.processing_service.planned_processing_selection_error.return_value = None
+def test_selecting_a_template_row_offers_a_planned_start():
+    controller = _start_button_controller(template_to_run=SimpleNamespace(id="template-1"),
+                                          gate_error=PLANNED_REASON)
 
-    plugin.app_context = SimpleNamespace(user_role=None)  # non-contributor: delete-button update is a no-op
-    plugin.on_processings_selection_changed()
+    controller.update_start_processing_button_state()
 
-    plugin.dlg.startProcessing.setText.assert_called_with("Start processing")
-    plugin.dlg.startProcessing.setEnabled.assert_called_with(True)
-    plugin.dlg.processingProblemsLabel.clear.assert_called_once()
-    plugin.dlg.disable_processing_start.assert_not_called()
+    dlg = controller.processing_view.dlg
+    dlg.startProcessing.setText.assert_called_with("Start planned processing")
+    dlg.disable_processing_start.assert_called_once()
+
+
+def test_without_a_template_the_button_returns_to_a_plain_start():
+    controller = _start_button_controller(template_to_run=None, gate_error=None)
+
+    controller.update_start_processing_button_state()
+
+    dlg = controller.processing_view.dlg
+    dlg.startProcessing.setText.assert_called_with("Start processing")
+    dlg.startProcessing.setEnabled.assert_called_with(True)
+    dlg.processingProblemsLabel.clear.assert_called_once()
+    dlg.disable_processing_start.assert_not_called()
+
+
+def test_a_reason_from_another_check_is_not_cleared():
+    """Only the planned-start reason is this gate's to clear. Blanking anything else would hide
+    a live reason the processing cannot start — the AOI being too large, say."""
+    controller = _start_button_controller(template_to_run=None, gate_error=None)
+    controller.processing_view.dlg.processingProblemsLabel.text.return_value = "AOI is too large"
+
+    controller.update_start_processing_button_state()
+
+    controller.processing_view.dlg.processingProblemsLabel.clear.assert_not_called()
 
 
 def test_load_results_double_click_template_enters_template_view():

--- a/tests/qgis/test_template_start_processing_refresh.py
+++ b/tests/qgis/test_template_start_processing_refresh.py
@@ -33,9 +33,7 @@ def _service(in_template_mode):
     service.api = MagicMock()
     service.view = MagicMock()
     service.processing_fetch_timer = MagicMock()
-    service.template_state = SimpleNamespace(
-        in_template_mode=in_template_mode,
-        active_template=SimpleNamespace(id="tpl-1") if in_template_mode else None)
+    service.set_open_template(SimpleNamespace(id="tpl-1") if in_template_mode else None)
     service.processings = {}
     service.processings_history = MagicMock()
     return service


### PR DESCRIPTION
…he template_state seam

Last of the three lifecycle slices, and the one the earlier two were clearing the way for.

The processings table's context menu — the last large self.dlg block in mapflow.py — its Delete button and its details dialog go to ProjectProcessingController, which already owned the table and the navigation between its two views. The Start button's text and its planned-processing gate go to ProcessingController, which owns the start panel.

on_processings_selection_changed dissolves rather than moving. It existed only to fan one widget signal out to two regions, and after the split it would have been one controller calling another, which spec/007_architecture.md:167 forbids. Each controller now subscribes to itemSelectionChanged itself. Two subscribers to one signal is the shape the spec asks for, and neither has to know the other exists.

ProcessingService.template_state is deleted. It was a duck-typed read-only reach into TemplateService covering three questions: which template is open (template_to_run), whether one is open at all (the start callback), and which pool a selected row resolves against (selected_processings). All three are now pushed instead — TemplateService announces via templateOpened/templateClosed and a new visibleProcessingsChanged, and ProjectProcessingController wires them to two plain setters. The direction of knowledge is inverted: the service that knows tells, rather than the service that needs reaching in for it. Nothing here imports TemplateService, and nothing asks it anything.

template_processings became a property whose setter emits, rather than an emit beside each assignment. There are four assignments today; the fifth would be written by someone with no reason to know an emit was expected, and silence there leaves the table resolving row ids against a stale dict — clicking a row and getting the wrong processing, or none. The setter also emits None whenever the view is not in template mode, which is what makes a fetch that lands after the user stepped out harmless.

show_details and show_processing_source moved with the rest of the table's actions. This reverses where 2b put show_processing_source one MR ago: it went to ProcessingController because that is where the processing panel lived, but its caller is show_details, and once show_details became a controller method the pair would have been a controller-to-controller call. The details dialog and its "go to source" button now have a single owner.

What this step does NOT do, despite the WAL entry saying so: move the start fork out of handle_processing_submission. template_to_run cannot leave the service, because planned_processing_selection_error calls it and is itself called from update_processing_cost — service-internal, on no path a controller drives. Moving the fork means dragging the cost estimate out with it, which is a different and larger change, and nothing depends on it now that the seam itself is gone. Left as its own WAL entry with that reasoning.

select_processing_in_table was dead — no callers anywhere — and is deleted.

Two of the new tests were passing vacuously at first: the helper built ProcessingService with __new__ and no QObject.__init__, so every connect() to its bound methods silently did nothing and the pool assertions passed because the fallback is the project pool. Two sibling tests failed outright, which is the only reason it surfaced; the helper now says why the __init__ is required.

mapflow.py is down to 1930 lines and 184 self.dlg accesses, from 2993 and ~250 when Phase C began.

## Manual test
Select rows in the processings table and open the options menu (the ⋮ button): a template row offers details / search results / processings, plus rename and pause-resume-restart when you may edit it; a processing row offers save result, download AOI, details, and update/restart/duplicate per your role; inside a template, AOI rows offer add/rename/delete/edit-geometry, and a processing row there offers only save result, details and exclude-from-search. As a contributor, the Delete button enables only while every selected row is a template you own. "See details" opens the template's details for a template row and the processing's for a processing row, and "Go to source" in that dialog still reopens a search, a My Imagery item, or the provider-info message. Enter a template, select one of its processings, and open its details — the row must resolve to the right processing, which is what the pushed pool does. Start a processing inside a template: it should appear grouped under its AOI, not under "No AOI". Leave the template and select a row in the project list: it must resolve against the project's processings again. The Start button must read "Start planned processing" only with a template selected (or open), the imagery-search source, and that template's results loaded, and must be disabled with the "select one or more images" reason until you pick images. Regression surface: the two selection-driven updates now run from separate connections, so watch for either the Start button or the Delete button failing to follow the selection while the other still does. Also watch that a reason already in the problems label — an AOI that is too large, say — is not blanked when the planned-start gate passes.