### PR TITLE
refactor: extract the local filter and the account status from mapflow.py

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -50,14 +50,10 @@ Extract processing lifecycle: options, start, review, rating → existing proces
 service/controller. Split in three because it was 3× what lands cleanly in one MR; 2a (review and
 rating) and 2b (model options) are on `dev`.
 
-[ready-for-review] 2c: the table's actions, the start button, and the `template_state` seam
-The processings table's context menu, its Delete button and the details dialog go to
-`ProjectProcessingController`; the Start button's text and state to `ProcessingController`.
-`on_processings_selection_changed` dissolves — each controller subscribes to
-`itemSelectionChanged` itself, rather than one poking the other.
-`ProcessingService.template_state` is **deleted**: what it reached for is now pushed, as
-`TemplateService.templateOpened`/`templateClosed` and a new `visibleProcessingsChanged`.
-`select_processing_in_table` was dead and is deleted.
+[ready-for-review] The local filter → `SearchController`, and `/user/status` → `AccountService`
+The last large widget block in `mapflow.py` (instant filtering over fetched results) and the
+account-status polling both leave it. `SearchView` emits `tableRefilled` so the template view's
+new-image markers survive a refill without one controller calling another.
 
 [ ] Move the start fork out of `ProcessingService`
 `handle_processing_submission` still forks on `template_to_run()`, and `template_to_run` still
@@ -71,10 +67,42 @@ Still in `mapflow.py` from this area: `load_results`, `download_results_file` an
 was listed with them, but it is a processings-table action rather than result loading, so it went
 to `ProjectProcessingController` with the rest of the table's actions in 2c.)
 
-[ ] Split auth from account status → `SessionService` + `AccountService`
+[ ] Session: login, logout and the token → `SessionService`
+The account half of this item is done (`AccountService`). What is left is `read_mapflow_token`,
+`login_oauth`, `login_basic`, `logout` and `log_in_callback`. The first four are a service; the
+fifth is startup orchestration and stays in `mapflow.py` beside `on_account_status`, for the same
+reason that one did.
+
 [ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction
+Four clusters left, in the order they are worth doing:
+1. **Imagery search / metadata** → `SearchController` + `SearchView`: `get_metadata`,
+   `handle_metadata_button_click`, `on_metadata_header_clicked`, the Search/Plan and Seen
+   dropdowns, the pager, and the three `sync_*` methods that keep the table and the footprint
+   layer in step. The sync pair is the delicate part — it disconnects and reconnects both
+   directions to avoid a signal loop, so it wants its own tests before it moves.
+2. **Providers** → a new `ProviderController` (`spec/007_architecture.md:165` names it):
+   `on_provider_change`, `on_zoom_change`, add/edit/remove provider, `setup_providers`,
+   `setup_search_providers`, `toggle_imagery_search`, `replace_search_provider`.
+   `on_provider_change` ends by refreshing the Start button's text, which would be a
+   controller-to-controller call — it needs a `ProviderService` signal that
+   `ProcessingController` subscribes to.
+3. **Results loading** → `ResultService`: `load_results`, `download_results_file`,
+   `download_aoi_file`, `_open_template`. Phase D also names this one.
+4. **Output directory and the error handlers**: `select_output_directory`,
+   `check_if_output_directory_is_selected`, `prompt_output_directory`, `ensure_output_directory`,
+   `default_error_handler`, `report_http_error`.
+
 Acceptance for the phase: no `self.dlg.<widget>` access in `mapflow.py`, and the layering test's
 allowlist is empty (`spec/007_architecture.md` invariants 1 and 5).
+Note on the first half: `mapflow.py` is the composition root, so it necessarily passes widgets to
+the controllers and views it builds. Read the criterion as *no widget access outside construction
+and wiring* — behaviour that reads or writes a widget must live in a view.
+The second half is a separate body of work from anything above: it means removing the `dlg`
+constructor argument from `ProcessingService`, `ProviderService`, `ProjectService`,
+`DataCatalogService`, `AreaCalculatorService`, `ProcessingApi` and `DataCatalogApi` — about 140
+`self.dlg` accesses across the five services, each of which changes that service's constructor and
+every test that builds it. Plan it as its own sequence of MRs, one service at a time, rather than
+as the tail of this item.
 
 ### Phase D — move the packages
 

--- a/mapflow/functional/controller/search_controller.py
+++ b/mapflow/functional/controller/search_controller.py
@@ -1,7 +1,10 @@
-from PyQt5.QtCore import QObject
+from typing import List, Optional
+
+from PyQt5.QtCore import QCoreApplication, QObject
 from PyQt5.QtWidgets import QMessageBox
 
 from ..service.alert_service import alert
+from ..service.local_filter_service import FilterCriteria, LocalFilterService
 from ..service.preview_service import PreviewService
 from ..service.provider_service import ProviderService
 from ..service.search_service import SearchService
@@ -10,14 +13,13 @@ from ...model.provider import ImagerySearchProvider
 
 
 class SearchController(QObject):
-    """The imagery-search tab's preview dispatch: which image to preview, and from where.
+    """The imagery-search tab: which image to preview, and the local filter over the results
+    already fetched.
 
-    Scope today is deliberately small — the three preview-dispatch handlers and their wiring.
-    A controller may own a signal connection only when it owns the *handler*; the run, sort and
+    A controller may own a signal connection only when it owns the *handler*; the run and
     pagination handlers still call collaborators that have not been extracted (provider
-    selection, the template search loader, the local filter), so their connections stay in
-    `mapflow.py` until those handlers can move here. This grows as they do, the same way
-    `ProcessingController` started with AOI selection alone.
+    selection, the template search loader), so their connections stay in `mapflow.py` until
+    those handlers can move here.
     """
 
     def __init__(self,
@@ -26,18 +28,40 @@ class SearchController(QObject):
                  preview_service: PreviewService,
                  provider_service: ProviderService,
                  search_button,
-                 metadata_table):
+                 metadata_table,
+                 local_filter_service: LocalFilterService = None,
+                 app_context=None,
+                 widen_warning_button=None,
+                 reset_filters_button=None,
+                 clear_search_button=None):
         super().__init__()
         self.search_service = search_service
         self.search_view = search_view
         self.preview_service = preview_service
         self.provider_service = provider_service
+        self.local_filter_service = local_filter_service
+        self.app_context = app_context
+
+        #: Guards the ``metadataTableFilled`` -> ``apply_local_filter`` -> ``fill_table`` ->
+        #: ``metadataTableFilled`` loop: the re-fill below re-emits the signal that called us.
+        self._suppress_local_filter = False
+        #: The last filter outcome, so an edit that changes nothing skips the re-fill entirely.
+        self._last_unfit_set = None
+        self._last_filtered_geoms = None
+        #: What the widen (!) indicator would say, kept for its click handler.
+        self._widen_details: List[str] = []
 
         # Owned handlers, so the connections are owned here too.
         search_button.clicked.connect(self.preview_or_search)
         metadata_table.cellDoubleClicked.connect(self.preview)
         # cellClicked -> preview is rewired on every table refill (see reconnect_cell_preview).
         self.reconnect_cell_preview()
+        if widen_warning_button is not None:
+            widen_warning_button.clicked.connect(self.show_widen_details)
+        if reset_filters_button is not None:
+            reset_filters_button.clicked.connect(self.reset_filters)
+        if clear_search_button is not None:
+            clear_search_button.clicked.connect(self.clear_results)
 
     def preview(self, *args) -> None:
         """Double-click / Preview: show tiles for the selected image."""
@@ -66,6 +90,147 @@ class SearchController(QObject):
             self.preview_service.preview_catalog(self.search_view.image_id_at(row))
 
     def reconnect_cell_preview(self) -> None:
-        """Rewire the Preview-cell click after a table refill. Public because `apply_local_filter`
-        (still in `mapflow.py`) drives it — it moves here with the local filter."""
+        """Rewire the Preview-cell click after a table refill."""
         self.search_view.connect_cell_preview(self.preview_search_from_cell)
+
+    # ---------- the local filter ----------
+
+    def apply_local_filter(self, *_) -> None:
+        """Instantly filter the current search/template results by the filter widgets
+        (intersection %, cloud cover, date range) without a server request.
+
+        Unfit rows are NOT removed: they are greyed-out, made non-selectable and sorted to the
+        bottom of the page (so pages keep their expected size and the user can see that some
+        images were filtered), and their footprints are hidden from the result layer. Runs on
+        every filter-widget change and after each table (re)fill, and refreshes the widen (!)
+        indicator. Applies to both regular search and template results — templates no longer
+        filter server-side; only "Update template" persists filter values."""
+        if self._suppress_local_filter:
+            return
+        geoms = self.app_context.search_result_geojson
+        if not geoms or not geoms.get("features"):
+            self.reconnect_cell_preview()
+            self.update_widen_indicator()
+            return
+        features = geoms["features"]
+        # Compute fit/unfit from the SAME GeoJSON properties that fill the table, so the greyed
+        # rows always match the values shown in the Cloud %/Date columns (reading the OGR layer
+        # instead risked field-type mismatches, greying rows that looked fine).
+        unfit = self.local_filter_service.unfit_indices(features, self._filter_criteria())
+        # Skip the (heavier) re-fill/re-mark when the outcome is unchanged — e.g. dragging a
+        # slider through a range where no image flips fit<->unfit. Invalidated automatically when
+        # a new search replaces ``search_result_geojson`` (a different object).
+        if unfit == self._last_unfit_set and geoms is self._last_filtered_geoms:
+            self.update_widen_indicator()
+            return
+        self._last_unfit_set = set(unfit)
+        self._last_filtered_geoms = geoms
+        # Order: fit rows first, unfit rows last. WITHIN each group keep the incoming order — the
+        # server sort (sortBy/sortOrder) for both regular AND template search — so header-click
+        # sorting actually shows in the table. Built-in column sorting is OFF so the order sticks
+        # (otherwise the table would re-sort and the unfit rows jump back up).
+        fit_features = [
+            f for f in features if f.get("properties", {}).get("local_index") not in unfit]
+        unfit_features = [
+            f for f in features if f.get("properties", {}).get("local_index") in unfit]
+        reordered = dict(geoms)
+        reordered["features"] = fit_features + unfit_features
+        # Re-fill in the new order. Preview cells are generic and ``local_index`` stays bound to
+        # each feature, so table<->layer selection and footprint mapping are preserved. The
+        # nested ``metadataTableFilled`` is swallowed by the re-entrancy guard.
+        self._suppress_local_filter = True
+        try:
+            self.search_view.fill_table(reordered, sort=False)
+        finally:
+            self._suppress_local_filter = False
+        self.search_view.mark_unfit_rows(unfit)
+        self.search_service.hide_unfit_footprints(unfit)
+        self.reconnect_cell_preview()
+        self.update_widen_indicator()
+        # The fill above hid the sort arrow (setSortingEnabled(False)); put it back so it persists.
+        self.restore_sort_indicator()
+
+    def _filter_criteria(self) -> FilterCriteria:
+        """The filter widgets plus the available-provider context, as the criteria the
+        (widget-free, functional-tier tested) comparison takes."""
+        return FilterCriteria(provider_set=self._allowed_provider_set(),
+                              product_filter=self.search_view.product_category_filter(),
+                              **self.search_view.filter_widget_values())
+
+    def _allowed_provider_set(self) -> Optional[set]:
+        """Lowercased provider api-names a result may come from for the LOCAL filter, or ``None``
+        for no provider filtering (show all).
+
+        - "Search only through available providers" OFF -> ``None`` (show all).
+        - ON with specific providers checked -> just those.
+        - ON with none checked -> all providers available to the user
+          (``app_context.search_data_providers``), so results from providers the user cannot use
+          are dropped."""
+        if not self.search_view.hide_unavailable_results():
+            return None
+        checked = self.search_view.checked_provider_names()
+        if checked:
+            return {str(p).lower() for p in checked}
+        available = self.app_context.search_data_providers or []
+        return {str(p).lower() for p in available} if available else None
+
+    def restore_sort_indicator(self) -> None:
+        column = self.search_service.active_sort_column()
+        if column is not None:
+            self.search_view.show_sort_indicator(
+                column, descending=self.search_service.sort_order == "DESC")
+
+    # ---------- the widen (!) indicator ----------
+
+    def update_widen_indicator(self) -> None:
+        """Show the (!) indicator when the current filter widgets are WIDER than the filters
+        that fetched the current results (relaxing them cannot surface more images without a new
+        search); hide it otherwise. Its tooltip lists exactly which settings will not apply."""
+        self._widen_details = self._widened_filter_messages()
+        if self._widen_details:
+            self.search_view.show_widen_warning(self._format_widen_message(self._widen_details))
+        else:
+            self.search_view.hide_widen_warning()
+
+    def _widened_filter_messages(self) -> List[str]:
+        """The ways the current filter widgets are wider than the baseline that fetched the
+        current results."""
+        return self.local_filter_service.widen_messages(
+            self.search_view.filter_baseline(), self.app_context.search_baseline_filters)
+
+    @staticmethod
+    def _format_widen_message(messages: List[str]) -> str:
+        header = QCoreApplication.translate(
+            "Mapflow",
+            "These filters are wider than the last search, so they will not bring more images. "
+            "Run a new Search to fetch them:")
+        return header + "\n• " + "\n• ".join(messages)
+
+    def show_widen_details(self, *args) -> None:
+        """On click of the (!) indicator, explain which filters are wider than the fetched
+        results and therefore have no effect until a new search is run."""
+        messages = self._widen_details or self._widened_filter_messages()
+        if not messages:
+            return
+        alert(self._format_widen_message(messages), QMessageBox.Information)
+
+    def clear_results(self, *args) -> None:
+        """Drop the search results: the service owns the results and the map layer, the view the
+        table and the (!) indicator."""
+        self.search_service.clear()
+        self.search_view.clear_table()
+        self.search_view.hide_widen_warning()
+
+    # ---------- resetting the filters ----------
+
+    def reset_filters(self, *args) -> None:
+        """Reset the filter widgets to the parameters the current results were fetched with — a
+        regular search's request params, or the open template's search params. Only params that
+        were part of that request are restored; params it did not carry are left untouched."""
+        baseline = self.app_context.search_baseline_filters
+        if not baseline:
+            return
+        self.search_view.apply_baseline(baseline)
+        # Re-filter once against the restored widgets: some setters above may not have changed a
+        # value, so their change-signal would not have fired the filter on its own.
+        self.apply_local_filter()

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -79,6 +79,10 @@ class TemplateController(QObject):
         template_service.templateProcessingsLoaded.connect(self.on_template_processings_loaded)
         template_service.templateOpened.connect(self.on_template_opened)
         template_service.templateClosed.connect(self.on_template_closed)
+        # Every refill rebuilds the cells and so drops the 'new image' icons. The local filter
+        # refills on each filter change, and it is `SearchController`'s — subscribing to the
+        # view's own signal is how the markers survive without either controller calling the other.
+        self.search_view.tableRefilled.connect(self.apply_new_image_markers)
 
         self.template_service.creationBusy.connect(
             lambda busy: self.template_view.set_search_enabled(not busy))
@@ -143,9 +147,16 @@ class TemplateController(QObject):
             template_id,
             on_success=lambda: [self.template_view.set_new_image_marker(r, False) for r in new_rows])
 
-    def apply_new_image_markers(self) -> None:
-        """Show the 'new image' icon on every row whose image DTO is still new. Called after a
-        template's results (re)fill."""
+    def apply_new_image_markers(self, *args) -> None:
+        """Show the 'new image' icon on every row whose image DTO is still new. Runs after every
+        results (re)fill; only a template's results carry the flag, so a regular search's refill
+        stops here rather than walking its rows.
+
+        The test is `open_template_results_id`, not `in_template_mode`: a template's results are
+        also shown from the project list ('See search results') without entering its view, and the
+        markers belong there too."""
+        if not getattr(self.app_context, "open_template_results_id", None):
+            return
         for row in range(self.template_view.metadata_row_count()):
             image_id = self.template_view.image_id_at(row)
             self.template_view.set_new_image_marker(row, self.template_service.image_is_new(image_id))
@@ -232,7 +243,7 @@ class TemplateController(QObject):
         if template is not None:
             self.template_service.remove_template_group(str(template.name))
         self.template_service.clear_search_state()
-        self.search_view.set_widen_warning_visible(False)
+        self.search_view.hide_widen_warning()
         self.template_view.set_update_template_visible(False)
         # Drop the AOI-selection processing Area so it doesn't leak to the project view.
         self.aoi_service.clear_processing_area_selection()
@@ -266,15 +277,13 @@ class TemplateController(QObject):
         self.template_service.filter_search_by_selected_aois()
 
     def show_search_results(self, geoms) -> None:
-        """Render a page of template results: fill the table, then re-draw the new-image markers
-        the fill dropped."""
+        """Render a page of template results."""
         # Built-in Qt column sorting stays OFF: search order is server-driven (regular search) or
         # local-filter-driven (templates); only SEARCH_SORT_FIELDS headers re-sort, server-side.
         # Filling the table emits `metadataTableFilled`, which is what runs the local filter —
-        # do not call it here as well, or every page would be filtered twice.
+        # do not call it here as well, or every page would be filtered twice. The fill also emits
+        # `tableRefilled`, which is what re-draws the new-image markers it dropped.
         self.search_view.fill_table(geoms, sort=False)
-        # New images are flagged with an icon in the leftmost column (not by editing text).
-        self.apply_new_image_markers()
 
     def show_renamed_template(self, template_id: str, new_name: str) -> None:
         """Put the new name in the template's row without waiting for the refreshed list."""

--- a/mapflow/functional/service/account_service.py
+++ b/mapflow/functional/service/account_service.py
@@ -1,0 +1,177 @@
+"""What the account may do and how much of it is left: the `/user/status` conversation.
+
+One endpoint, two callers with different needs. A periodic refresh keeps the remaining limit and
+the balance current while the plugin is open. A separate poll runs right after login until the
+first response lands, because several things — the billing mode, the review workflow, the provider
+lists, the area caps — cannot be configured until it does, and the request can fail on a slow or
+offline start.
+
+Holds no widget (`spec/007_architecture.md` § Layer rules). It parses the response into
+`AppContext` and announces it; who repaints what is the listener's business. Its timers are
+parented to the service rather than to the dialog, so nothing here needs a dialog to exist.
+"""
+import json
+import logging
+from typing import Optional
+
+from PyQt5.QtCore import QObject, QTimer, pyqtSignal
+from PyQt5.QtNetwork import QNetworkReply
+
+from ..app_context import AppContext
+from ...http import Http
+from ...schema import BillingType
+
+logger = logging.getLogger(__name__)
+
+
+class AccountService(QObject):
+    """The account's status: limits, balance, billing mode, and the caps a processing is checked
+    against."""
+
+    #: A status response was parsed into `AppContext`. Carries the raw payload (the provider lists
+    #: live in it and are nobody else's to interpret) and whether this is the first response after
+    #: login — the one the startup configuration is waiting for.
+    statusApplied = pyqtSignal(dict, bool)
+    #: The balance line: credits, remaining area, or empty when neither applies.
+    balanceChanged = pyqtSignal(str)
+    #: The startup retries ran out. Carries the message for the user; emitted once, ever, because
+    #: giving up is latched.
+    startupGaveUp = pyqtSignal(str)
+
+    def __init__(self,
+                 http: Http,
+                 app_context: AppContext,
+                 config,
+                 server: str,
+                 plugin_name: str):
+        super().__init__()
+        self.http = http
+        self.app_context = app_context
+        self.config = config
+        self.server = server
+        self.plugin_name = plugin_name
+
+        #: The steady-state refresh while the plugin is open.
+        self.refresh_timer = QTimer(self)
+        self.refresh_timer.setInterval(config.USER_STATUS_UPDATE_INTERVAL * 1000)
+        self.refresh_timer.timeout.connect(self.refresh_status)
+        #: The post-login retry, on a much shorter interval, until the first response arrives.
+        self.startup_timer = QTimer(self)
+        self.startup_timer.setInterval(config.STARTUP_STATUS_RETRY_INTERVAL)
+        self.startup_timer.timeout.connect(self.request_startup_status)
+        self._startup_attempts = 0
+        self._startup_pending = False
+        self._startup_given_up = False
+
+    # ---------- the steady-state refresh ----------
+
+    def start_refreshing(self) -> None:
+        self.refresh_timer.start()
+
+    def stop_refreshing(self) -> None:
+        self.refresh_timer.stop()
+
+    def refresh_status(self) -> None:
+        self.http.get(
+            url=f'{self.server}/user/status',
+            callback=self.apply_status,
+            use_default_error_handler=False  # driven by a timer, so errors would stack up alerts
+        )
+
+    def request_status(self) -> None:
+        """A one-off refresh, for the moments the timer's cadence is too slow to wait for —
+        right after login, and after an action that spends limit."""
+        self.refresh_status()
+
+    # ---------- the post-login retry ----------
+
+    def begin_startup_polling(self) -> None:
+        """Start (or restart) the wait for the first status. Logging in again after a failed
+        start must get a full budget of retries, so the counters reset here."""
+        self._startup_attempts = 0
+        self._startup_pending = False
+        self._startup_given_up = False
+        self.startup_timer.start()
+
+    def stop_startup_polling(self) -> None:
+        self.startup_timer.stop()
+        self._startup_pending = False
+
+    def request_startup_status(self) -> None:
+        if self._startup_given_up or self._startup_pending:
+            return
+        if self._startup_attempts >= self.config.STARTUP_STATUS_MAX_ATTEMPTS:
+            # Latched rather than left to the stopped timer: giving up must be a terminal
+            # state, so a stray call cannot turn one warning into a modal per invocation.
+            self._startup_given_up = True
+            self.stop_startup_polling()
+            self.startupGaveUp.emit(
+                self.tr('Could not load your account status from Mapflow.\n\n'
+                        'Some features stay unavailable until you reconnect and '
+                        'reopen the plugin.'))
+            return
+        self._startup_attempts += 1
+        self._startup_pending = True
+        self.http.get(
+            url=f'{self.server}/user/status',
+            callback=self.startup_status_callback,
+            error_handler=self.startup_status_error_handler,
+            use_default_error_handler=False
+        )
+
+    def startup_status_callback(self, response: QNetworkReply) -> None:
+        """Apply the startup configuration carried by the first `/user/status` response.
+
+        The timer is stopped *before* the configuration runs, not after it. `apply_status` is
+        invoked through the error guard, which swallows an exception and skips the rest of the
+        callback — so a stop placed after the configuration would never run on a bad response, and
+        the plugin would re-attempt the whole setup twice a second for the rest of the session.
+        See spec/006_error_reporting.md § Consequences for new code.
+        """
+        self.stop_startup_polling()
+        self.apply_status(response, app_startup_request=True)
+
+    def startup_status_error_handler(self, response: QNetworkReply) -> None:
+        """Let the next tick retry, and surface the failure once the attempts run out."""
+        self._startup_pending = False
+        logger.warning("Startup /user/status attempt %s failed with Qt error %s",
+                       self._startup_attempts, response.error())
+
+    # ---------- the response ----------
+
+    def apply_status(self,
+                     response: QNetworkReply,
+                     app_startup_request: Optional[bool] = False) -> None:
+        """Read the account's limits and modes out of a status response and into `AppContext`."""
+        response_data = json.loads(response.readAll().data())
+        if self.plugin_name != 'Mapflow':
+            # In custom plugins we neither show the remaining limit nor check it before a start.
+            self.app_context.billing_type = BillingType.none
+        else:
+            self.app_context.billing_type = BillingType(
+                response_data.get('billingType', 'AREA').upper())
+        self.app_context.remaining_limit = int(response_data.get('remainingArea', 0)) / 1e6  # sq.km
+        self.app_context.remaining_credits = int(response_data.get('remainingCredits', 0))
+        # Planned-processing (template) area cap; absent/zero means "unknown" and disables the
+        # client-side check.
+        self.app_context.template_area_limit = int(
+            response_data.get('templateAreaLimit', 0)) / 1e6  # sq.km
+        # Immediate-search area cap; above it the user is offered a Planned Search (T8).
+        # Zero = unknown/disabled.
+        self.app_context.search_area_limit = int(
+            response_data.get('searchAreaLimit', 0)) / 1e6  # sq.km
+        self.app_context.max_aois_per_processing = int(
+            response_data.get("maxAoisPerProcessing", self.config.MAX_AOIS_PER_PROCESSING))
+        self.app_context.review_workflow_enabled = response_data.get('reviewWorkflowEnabled', False)
+
+        self.balanceChanged.emit(self.balance_message())
+        self.statusApplied.emit(response_data, bool(app_startup_request))
+
+    def balance_message(self) -> str:
+        """What the account has left, in the unit it is billed in. Empty for an account that is
+        not billed at all — there is no number to show, and '0' would read as 'nothing left'."""
+        if self.app_context.billing_type == BillingType.credits:
+            return self.tr("Your balance: {} credits").format(self.app_context.remaining_credits)
+        if self.app_context.billing_type == BillingType.area:
+            return self.tr('Remaining limit: {:.2f} sq.km').format(self.app_context.remaining_limit)
+        return ''

--- a/mapflow/functional/service/search_service.py
+++ b/mapflow/functional/service/search_service.py
@@ -239,6 +239,20 @@ class SearchService(QObject):
         except (AttributeError, RuntimeError):  # metadata layer has been deleted
             pass
 
+    def hide_unfit_footprints(self, unfit: set) -> None:
+        """Take the locally filtered-out images' footprints off the map, so what is drawn matches
+        what the results table offers. A subset string rather than deleting features: the layer is
+        rebuilt only by a new search, and widening the filter has to bring them straight back."""
+        layer = self.app_context.metadata_layer
+        try:
+            if unfit:
+                layer.setSubsetString(
+                    'local_index NOT IN ({})'.format(', '.join(str(i) for i in sorted(unfit))))
+            else:
+                layer.setSubsetString('')
+        except (RuntimeError, AttributeError):  # no layer yet, or its C++ object is gone
+            pass
+
     def clear(self) -> None:
         """Drop the results, the layer and the retained baseline. The widen (!) indicator is the
         controller's to hide — this only makes it meaningless."""

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple
 
-from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtCore import QObject, Qt, pyqtSignal
+from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtWidgets import QPushButton, QWidget
 
 from ..helpers import utc_date_from_iso
@@ -20,6 +21,12 @@ class SearchView(QObject):
     single call is what makes "the request is built from what the widgets said *then*" true by
     construction instead of by convention.
     """
+
+    #: The results table was refilled, so anything drawn per-row must be reapplied. A refill
+    #: rebuilds every cell, which drops decorations that are not part of the data — the template
+    #: view's 'new image' icons. Emitting rather than calling keeps this view ignorant of who
+    #: decorates its rows.
+    tableRefilled = pyqtSignal()
 
     def __init__(self, dlg: MainDialog, config):
         super().__init__()
@@ -223,6 +230,10 @@ class SearchView(QObject):
         """Built-in Qt sorting stays OFF by default: results already arrive in the server's sort
         order, and a header click re-requests with sortBy/sortOrder rather than sorting locally."""
         self.dlg.fill_metadata_table(geoms, sort=sort)
+        self.tableRefilled.emit()
+
+    def metadata_row_count(self) -> int:
+        return self.dlg.metadataTable.rowCount()
 
     # ---------- pagination ----------
 
@@ -234,7 +245,128 @@ class SearchView(QObject):
     def hide_pages(self) -> None:
         self.dlg.enable_search_pages(False)
 
+    # ---------- server-side sort ----------
+
+    def show_sort_indicator(self, column: int, descending: bool) -> None:
+        """Every table (re)fill calls setSortingEnabled(False), which Qt implements as hiding the
+        sort indicator — so it has to be put back after each fill, or the arrow flashes on click
+        and immediately vanishes."""
+        header = self.dlg.metadataTable.horizontalHeader()
+        header.setSortIndicatorShown(True)
+        header.setSortIndicator(column, Qt.DescendingOrder if descending else Qt.AscendingOrder)
+
+    # ---------- the local filter's widgets ----------
+
+    def filter_widget_values(self) -> dict:
+        """The filter widgets as plain values, for the criteria the local filter is computed from.
+        `off_nadir_filtered` is False at the full 0-30 range, which means "no off-nadir filter"
+        rather than "0 to 30" — an image with an unknown angle passes the first and fails the
+        second."""
+        min_off_nadir, max_off_nadir = self.dlg.off_nadir_range()
+        return {
+            "date_from": self.dlg.metadataFrom.date(),
+            "date_to": self.dlg.metadataTo.date(),
+            "max_cloud_cover": self.dlg.maxCloudCover.value(),
+            "min_intersection": self.dlg.minIntersection.value(),
+            "off_nadir_filtered": not self.dlg.off_nadir_is_full_range(),
+            "min_off_nadir": min_off_nadir,
+            "max_off_nadir": max_off_nadir,
+        }
+
+    def hide_unavailable_results(self) -> bool:
+        return self.dlg.hideUnavailableResults.isChecked()
+
+    def checked_provider_names(self) -> list:
+        """The provider api-names ticked in the combo, whether or not they are being applied."""
+        return self.dlg.searchProvidersCombo.checkedItemsData()
+
+    def product_category_filter(self) -> Optional[set]:
+        """The product categories to KEEP ({'MOSAIC'} or {'IMAGE'}), or ``None`` when both or
+        neither Mosaic/Image is checked (= all, no filter)."""
+        mosaic = self.dlg.searchMosaicCheckBox.isChecked()
+        image = self.dlg.searchImageCheckBox.isChecked()
+        if mosaic == image:  # both or neither -> show all
+            return None
+        return {ProductType.mosaic.upper()} if mosaic else {ProductType.image.upper()}
+
+    def mark_unfit_rows(self, unfit: set) -> None:
+        """Grey-out and disable (non-selectable) the rows whose image was filtered out; restore
+        fit rows to normal. The row order already places the unfit rows last."""
+        grey_text = QBrush(QColor(150, 150, 150))
+        grey_bg = QBrush(QColor(235, 235, 235))
+        table = self.dlg.metadataTable
+        local_col = self.config.LOCAL_INDEX_COLUMN
+        for row in range(table.rowCount()):
+            key = table.item(row, local_col)
+            if key is None:
+                continue
+            try:
+                is_unfit = int(key.text()) in unfit
+            except (TypeError, ValueError):
+                continue
+            for col in range(table.columnCount()):
+                item = table.item(row, col)
+                if item is None:
+                    continue
+                if is_unfit:
+                    item.setForeground(grey_text)
+                    item.setBackground(grey_bg)
+                    item.setFlags(item.flags() & ~Qt.ItemIsSelectable & ~Qt.ItemIsEnabled)
+                else:
+                    item.setForeground(QBrush())
+                    item.setBackground(QBrush())
+                    item.setFlags(item.flags() | Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+
     # ---------- the widen (!) indicator ----------
 
-    def set_widen_warning_visible(self, visible: bool) -> None:
-        self.dlg.searchWidenWarning.setVisible(visible)
+    def show_widen_warning(self, tooltip: str) -> None:
+        self.dlg.searchWidenWarning.setToolTip(tooltip)
+        self.dlg.searchWidenWarning.setVisible(True)
+
+    def hide_widen_warning(self) -> None:
+        self.dlg.searchWidenWarning.setToolTip("")
+        self.dlg.searchWidenWarning.setVisible(False)
+
+    # ---------- the baseline the widen indicator compares against ----------
+
+    def filter_baseline(self) -> dict:
+        """Snapshot of the filter widgets, stored at search time as what later edits are compared
+        against."""
+        off_nadir_lo, off_nadir_hi = self.dlg.off_nadir_range()
+        return {
+            "date_from": self.dlg.metadataFrom.date(),
+            "date_to": self.dlg.metadataTo.date(),
+            "max_cloud_cover": self.dlg.maxCloudCover.value(),
+            "min_intersection": self.dlg.minIntersection.value(),
+            "min_off_nadir": off_nadir_lo,
+            "max_off_nadir": off_nadir_hi,
+            "product_types": [str(pt).upper() for pt in self.product_types()],
+            "data_providers": self.search_providers() or [],
+            "hide_unavailable": self.dlg.hideUnavailableResults.isChecked(),
+        }
+
+    def apply_baseline(self, baseline: dict) -> None:
+        """Put the filter widgets back to a stored baseline. Only keys the baseline actually
+        carries are restored — a search that did not send a filter must not have that filter
+        invented here."""
+        if baseline.get("date_from") is not None:
+            self.dlg.metadataFrom.setDate(baseline["date_from"])
+        if baseline.get("date_to") is not None:
+            self.dlg.metadataTo.setDate(baseline["date_to"])
+        if baseline.get("max_cloud_cover") is not None:
+            self.dlg.maxCloudCover.setValue(int(round(baseline["max_cloud_cover"])))
+        if baseline.get("min_intersection") is not None:
+            self.dlg.minIntersection.setValue(int(round(baseline["min_intersection"])))
+        base_off_lo = baseline.get("min_off_nadir")
+        base_off_hi = baseline.get("max_off_nadir")
+        if base_off_lo is not None and base_off_hi is not None:
+            self.dlg.set_off_nadir_range(int(round(base_off_lo)), int(round(base_off_hi)))
+        products = baseline.get("product_types")
+        if products is not None:
+            self.dlg.searchMosaicCheckBox.setChecked(ProductType.mosaic.upper() in products)
+            self.dlg.searchImageCheckBox.setChecked(ProductType.image.upper() in products)
+        if baseline.get("hide_unavailable") is not None:
+            self.dlg.hideUnavailableResults.setChecked(bool(baseline["hide_unavailable"]))
+        providers = baseline.get("data_providers")
+        if providers is not None:
+            self.apply_providers_to_combo(providers)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -43,6 +43,7 @@ from .functional.service import (DataCatalogService,
                                  ProcessingService,
                                  ProjectService,
                                  ProviderService)
+from .functional.service.account_service import AccountService
 from .functional.service.alert_service import AlertService, alert
 from .functional.service.area_calculator_service import AreaCalculatorService
 # HTTP
@@ -50,7 +51,7 @@ from .http import (Http,
                    api_message_parser,
                    get_error_report_body)
 # Schema
-from .schema import BillingType, ProviderReturnSchema
+from .schema import ProviderReturnSchema
 from .schema.project import MapflowProject
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
@@ -148,20 +149,18 @@ class Mapflow(QObject):
         # Restore directory from settings
         self.dlg.outputDirectory.setText(self.app_context.settings.value('outputDir'))
 
-        # ========== 4. CREATE TIMERS ==========
-        # Poll user status to get limits
-        self.user_status_update_timer = QTimer(self.dlg)
-        self.user_status_update_timer.setInterval(self.config.USER_STATUS_UPDATE_INTERVAL * 1000)
-        self.user_status_update_timer.timeout.connect(self.refresh_status)
-        # Retries /user/status until the response that configures the plugin arrives.
-        # A tick is skipped while a request is still in flight, so a slow or unreachable
-        # server produces one outstanding request rather than two per second.
-        self.app_startup_user_update_timer = QTimer(self.dlg)
-        self.app_startup_user_update_timer.setInterval(self.config.STARTUP_STATUS_RETRY_INTERVAL)
-        self.app_startup_user_update_timer.timeout.connect(self.first_status_request)
-        self._startup_status_attempts = 0
-        self._startup_status_pending = False
-        self._startup_status_given_up = False
+        # ========== 4. ACCOUNT STATUS ==========
+        # Owns both /user/status polls and their timers: the steady-state refresh for the limits
+        # and balance, and the post-login retry that the startup configuration below waits for.
+        self.account_service = AccountService(http=self.http,
+                                              app_context=self.app_context,
+                                              config=self.config,
+                                              server=self.server,
+                                              plugin_name=self.plugin_name)
+        self.account_service.balanceChanged.connect(self.dlg.balanceLabel.setText)
+        self.account_service.statusApplied.connect(self.on_account_status)
+        self.account_service.startupGaveUp.connect(
+            lambda message: self.alert(message, icon=QMessageBox.Warning))
 
         # ========== 5. SETUP TEMP DIRECTORY ==========
         # AlertService must exist before setup_tempdir: an unavailable working directory below (and
@@ -489,60 +488,32 @@ class Mapflow(QObject):
         self.processing_controller.refresh_excepted_layers()
         self.app_context.settings.setValue('useAllVectorLayers', str(self.dlg.useAllVectorLayers.isChecked()))
 
-    def refresh_status(self):
-        self.http.get(
-            url=f'{self.server}/user/status',
-            callback=self.set_processing_limit,
-            use_default_error_handler=False  # ignore errors to prevent repetitive alerts
-        )
+    def on_account_status(self, response_data: dict, app_startup_request: bool) -> None:
+        """Configure the plugin from an account-status response.
 
-    def first_status_request(self):
-        if self._startup_status_given_up or self._startup_status_pending:
-            return
-        if self._startup_status_attempts >= self.config.STARTUP_STATUS_MAX_ATTEMPTS:
-            # Latched rather than left to the stopped timer: giving up must be a terminal
-            # state, so a stray call cannot turn one warning into a modal per invocation.
-            self._startup_status_given_up = True
-            self.stop_startup_status_polling()
-            self.alert(self.tr('Could not load your account status from Mapflow.\n\n'
-                               'Some features stay unavailable until you reconnect and '
-                               'reopen the plugin.'),
-                       icon=QMessageBox.Warning)
-            return
-        self._startup_status_attempts += 1
-        self._startup_status_pending = True
-        self.http.get(
-            url=f'{self.server}/user/status',
-            callback=self.first_status_callback,
-            error_handler=self.first_status_error_handler,
-            use_default_error_handler=False
-        )
-
-    def stop_startup_status_polling(self):
-        self.app_startup_user_update_timer.stop()
-        self._startup_status_pending = False
-
-    def first_status_callback(self, response: QNetworkReply) -> None:
-        """Apply the startup configuration carried by the first /user/status response.
-
-        The timer is stopped *before* the configuration runs, not after it. `set_processing_limit`
-        is invoked through the error guard, which swallows an exception and skips the rest of the
-        callback — so a stop placed after the configuration would never run on a bad response, and
-        the plugin would re-attempt the whole setup twice a second for the rest of the session.
-        See spec/006_error_reporting.md § Consequences for new code.
+        Only the first response after login configures anything: everything below depends on the
+        billing mode, the review workflow and the provider lists, none of which are known before
+        it. Later refreshes only update the limits `AccountService` has already applied.
         """
-        self.stop_startup_status_polling()
-        self.set_processing_limit(response, app_startup_request=True)
+        if not app_startup_request:
+            return
         # Storage quota for My Imagery: needed once at startup, and refreshed later by
         # mosaicsUpdated. Issuing it per retry would mean a second endpoint polled at the
         # retry interval, with its own error dialog on every failed tick.
         self.data_catalog_service.get_user_limit()
-
-    def first_status_error_handler(self, response: QNetworkReply) -> None:
-        """Let the next tick retry, and surface the failure once the attempts run out."""
-        self._startup_status_pending = False
-        logger.warning("Startup /user/status attempt %s failed with Qt error %s",
-                       self._startup_status_attempts, response.error())
+        self.processing_service.update_processing_cost()
+        self.dlg.setup_for_billing(self.app_context.billing_type)
+        self.dlg.setup_for_review(self.app_context.review_workflow_enabled)
+        self.dlg.modelCombo.activated.emit(self.dlg.modelCombo.currentIndex())
+        self.setup_providers(response_data.get("dataProviders") or [])
+        self.setup_search_providers(response_data.get("searchDataProviders") or [])
+        self.on_provider_change()
+        # Open processings or projects table
+        if self.app_context.current_project:
+            self.project_processing_controller.show_processings()
+        else:
+            self.project_processing_controller.show_projects()
+            self.project_service.setup_project_change_rights()
 
     def setup_add_layer_menu(self):
         self.add_layer_menu.addAction(self.draw_aoi)
@@ -1081,57 +1052,6 @@ class Mapflow(QObject):
             #self.dlg.metadataTable.selectRow(items[0].row())
         # Redundant since imageId is temorary removed
 
-    def update_processing_limit(self) -> None:
-        """Set the user's processing limit as reported by Mapflow."""
-        self.http.get(
-            url=f'{self.server}/user/status',
-            callback=self.set_processing_limit,
-            use_default_error_handler=False  # it is done by timer, so we ignore errors to avoid stacking
-        )
-
-    def set_processing_limit(self, response: QNetworkReply,
-                             app_startup_request: Optional[bool] = False) -> None:
-        response_data = json.loads(response.readAll().data())
-        if self.plugin_name != 'Mapflow':
-            # In custom plugins, we don't show the remaining limit and do not check it for the processing
-            self.app_context.billing_type = BillingType.none
-        else:
-            # get billing type, by default it is area
-            self.app_context.billing_type = BillingType(response_data.get('billingType', 'AREA').upper())
-        # get limits
-        self.app_context.remaining_limit = int(response_data.get('remainingArea', 0)) / 1e6  # convert into sq.km
-        self.app_context.remaining_credits = int(response_data.get('remainingCredits', 0))
-        # Planned-processing (template) area cap; absent/zero means "unknown" and disables the client-side check
-        self.app_context.template_area_limit = int(response_data.get('templateAreaLimit', 0)) / 1e6  # convert into sq.km
-        # Immediate-search area cap; above it the user is offered a Planned Search (T8). Zero = unknown/disabled.
-        self.app_context.search_area_limit = int(response_data.get('searchAreaLimit', 0)) / 1e6  # convert into sq.km
-        self.app_context.max_aois_per_processing = int(response_data.get("maxAoisPerProcessing",
-                                                             self.config.MAX_AOIS_PER_PROCESSING))
-        if self.app_context.billing_type == BillingType.credits:
-            balance_str = self.tr("Your balance: {} credits").format(self.app_context.remaining_credits)
-        elif self.app_context.billing_type == BillingType.area:  # area
-            balance_str = self.tr('Remaining limit: {:.2f} sq.km').format(self.app_context.remaining_limit)
-        else:  # BillingType.none
-            balance_str = ''
-
-        self.app_context.review_workflow_enabled = response_data.get('reviewWorkflowEnabled', False)
-        self.dlg.balanceLabel.setText(balance_str)
-
-        if app_startup_request:
-            self.processing_service.update_processing_cost()
-            self.dlg.setup_for_billing(self.app_context.billing_type)
-            self.dlg.setup_for_review(self.app_context.review_workflow_enabled)
-            self.dlg.modelCombo.activated.emit(self.dlg.modelCombo.currentIndex())
-            self.setup_providers(response_data.get("dataProviders") or [])
-            self.setup_search_providers(response_data.get("searchDataProviders") or [])
-            self.on_provider_change()
-            # Open processings or projects table
-            if self.app_context.current_project:
-                self.project_processing_controller.show_processings()
-            else:
-                self.project_processing_controller.show_projects()
-                self.project_service.setup_project_change_rights()
-
     def _register_provider_min_areas(self, providers_data):
         """Map provider name -> minimum AOI area (sq km) from /user/status provider data.
 
@@ -1278,7 +1198,7 @@ class Mapflow(QObject):
     def unload(self) -> None:
         """Remove the plugin icon & toolbar from QGIS GUI."""
         self.processing_service.stop()
-        self.user_status_update_timer.stop()
+        self.account_service.stop_refreshing()
         self.iface.removeCustomActionForLayerType(self.add_layer_action)
         self.iface.removeCustomActionForLayerType(self.remove_layer_action)
         for dlg in self.dlg, self.dlg_login, self.dlg_provider:
@@ -1366,8 +1286,8 @@ class Mapflow(QObject):
         # set token to empty to delete it from settings
         self.app_context.settings.setValue('token', '')
         self.processing_service.processing_fetch_timer.stop()
-        self.user_status_update_timer.stop()
-        self.stop_startup_status_polling()
+        self.account_service.stop_refreshing()
+        self.account_service.stop_startup_polling()
         self.app_context.logged_in = False
         self.http.logout()
         self.dlg.close()
@@ -1499,7 +1419,7 @@ class Mapflow(QObject):
         if default_project.user is not None:
             self.app_context.user_id = default_project.user.id
 
-        self.update_processing_limit()
+        self.account_service.request_status()
         # We have different behavior for admin as he has access to all processings
         self.is_admin = userinfo.get("role") == "ADMIN"
 
@@ -1526,12 +1446,8 @@ class Mapflow(QObject):
             self.data_catalog_service.get_mosaics()
         self.dlg.setup_for_billing(self.app_context.billing_type)
         self.dlg.show()
-        self.user_status_update_timer.start()
-        # Logging in again after a failed startup must get a full budget of retries.
-        self._startup_status_attempts = 0
-        self._startup_status_pending = False
-        self._startup_status_given_up = False
-        self.app_startup_user_update_timer.start()
+        self.account_service.start_refreshing()
+        self.account_service.begin_startup_polling()
 
     def check_plugin_version_callback(self, response: QNetworkReply) -> None:
         """Inspect the plugin version backend expects and show a warning if it is incompatible w/ the plugin.
@@ -1655,8 +1571,8 @@ class Mapflow(QObject):
             # with any auth method
             self.dlg.show()
             self.dlg.raise_()
-            self.update_processing_limit()
-            self.user_status_update_timer.start()
+            self.account_service.request_status()
+            self.account_service.start_refreshing()
             return
 
         token = self.app_context.settings.value('token')

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -11,15 +11,13 @@ from PyQt5.QtCore import (
     QCoreApplication, QDate, QObject, Qt,
     QTimer, QTranslator
 )
-from PyQt5.QtGui import QBrush, QColor
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
     QAbstractItemView, QAction, QApplication, QFileDialog,
     QMenu, QMessageBox, QWidget, QToolButton
 )
 from qgis.core import (
-    QgsDistanceArea, QgsMapLayer, QgsMapLayerType,
-    QgsProject, QgsVectorLayer
+    QgsDistanceArea, QgsMapLayer, QgsMapLayerType, QgsProject
 )
 
 from .config import Config, ConfigColumns
@@ -36,7 +34,7 @@ from .functional.controller.template_controller import TemplateController
 from .functional.service.template_service import TemplateService
 from .functional.view.template_view import TemplateView
 from .functional.service.aoi_service import AoiService
-from .functional.service.local_filter_service import FilterCriteria, LocalFilterService
+from .functional.service.local_filter_service import LocalFilterService
 from .functional.service.preview_service import PreviewService
 from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
@@ -53,7 +51,6 @@ from .http import (Http,
                    get_error_report_body)
 # Schema
 from .schema import BillingType, ProviderReturnSchema
-from .schema.catalog import ProductType
 from .schema.project import MapflowProject
 # Dialogs
 from .dialogs import (ErrorMessageWidget,
@@ -75,16 +72,6 @@ logger = logging.getLogger(__name__)
 
 class Mapflow(QObject):
     """This class represents the plugin. It is instantiated by QGIS."""
-
-    # Guards against the ``metadataTableFilled`` -> ``apply_local_filter`` -> ``fill_metadata_table``
-    # -> ``metadataTableFilled`` re-entrancy: the local filter re-fills the table itself, so the
-    # nested fill must not trigger another filter pass.
-    _suppress_local_filter = False
-    # Last local-filter outcome, so a slider drag that doesn't flip any image skips the re-fill.
-    _last_unfit_set = None
-    _last_filtered_geoms = None
-    # Cached widen-warning messages backing the (!) indicator's click handler.
-    _widen_details = None
 
     def __init__(self, iface) -> None:
         """Initialize the plugin.
@@ -292,13 +279,19 @@ class Mapflow(QObject):
         self.search_service.metadataLayerReady.connect(self._on_metadata_layer_ready)
         self.search_service.pagerChanged.connect(self.search_view.show_pages)
         self.search_service.pagerHidden.connect(self.search_view.hide_pages)
-        # Owns the preview-dispatch handlers (search button, cell/double click) and their wiring.
+        # Owns the preview-dispatch handlers (search button, cell/double click), the local filter
+        # over the fetched results, and their wiring.
         self.search_controller = SearchController(search_service=self.search_service,
                                                   search_view=self.search_view,
                                                   preview_service=self.preview_service,
                                                   provider_service=self.provider_service,
                                                   search_button=self.dlg.searchImageryButton,
-                                                  metadata_table=self.dlg.metadataTable)
+                                                  metadata_table=self.dlg.metadataTable,
+                                                  local_filter_service=self.local_filter_service,
+                                                  app_context=self.app_context,
+                                                  widen_warning_button=self.dlg.searchWidenWarning,
+                                                  reset_filters_button=self.dlg.resetSearchFilters,
+                                                  clear_search_button=self.dlg.clearSearch)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
@@ -451,27 +444,25 @@ class Mapflow(QObject):
         self.dlg.metadataTable.cellClicked.connect(self.on_metadata_table_cell_clicked)
         self.dlg.metadataTable.horizontalHeader().sectionClicked.connect(self.on_metadata_header_clicked)
         self.dlg.rasterSourceChanged.connect(self.on_provider_change)
-        self.dlg.clearSearch.clicked.connect(self.clear_metadata)
-        self.dlg.metadataTableFilled.connect(self.apply_local_filter)
+        self.dlg.metadataTableFilled.connect(self.search_controller.apply_local_filter)
         # Instant local filtering: changing a filter widget re-filters the already-fetched
         # results in place (no server request), for both regular search and templates.
-        self.dlg.minIntersection.valueChanged.connect(self.apply_local_filter)
-        self.dlg.maxCloudCover.valueChanged.connect(self.apply_local_filter)
-        self.dlg.offNadirSlider.rangeChanged.connect(self.apply_local_filter)
-        self.dlg.metadataFrom.dateChanged.connect(self.apply_local_filter)
-        self.dlg.metadataTo.dateChanged.connect(self.apply_local_filter)
-        # Provider selection/availability and product type (Mosaic/Image) are local filters too;
-        # re-filter when any of them change.
-        self.dlg.searchProvidersCombo.checkedItemsChanged.connect(self.apply_local_filter)
-        self.dlg.hideUnavailableResults.toggled.connect(self.apply_local_filter)
-        self.dlg.searchMosaicCheckBox.toggled.connect(self.apply_local_filter)
-        self.dlg.searchImageCheckBox.toggled.connect(self.apply_local_filter)
-        self.dlg.resetSearchFilters.clicked.connect(self.reset_filters)
+        # The handler and the Reset/(!) buttons are SearchController's; only these
+        # widget-change connections stay here, because the widgets are the dialog's.
+        for signal in (self.dlg.minIntersection.valueChanged,
+                       self.dlg.maxCloudCover.valueChanged,
+                       self.dlg.offNadirSlider.rangeChanged,
+                       self.dlg.metadataFrom.dateChanged,
+                       self.dlg.metadataTo.dateChanged,
+                       # Provider selection/availability and product type (Mosaic/Image) are
+                       # local filters too; re-filter when any of them change.
+                       self.dlg.searchProvidersCombo.checkedItemsChanged,
+                       self.dlg.hideUnavailableResults.toggled,
+                       self.dlg.searchMosaicCheckBox.toggled,
+                       self.dlg.searchImageCheckBox.toggled):
+            signal.connect(self.search_controller.apply_local_filter)
         self.dlg.searchRightButton.clicked.connect(self.show_search_next_page)
         self.dlg.searchLeftButton.clicked.connect(self.show_search_previous_page)
-        # Repurposed Filter button: now the widen-warning (!) indicator (shown only when the
-        # current filters are wider than what was fetched); clicking it explains what won't apply.
-        self.dlg.searchWidenWarning.clicked.connect(self.show_widen_details)
         self.setup_metadata_search_dropdown()
         self.setup_metadata_seen_dropdown()
 
@@ -596,239 +587,6 @@ class Mapflow(QObject):
         if not selected_ids:
             return
         self.aoi_service.add_aois_from_layers(selected_ids)
-
-    def apply_local_filter(self, *_) -> None:
-        """Instantly filter the current search/template results by the filter widgets
-        (intersection %, cloud cover, date range) without a server request.
-
-        Unfit rows are NOT removed: they are greyed-out, made non-selectable and sorted to the
-        bottom of the page (so pages keep their expected size and the user can see that some
-        images were filtered), and their footprints are hidden from the result layer. Runs on
-        every filter-widget change and after each table (re)fill, and refreshes the widen (!)
-        indicator. Applies to both regular search and template results — templates no longer
-        filter server-side; only "Update template" persists filter values."""
-        if self._suppress_local_filter:
-            return
-        geoms = self.app_context.search_result_geojson
-        if not geoms or not geoms.get("features"):
-            self.search_controller.reconnect_cell_preview()
-            self._update_widen_indicator()
-            return
-        features = geoms["features"]
-        # Compute fit/unfit from the SAME GeoJSON properties that fill the table, so the greyed
-        # rows always match the values shown in the Cloud %/Date columns (reading the OGR layer
-        # instead risked field-type mismatches, greying rows that looked fine).
-        unfit = self._unfit_local_indices(features)
-        # Skip the (heavier) re-fill/re-mark when the outcome is unchanged — e.g. dragging a
-        # slider through a range where no image flips fit<->unfit. Invalidated automatically when
-        # a new search replaces ``search_result_geojson`` (a different object).
-        if unfit == self._last_unfit_set and geoms is self._last_filtered_geoms:
-            self._update_widen_indicator()
-            return
-        self._last_unfit_set = set(unfit)
-        self._last_filtered_geoms = geoms
-        # Order: fit rows first, unfit rows last. WITHIN each group keep the incoming order — the
-        # server sort (sortBy/sortOrder) for both regular AND template search — so header-click
-        # sorting actually shows in the table. Built-in column sorting is OFF so the order sticks
-        # (otherwise the table would re-sort and the unfit rows jump back up).
-        fit_features = [
-            f for f in features if f.get("properties", {}).get("local_index") not in unfit]
-        unfit_features = [
-            f for f in features if f.get("properties", {}).get("local_index") in unfit]
-        reordered = dict(geoms)
-        reordered["features"] = fit_features + unfit_features
-        # Re-fill in the new order. Preview cells are generic and ``local_index`` stays bound to
-        # each feature, so table<->layer selection and footprint mapping are preserved. The
-        # nested ``metadataTableFilled`` is swallowed by the re-entrancy guard.
-        self._suppress_local_filter = True
-        try:
-            self.dlg.fill_metadata_table(reordered, sort=False)
-        finally:
-            self._suppress_local_filter = False
-        # Re-filling drops the per-row 'new image' icons; restore them for template results.
-        if getattr(self.template_service, "in_template_mode", False):
-            self.template_controller.apply_new_image_markers()
-        self._mark_unfit_rows(unfit)
-        self._hide_unfit_footprints(getattr(self.app_context, "metadata_layer", None), unfit)
-        self.search_controller.reconnect_cell_preview()
-        self._update_widen_indicator()
-        # The fill above hid the sort arrow (setSortingEnabled(False)); put it back so it persists.
-        self._restore_search_sort_indicator()
-
-    def _unfit_local_indices(self, features: list) -> set:
-        """Which results fail the current filter, computed by `LocalFilterService`. This wrapper
-        assembles the criteria from the widgets and `app_context`; the computation itself is
-        widget-free and functional-tier tested."""
-        return self.local_filter_service.unfit_indices(features, self._filter_criteria())
-
-    def _filter_criteria(self) -> FilterCriteria:
-        """The filter widgets + available-provider context, resolved to a `FilterCriteria`."""
-        min_off_nadir, max_off_nadir = self.dlg.off_nadir_range()
-        return FilterCriteria(
-            date_from=self.dlg.metadataFrom.date(),
-            date_to=self.dlg.metadataTo.date(),
-            max_cloud_cover=self.dlg.maxCloudCover.value(),
-            min_intersection=self.dlg.minIntersection.value(),
-            off_nadir_filtered=not self.dlg.off_nadir_is_full_range(),  # full 0-30 = no filter
-            min_off_nadir=min_off_nadir,
-            max_off_nadir=max_off_nadir,
-            provider_set=self._allowed_provider_set(),
-            product_filter=self._product_category_filter(),
-        )
-
-    def _allowed_provider_set(self) -> Optional[set]:
-        """Lowercased provider api-names a result may come from for the LOCAL filter, or ``None``
-        for no provider filtering (show all).
-
-        - "Search only through available providers" OFF -> ``None`` (show all).
-        - ON with specific providers checked -> just those.
-        - ON with none checked -> all providers available to the user
-          (``app_context.search_data_providers``), so results from providers the user cannot use
-          are dropped."""
-        if not self.dlg.hideUnavailableResults.isChecked():
-            return None
-        checked = self.dlg.searchProvidersCombo.checkedItemsData()
-        if checked:
-            return {str(p).lower() for p in checked}
-        available = self.app_context.search_data_providers or []
-        return {str(p).lower() for p in available} if available else None
-
-    def _product_category_filter(self) -> Optional[set]:
-        """The product categories to KEEP ({'MOSAIC'} or {'IMAGE'}), or ``None`` when both or
-        neither Mosaic/Image is checked (= all, no filter)."""
-        mosaic = self.dlg.searchMosaicCheckBox.isChecked()
-        image = self.dlg.searchImageCheckBox.isChecked()
-        if mosaic == image:  # both or neither -> show all
-            return None
-        return {ProductType.mosaic.upper()} if mosaic else {ProductType.image.upper()}
-
-    def _mark_unfit_rows(self, unfit: set) -> None:
-        """Grey-out and disable (non-selectable) the rows whose image was filtered out; restore
-        fit rows to normal. The row order already places the unfit rows last."""
-        grey_text = QBrush(QColor(150, 150, 150))
-        grey_bg = QBrush(QColor(235, 235, 235))
-        table = self.dlg.metadataTable
-        local_col = self.config.LOCAL_INDEX_COLUMN
-        for row in range(table.rowCount()):
-            key = table.item(row, local_col)
-            if key is None:
-                continue
-            try:
-                is_unfit = int(key.text()) in unfit
-            except (TypeError, ValueError):
-                continue
-            for col in range(table.columnCount()):
-                item = table.item(row, col)
-                if item is None:
-                    continue
-                if is_unfit:
-                    item.setForeground(grey_text)
-                    item.setBackground(grey_bg)
-                    item.setFlags(item.flags() & ~Qt.ItemIsSelectable & ~Qt.ItemIsEnabled)
-                else:
-                    item.setForeground(QBrush())
-                    item.setBackground(QBrush())
-                    item.setFlags(item.flags() | Qt.ItemIsSelectable | Qt.ItemIsEnabled)
-
-    def _hide_unfit_footprints(self, layer: QgsVectorLayer, unfit: set) -> None:
-        """Hide the filtered-out images' footprints from the result layer (subset filter),
-        matching the previous behaviour where filtered geometries disappear from the map."""
-        try:
-            if unfit:
-                ids = ', '.join(str(i) for i in sorted(unfit))
-                layer.setSubsetString(f'local_index NOT IN ({ids})')
-            else:
-                layer.setSubsetString('')
-        except (RuntimeError, AttributeError):
-            pass
-
-    def _update_widen_indicator(self) -> None:
-        """Show the (!) indicator when the current filter widgets are WIDER than the filters
-        that fetched the current results (relaxing them cannot surface more images without a new
-        search); hide it otherwise. Its tooltip lists exactly which settings will not apply."""
-        widened = self._widened_filter_messages()
-        button = self.dlg.searchWidenWarning
-        self._widen_details = widened
-        if widened:
-            button.setToolTip(self._format_widen_message(widened))
-            button.setVisible(True)
-        else:
-            button.setToolTip("")
-            button.setVisible(False)
-
-    def _widened_filter_messages(self) -> List[str]:
-        """The ways the current filter widgets are wider than the baseline that fetched the
-        current results. The comparison is `LocalFilterService`; this passes the current widget
-        values (as a baseline snapshot) and the fetched baseline."""
-        return self.local_filter_service.widen_messages(
-            self._current_filter_baseline(), self.app_context.search_baseline_filters)
-
-    @staticmethod
-    def _format_widen_message(messages: List[str]) -> str:
-        header = QCoreApplication.translate(
-            "Mapflow",
-            "These filters are wider than the last search, so they will not bring more images. "
-            "Run a new Search to fetch them:")
-        return header + "\n• " + "\n• ".join(messages)
-
-    def show_widen_details(self):
-        """On click of the (!) indicator, explain which filters are wider than the fetched
-        results and therefore have no effect until a new search is run."""
-        messages = self._widen_details or self._widened_filter_messages()
-        if not messages:
-            return
-        self.alert(self._format_widen_message(messages), QMessageBox.Information)
-
-    def _current_filter_baseline(self) -> dict:
-        """Snapshot of the filter widgets at search time, stored as the baseline the widen (!)
-        indicator compares later widget edits against."""
-        off_nadir_lo, off_nadir_hi = self.dlg.off_nadir_range()
-        return {
-            "date_from": self.dlg.metadataFrom.date(),
-            "date_to": self.dlg.metadataTo.date(),
-            "max_cloud_cover": self.dlg.maxCloudCover.value(),
-            "min_intersection": self.dlg.minIntersection.value(),
-            "min_off_nadir": off_nadir_lo,
-            "max_off_nadir": off_nadir_hi,
-            "product_types": [str(pt).upper() for pt in self.selected_search_product_types()],
-            "data_providers": self.selected_search_providers() or [],
-            "hide_unavailable": self.dlg.hideUnavailableResults.isChecked(),
-        }
-
-    def reset_filters(self):
-        """Reset the filter widgets to the parameters the current results were fetched with — a
-        regular search's request params, or the open template's search params. Only params that
-        were part of that request are restored; params it did not carry are left untouched. The
-        local filter is re-applied afterwards (so the greying/order returns to the fetched set)."""
-        self._apply_baseline_to_widgets(self.app_context.search_baseline_filters)
-
-    def _apply_baseline_to_widgets(self, baseline: Optional[dict]) -> None:
-        if not baseline:
-            return
-        if baseline.get("date_from") is not None:
-            self.dlg.metadataFrom.setDate(baseline["date_from"])
-        if baseline.get("date_to") is not None:
-            self.dlg.metadataTo.setDate(baseline["date_to"])
-        if baseline.get("max_cloud_cover") is not None:
-            self.dlg.maxCloudCover.setValue(int(round(baseline["max_cloud_cover"])))
-        if baseline.get("min_intersection") is not None:
-            self.dlg.minIntersection.setValue(int(round(baseline["min_intersection"])))
-        base_off_lo = baseline.get("min_off_nadir")
-        base_off_hi = baseline.get("max_off_nadir")
-        if base_off_lo is not None and base_off_hi is not None:
-            self.dlg.set_off_nadir_range(int(round(base_off_lo)), int(round(base_off_hi)))
-        products = baseline.get("product_types")
-        if products is not None:
-            self.dlg.searchMosaicCheckBox.setChecked(ProductType.mosaic.upper() in products)
-            self.dlg.searchImageCheckBox.setChecked(ProductType.image.upper() in products)
-        if baseline.get("hide_unavailable") is not None:
-            self.dlg.hideUnavailableResults.setChecked(bool(baseline["hide_unavailable"]))
-        providers = baseline.get("data_providers")
-        if providers is not None:
-            self.search_view.apply_providers_to_combo(providers)
-        # Re-filter once against the restored widgets (some setters above may not have changed a
-        # value, so their change-signal would not have fired the filter).
-        self.apply_local_filter()
 
     def set_up_login_dialog(self) -> MapflowLoginDialog:
         """Create a login dialog, set its title and signal-slot connections."""
@@ -1019,7 +777,7 @@ class Mapflow(QObject):
             # the current filter widgets instead of showing a stale/unfiltered view.
             self.app_context.search_result_geojson = geoms
         else:
-            self.clear_metadata()
+            self.search_controller.clear_results()
 
         self.dlg.setup_imagery_search(provider=self.app_context.search_provider,
                                       columns=columns,
@@ -1172,27 +930,14 @@ class Mapflow(QObject):
         if not sort_field:
             return  # column is not server-sortable
         self.search_service.toggle_sort(sort_field)
-        self._update_search_sort_indicator(column)
+        self.search_view.show_sort_indicator(
+            column, descending=self.search_service.sort_order == "DESC")
         # Re-request the first page with the new sort — the template-images endpoint and
         # /catalog/meta take the same sort params, so both re-sort server-side.
         if self.template_service.in_template_mode:
             self.template_controller.load_search_page(0)
         else:
             self.get_metadata()
-
-    def _update_search_sort_indicator(self, column: int) -> None:
-        header = self.dlg.metadataTable.horizontalHeader()
-        header.setSortIndicatorShown(True)
-        order = Qt.DescendingOrder if self.search_service.sort_order == "DESC" else Qt.AscendingOrder
-        header.setSortIndicator(column, order)
-
-    def _restore_search_sort_indicator(self) -> None:
-        """Re-show the sort arrow on the active sort column. Every table (re)fill calls
-        setSortingEnabled(False), which Qt implements as hiding the sort indicator, so it must be
-        restored after each fill (otherwise the arrow flashes on click and immediately vanishes)."""
-        column = self.search_service.active_sort_column()
-        if column is not None:
-            self._update_search_sort_indicator(column)
 
     def get_metadata(self, _: Optional[bool] = False, offset: Optional[int] = 0) -> None:
         """Metadata is image footprints with attributes like acquisition date or cloud cover."""
@@ -1222,16 +967,9 @@ class Mapflow(QObject):
         self.search_service.search(aoi=aoi,
                                    provider=provider,
                                    aoi_layer=self.aoi_view.current_layer(),
-                                   baseline_filters=self._current_filter_baseline(),
+                                   baseline_filters=self.search_view.filter_baseline(),
                                    offset=offset,
                                    **self.search_view.search_parameters())
-
-    def clear_metadata(self):
-        """Drop the search results. The service owns the results and the layer; the table and the
-        widen (!) indicator are widgets, so they are cleared here until `SearchController` lands."""
-        self.search_service.clear()
-        self.search_view.clear_table()
-        self.search_view.set_widen_warning_visible(False)
 
     def _on_search_results(self, geoms) -> None:
         """Built-in Qt sorting stays OFF: results already arrive in the server's sort order, and

--- a/tests/qgis/test_local_filter.py
+++ b/tests/qgis/test_local_filter.py
@@ -1,26 +1,22 @@
-"""QGIS-tier tests for the local-filter machinery that stays in `mapflow.py`: assembling a
-`FilterCriteria` from the widgets + context, and applying the result to the table and layer.
+"""QGIS-tier tests for the local filter, now that it belongs to `SearchController`.
 
-The pure computation (which results fail the filter, and the widen `(!)` comparison) moved to
-`LocalFilterService` and is tested in `tests/functional/test_local_filter.py`. What remains here
-needs the QGIS runtime and/or real widgets: the provider/product resolution that reads
+The pure computation (which results fail the filter, and the widen `(!)` comparison) is
+`LocalFilterService`'s and is tested in `tests/functional/test_local_filter.py`. What is here needs
+the QGIS runtime and/or real widgets: the criteria assembly that reads the widgets and
 `app_context`, the `apply_local_filter` orchestration (reorder, re-entrancy guard, skip-unchanged),
-the row greying and footprint hiding, and the widen-indicator button toggle.
+the row greying, the footprint hiding, and the widen-indicator toggle.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from PyQt5.QtCore import QDate, Qt
+from PyQt5.QtCore import QDate, QObject, Qt
 from PyQt5.QtWidgets import QTableWidget, QTableWidgetItem
-from qgis.core import QgsDistanceArea, QgsGeometry, QgsProject
+from qgis.core import QgsGeometry, QgsProject
 
+from mapflow.functional.controller.search_controller import SearchController
 from mapflow.functional.service.local_filter_service import LocalFilterService
-from mapflow.mapflow import Mapflow
-
-
-def _square(x0, y0, x1, y1):
-    return QgsGeometry.fromWkt(
-        f"POLYGON(({x0} {y0},{x1} {y0},{x1} {y1},{x0} {y1},{x0} {y0}))")
+from mapflow.functional.service.search_service import SearchService
+from mapflow.functional.view.search_view import SearchView
 
 
 def _square_geojson(x0, y0, x1, y1):
@@ -42,87 +38,102 @@ def _feature_p(local_index, provider, product_type="OPTICAL"):
     return f
 
 
-def _plugin_regular(min_intersection=50, max_cloud=50, date_from=None, date_to=None):
-    date_from = date_from or QDate(2025, 1, 1)
-    date_to = date_to or QDate(2025, 12, 31)
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.dlg = MagicMock()
-    plugin.dlg.metadataFrom.date.return_value = date_from
-    plugin.dlg.metadataTo.date.return_value = date_to
-    plugin.dlg.maxCloudCover.value.return_value = max_cloud
-    plugin.dlg.minIntersection.value.return_value = min_intersection
-    plugin.dlg.off_nadir_range.return_value = (0, 30)
-    plugin.dlg.off_nadir_is_full_range.return_value = True
-    # The pure computation lives in the service; these mapflow tests exercise the criteria
-    # assembly that feeds it, so a real service is wired in.
-    plugin.local_filter_service = LocalFilterService()
-    plugin._allowed_provider_set = MagicMock(return_value=None)
-    plugin._product_category_filter = MagicMock(return_value=None)
-    plugin.template_service = SimpleNamespace(in_template_mode=False)
-    plugin.app_context = SimpleNamespace(
-        metadata_aoi=_square(0, 0, 10, 10),
-        project=QgsProject.instance(),
-        search_baseline_filters=None,
-        search_result_geojson=None,
-        metadata_layer=None)
-    return plugin
+def _view(dlg=None):
+    """A real `SearchView` over a mock dialog, so the widget reads under test are the real ones."""
+    return SearchView(dlg=dlg or MagicMock(), config=SimpleNamespace(LOCAL_INDEX_COLUMN=0))
 
 
-# ---------- _allowed_provider_set / _product_category_filter (criteria assembly) ----------
+def _controller(search_view=None, app_context=None):
+    controller = SearchController.__new__(SearchController)
+    QObject.__init__(controller)
+    controller.tr = lambda t: t
+    controller.search_view = search_view or MagicMock()
+    controller.search_service = MagicMock()
+    controller.local_filter_service = LocalFilterService()
+    controller.app_context = app_context or SimpleNamespace(
+        search_baseline_filters=None, search_result_geojson=None, search_data_providers=None)
+    controller._suppress_local_filter = False
+    controller._last_unfit_set = None
+    controller._last_filtered_geoms = None
+    controller._widen_details = []
+    return controller
+
+
+def _filter_dlg(min_intersection=50, max_cloud=50, date_from=None, date_to=None):
+    dlg = MagicMock()
+    dlg.metadataFrom.date.return_value = date_from or QDate(2025, 1, 1)
+    dlg.metadataTo.date.return_value = date_to or QDate(2025, 12, 31)
+    dlg.maxCloudCover.value.return_value = max_cloud
+    dlg.minIntersection.value.return_value = min_intersection
+    dlg.off_nadir_range.return_value = (0, 30)
+    dlg.off_nadir_is_full_range.return_value = True
+    return dlg
+
+
+# ---------- criteria assembly: which providers a result may come from ----------
 
 def test_allowed_provider_set_off_when_unavailable_toggle_off():
-    plugin = _plugin_regular()
-    del plugin._allowed_provider_set  # use the real method
-    plugin.dlg.hideUnavailableResults.isChecked.return_value = False
+    dlg = _filter_dlg()
+    dlg.hideUnavailableResults.isChecked.return_value = False
+    controller = _controller(search_view=_view(dlg))
 
-    assert plugin._allowed_provider_set() is None
+    assert controller._allowed_provider_set() is None
 
 
 def test_allowed_provider_set_uses_checked_when_any():
-    plugin = _plugin_regular()
-    del plugin._allowed_provider_set  # use the real method
-    plugin.dlg.hideUnavailableResults.isChecked.return_value = True
-    plugin.dlg.searchProvidersCombo.checkedItemsData.return_value = ["Orbview_SVN1"]
+    dlg = _filter_dlg()
+    dlg.hideUnavailableResults.isChecked.return_value = True
+    dlg.searchProvidersCombo.checkedItemsData.return_value = ["Orbview_SVN1"]
+    controller = _controller(search_view=_view(dlg))
 
-    assert plugin._allowed_provider_set() == {"orbview_svn1"}
+    assert controller._allowed_provider_set() == {"orbview_svn1"}
 
 
 def test_allowed_provider_set_falls_back_to_available_when_none_checked():
     # "Search only through available providers" ON, nothing checked -> limit to available list.
-    plugin = _plugin_regular()
-    del plugin._allowed_provider_set  # use the real method
-    plugin.dlg.hideUnavailableResults.isChecked.return_value = True
-    plugin.dlg.searchProvidersCombo.checkedItemsData.return_value = []
-    plugin.app_context.search_data_providers = ["orbview_svn1", "orbview_svn3"]
+    dlg = _filter_dlg()
+    dlg.hideUnavailableResults.isChecked.return_value = True
+    dlg.searchProvidersCombo.checkedItemsData.return_value = []
+    controller = _controller(
+        search_view=_view(dlg),
+        app_context=SimpleNamespace(search_data_providers=["orbview_svn1", "orbview_svn3"],
+                                    search_baseline_filters=None, search_result_geojson=None))
 
-    assert plugin._allowed_provider_set() == {"orbview_svn1", "orbview_svn3"}
+    assert controller._allowed_provider_set() == {"orbview_svn1", "orbview_svn3"}
 
 
 def test_search_only_available_greys_unavailable_provider():
-    # End to end through the wrapper: real assembly + real service. A provider not available to
-    # the user is dropped from an otherwise-fit result.
-    plugin = _plugin_regular(min_intersection=0, max_cloud=100)
-    plugin._product_category_filter = MagicMock(return_value=None)
-    plugin.dlg.hideUnavailableResults.isChecked.return_value = True
-    plugin.dlg.searchProvidersCombo.checkedItemsData.return_value = []
-    plugin.app_context.search_data_providers = ["orbview_svn1"]
-    del plugin._allowed_provider_set  # use the real method
+    # End to end through the assembly + the real service: a provider not available to the user is
+    # dropped from an otherwise-fit result.
+    dlg = _filter_dlg(min_intersection=0, max_cloud=100)
+    dlg.hideUnavailableResults.isChecked.return_value = True
+    dlg.searchProvidersCombo.checkedItemsData.return_value = []
+    dlg.searchMosaicCheckBox.isChecked.return_value = True
+    dlg.searchImageCheckBox.isChecked.return_value = True  # both -> no product filter
+    controller = _controller(
+        search_view=_view(dlg),
+        app_context=SimpleNamespace(search_data_providers=["orbview_svn1"],
+                                    metadata_aoi=QgsGeometry.fromWkt(
+                                        "POLYGON((0 0,10 0,10 10,0 10,0 0))"),
+                                    project=QgsProject.instance(),
+                                    search_baseline_filters=None, search_result_geojson=None))
     features = [_feature_p(0, "orbview_svn1"), _feature_p(1, "legacy_provider")]
 
-    assert plugin._unfit_local_indices(features) == {1}
+    unfit = controller.local_filter_service.unfit_indices(features, controller._filter_criteria())
+
+    assert unfit == {1}
 
 
 def test_product_category_filter_none_when_both_or_neither():
-    plugin = _plugin_regular()
-    del plugin._product_category_filter  # use the real method
+    dlg = _filter_dlg()
+    view = _view(dlg)
     for mosaic, image in [(True, True), (False, False)]:
-        plugin.dlg.searchMosaicCheckBox.isChecked.return_value = mosaic
-        plugin.dlg.searchImageCheckBox.isChecked.return_value = image
-        assert plugin._product_category_filter() is None
-    plugin.dlg.searchMosaicCheckBox.isChecked.return_value = True
-    plugin.dlg.searchImageCheckBox.isChecked.return_value = False
-    assert plugin._product_category_filter() == {"MOSAIC"}
+        dlg.searchMosaicCheckBox.isChecked.return_value = mosaic
+        dlg.searchImageCheckBox.isChecked.return_value = image
+        assert view.product_category_filter() is None
+    dlg.searchMosaicCheckBox.isChecked.return_value = True
+    dlg.searchImageCheckBox.isChecked.return_value = False
+    assert view.product_category_filter() == {"MOSAIC"}
 
 
 # ---------- apply_local_filter orchestration ----------
@@ -131,41 +142,35 @@ def _geoms(*local_indices):
     return {"features": [{"properties": {"local_index": i}} for i in local_indices]}
 
 
-def _plugin_orchestration(unfit):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.dlg = MagicMock()
-    plugin.template_service = SimpleNamespace(in_template_mode=False)
-    layer = MagicMock()
-    layer.crs.return_value = "crs"
-    plugin.app_context = SimpleNamespace(
-        metadata_layer=layer,
-        search_result_geojson=_geoms(0, 1, 2, 3),
-        search_baseline_filters=None)
-    plugin._unfit_local_indices = MagicMock(return_value=set(unfit))
-    plugin._mark_unfit_rows = MagicMock()
-    plugin._hide_unfit_footprints = MagicMock()
-    plugin.search_controller = MagicMock()  # apply_local_filter drives reconnect_cell_preview
-    plugin.template_controller = MagicMock()  # ...and apply_new_image_markers in template mode
-    plugin._update_widen_indicator = MagicMock()
-    plugin._restore_search_sort_indicator = MagicMock()
-    return plugin
+def _orchestration_controller(unfit, geoms=None):
+    controller = _controller(app_context=SimpleNamespace(
+        search_result_geojson=geoms or _geoms(0, 1, 2, 3),
+        search_baseline_filters=None,
+        search_data_providers=None))
+    controller.local_filter_service = MagicMock()
+    controller.local_filter_service.unfit_indices.return_value = set(unfit)
+    controller.local_filter_service.widen_messages.return_value = []
+    # The criteria assembly has its own tests above; here the orchestration is what matters.
+    controller._filter_criteria = MagicMock()
+    controller.reconnect_cell_preview = MagicMock()
+    controller.restore_sort_indicator = MagicMock()
+    return controller
 
 
 def test_apply_local_filter_sorts_unfit_rows_to_bottom():
-    plugin = _plugin_orchestration(unfit={1, 3})
+    controller = _orchestration_controller(unfit={1, 3})
 
-    plugin.apply_local_filter()
+    controller.apply_local_filter()
 
-    filled = plugin.dlg.fill_metadata_table.call_args.args[0]
+    filled = controller.search_view.fill_table.call_args.args[0]
     order = [f["properties"]["local_index"] for f in filled["features"]]
     assert order == [0, 2, 1, 3]  # fit first (original order), then unfit (original order)
     # Built-in column sorting must be OFF for this fill, or the table re-sorts by date and the
     # unfit rows jump back up.
-    assert plugin.dlg.fill_metadata_table.call_args.kwargs.get("sort") is False
-    plugin._mark_unfit_rows.assert_called_once_with({1, 3})
-    plugin._hide_unfit_footprints.assert_called_once()
-    plugin._update_widen_indicator.assert_called_once()
+    assert controller.search_view.fill_table.call_args.kwargs.get("sort") is False
+    controller.search_view.mark_unfit_rows.assert_called_once_with({1, 3})
+    controller.search_service.hide_unfit_footprints.assert_called_once_with({1, 3})
+    controller.restore_sort_indicator.assert_called_once()
 
 
 def _dated_geoms():
@@ -177,76 +182,79 @@ def _dated_geoms():
     ]}
 
 
-def test_apply_local_filter_preserves_server_order_for_regular_search():
-    # Regression: the local filter used to force date-desc, discarding the server's sort order
-    # (so a pixel-resolution sort never showed in the table). Regular search must keep server order.
-    plugin = _plugin_orchestration(unfit=set())
-    plugin.app_context.search_result_geojson = _dated_geoms()
+def test_apply_local_filter_preserves_server_order():
+    # Regression: the local filter used to force date-desc, discarding the server's sort order (so
+    # a pixel-resolution sort never showed in the table). Both regular and template results are
+    # sorted server-side, so the incoming order must survive.
+    controller = _orchestration_controller(unfit=set(), geoms=_dated_geoms())
 
-    plugin.apply_local_filter()
+    controller.apply_local_filter()
 
     order = [f["properties"]["local_index"]
-             for f in plugin.dlg.fill_metadata_table.call_args.args[0]["features"]]
+             for f in controller.search_view.fill_table.call_args.args[0]["features"]]
     assert order == [0, 1, 2]  # server order preserved (date-desc would have given [1, 2, 0])
 
 
-def test_apply_local_filter_preserves_server_order_for_template():
-    # Template results are now also sorted server-side (the template-images endpoint takes the
-    # same sortBy/sortOrder), so the local filter must preserve their incoming order too.
-    plugin = _plugin_orchestration(unfit=set())
-    plugin.template_service = SimpleNamespace(in_template_mode=True)
-    plugin.app_context.search_result_geojson = _dated_geoms()
-
-    plugin.apply_local_filter()
-
-    order = [f["properties"]["local_index"]
-             for f in plugin.dlg.fill_metadata_table.call_args.args[0]["features"]]
-    assert order == [0, 1, 2]  # server order preserved (no client date re-sort)
-
-
 def test_apply_local_filter_is_reentrancy_guarded():
-    plugin = _plugin_orchestration(unfit=set())
-    # Simulate the nested metadataTableFilled emission during fill_metadata_table.
-    plugin.dlg.fill_metadata_table.side_effect = lambda *a, **k: plugin.apply_local_filter()
+    controller = _orchestration_controller(unfit=set())
+    # Simulate the nested metadataTableFilled emission during the fill.
+    controller.search_view.fill_table.side_effect = lambda *a, **k: controller.apply_local_filter()
 
-    plugin.apply_local_filter()
+    controller.apply_local_filter()
 
     # The nested call is swallowed: exactly one real fill.
-    assert plugin.dlg.fill_metadata_table.call_count == 1
-    assert plugin._suppress_local_filter is False
+    assert controller.search_view.fill_table.call_count == 1
+    assert controller._suppress_local_filter is False
 
 
 def test_apply_local_filter_skips_refill_when_unchanged():
-    plugin = _plugin_orchestration(unfit={2})
+    controller = _orchestration_controller(unfit={2})
 
-    plugin.apply_local_filter()
-    plugin.apply_local_filter()  # same unfit set + same geoms object
+    controller.apply_local_filter()
+    controller.apply_local_filter()  # same unfit set + same geoms object
 
-    assert plugin.dlg.fill_metadata_table.call_count == 1
+    assert controller.search_view.fill_table.call_count == 1
 
+
+def test_apply_local_filter_with_no_results_still_refreshes_the_indicator():
+    controller = _orchestration_controller(unfit=set(), geoms={"features": []})
+
+    controller.apply_local_filter()
+
+    controller.search_view.fill_table.assert_not_called()
+    controller.reconnect_cell_preview.assert_called_once()
+
+
+# ---------- what the filter does to the table and the map ----------
 
 def test_hide_unfit_footprints_builds_subset_string():
-    plugin = Mapflow.__new__(Mapflow)
+    service = SearchService.__new__(SearchService)
     layer = MagicMock()
+    service.app_context = SimpleNamespace(metadata_layer=layer)
 
-    plugin._hide_unfit_footprints(layer, {3, 1})
+    service.hide_unfit_footprints({3, 1})
     layer.setSubsetString.assert_called_once_with("local_index NOT IN (1, 3)")
 
     layer.reset_mock()
-    plugin._hide_unfit_footprints(layer, set())
+    service.hide_unfit_footprints(set())
     layer.setSubsetString.assert_called_once_with("")
 
 
+def test_hide_unfit_footprints_survives_a_missing_layer():
+    service = SearchService.__new__(SearchService)
+    service.app_context = SimpleNamespace(metadata_layer=None)
+
+    service.hide_unfit_footprints({1})  # must not raise
+
+
 def test_mark_unfit_rows_greys_and_disables_only_unfit():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.config = SimpleNamespace(LOCAL_INDEX_COLUMN=0)
     table = QTableWidget(2, 2)
     for row, local_index in enumerate([5, 6]):
         table.setItem(row, 0, QTableWidgetItem(str(local_index)))
         table.setItem(row, 1, QTableWidgetItem("x"))
-    plugin.dlg = SimpleNamespace(metadataTable=table)
+    view = _view(SimpleNamespace(metadataTable=table))
 
-    plugin._mark_unfit_rows({6})
+    view.mark_unfit_rows({6})
 
     fit_item = table.item(0, 1)
     unfit_item = table.item(1, 1)
@@ -257,27 +265,59 @@ def test_mark_unfit_rows_greys_and_disables_only_unfit():
 
 # ---------- widen (!) indicator button ----------
 
-def _plugin_widen(baseline):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda t: t
-    plugin.dlg = MagicMock()
-    plugin.dlg.metadataFrom.date.return_value = QDate(2025, 1, 1)
-    plugin.dlg.metadataTo.date.return_value = QDate(2025, 6, 1)
-    plugin.dlg.maxCloudCover.value.return_value = 30
-    plugin.dlg.minIntersection.value.return_value = 40
-    plugin.dlg.off_nadir_range.return_value = (0, 30)
-    plugin.local_filter_service = LocalFilterService()
-    plugin.selected_search_product_types = MagicMock(return_value=["IMAGE"])
-    plugin.selected_search_providers = MagicMock(return_value=["providerA"])
-    plugin.app_context = SimpleNamespace(search_baseline_filters=baseline)
-    return plugin
+def _widen_controller(baseline):
+    dlg = _filter_dlg(min_intersection=40, max_cloud=30,
+                      date_from=QDate(2025, 1, 1), date_to=QDate(2025, 6, 1))
+    dlg.searchMosaicCheckBox.isChecked.return_value = False
+    dlg.searchImageCheckBox.isChecked.return_value = True
+    dlg.hideUnavailableResults.isChecked.return_value = True
+    dlg.searchProvidersCombo.checkedItemsData.return_value = ["providerA"]
+    controller = _controller(
+        search_view=_view(dlg),
+        app_context=SimpleNamespace(search_baseline_filters=baseline,
+                                    search_result_geojson=None, search_data_providers=None))
+    return controller, dlg
 
 
 def test_update_widen_indicator_toggles_button_visibility():
-    plugin = _plugin_widen(None)  # no baseline -> nothing to warn about
-    plugin._update_widen_indicator()
-    plugin.dlg.searchWidenWarning.setVisible.assert_called_with(False)
+    controller, dlg = _widen_controller(None)  # no baseline -> nothing to warn about
+    controller.update_widen_indicator()
+    dlg.searchWidenWarning.setVisible.assert_called_with(False)
 
-    plugin.app_context.search_baseline_filters = {"max_cloud_cover": 5}
-    plugin._update_widen_indicator()
-    plugin.dlg.searchWidenWarning.setVisible.assert_called_with(True)
+    controller.app_context.search_baseline_filters = {"max_cloud_cover": 5}
+    controller.update_widen_indicator()
+    dlg.searchWidenWarning.setVisible.assert_called_with(True)
+
+
+def test_the_widen_tooltip_names_what_will_not_apply():
+    controller, dlg = _widen_controller({"max_cloud_cover": 5})
+
+    controller.update_widen_indicator()
+
+    tooltip = dlg.searchWidenWarning.setToolTip.call_args.args[0]
+    assert "Run a new Search" in tooltip
+    assert "cloud" in tooltip.lower()
+
+
+# ---------- resetting the filters ----------
+
+def test_reset_filters_puts_the_widgets_back_and_refilters():
+    controller = _controller()
+    controller.app_context.search_baseline_filters = {"max_cloud_cover": 20}
+    controller.apply_local_filter = MagicMock()
+
+    controller.reset_filters()
+
+    controller.search_view.apply_baseline.assert_called_once_with({"max_cloud_cover": 20})
+    # Some setters may not change a value, so their change-signal would not fire the filter.
+    controller.apply_local_filter.assert_called_once()
+
+
+def test_reset_filters_without_a_baseline_does_nothing():
+    controller = _controller()
+    controller.apply_local_filter = MagicMock()
+
+    controller.reset_filters()
+
+    controller.search_view.apply_baseline.assert_not_called()
+    controller.apply_local_filter.assert_not_called()

--- a/tests/qgis/test_plan_search_prompt.py
+++ b/tests/qgis/test_plan_search_prompt.py
@@ -6,7 +6,10 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from PyQt5.QtCore import QObject
+
 from mapflow.functional.app_context import AppContext
+from mapflow.functional.service.account_service import AccountService
 from mapflow.functional.service.template_service import TemplateService
 from mapflow.mapflow import Mapflow
 
@@ -26,35 +29,35 @@ def _user_status_response(**overrides):
     return response
 
 
-def test_set_processing_limit_stores_search_area_limit_in_sq_km():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
-    plugin.app_context = AppContext()
-    plugin.dlg = MagicMock()
-
-    plugin.set_processing_limit(_user_status_response())
-
-    assert plugin.app_context.search_area_limit == 1.0
+def _account_service():
+    service = AccountService.__new__(AccountService)
+    QObject.__init__(service)
+    service.tr = lambda text: text
+    service.plugin_name = "Mapflow"
+    service.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
+    service.app_context = AppContext()
+    return service
 
 
-def test_set_processing_limit_defaults_search_area_limit_to_zero_when_absent():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
-    plugin.app_context = AppContext()
-    plugin.dlg = MagicMock()
+def test_search_area_limit_is_stored_in_sq_km():
+    service = _account_service()
+
+    service.apply_status(_user_status_response())
+
+    assert service.app_context.search_area_limit == 1.0
+
+
+def test_search_area_limit_defaults_to_zero_when_absent():
+    service = _account_service()
 
     response = _user_status_response()
     payload = json.loads(response.readAll.return_value.data.return_value)
     payload.pop("searchAreaLimit")
     response.readAll.return_value.data.return_value = json.dumps(payload).encode()
 
-    plugin.set_processing_limit(response)
+    service.apply_status(response)
 
-    assert plugin.app_context.search_area_limit == 0.0
+    assert service.app_context.search_area_limit == 0.0
 
 
 # ---------- the plan-search gating moved to TemplateService / TemplateController ----------

--- a/tests/qgis/test_search_sort.py
+++ b/tests/qgis/test_search_sort.py
@@ -45,10 +45,22 @@ def _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC", in_template=False, ro
     plugin.template_service = SimpleNamespace(in_template_mode=in_template)
     plugin.dlg = MagicMock()
     plugin.dlg.metadataTable.rowCount.return_value = rows
-    plugin._update_search_sort_indicator = MagicMock()
+    plugin.search_view = MagicMock()
     plugin.get_metadata = MagicMock()
     plugin.template_controller = MagicMock()
     return plugin
+
+
+def _sort_controller(sort_by="ACQUISITION_DATE", sort_order="DESC"):
+    """Restoring the arrow after a re-fill is `SearchController`'s; the column<->token mapping it
+    asks for is still the search service's."""
+    from PyQt5.QtCore import QObject
+    from mapflow.functional.controller.search_controller import SearchController
+    controller = SearchController.__new__(SearchController)
+    QObject.__init__(controller)
+    controller.search_service = _search_service(sort_by, sort_order)
+    controller.search_view = MagicMock()
+    return controller
 
 
 def test_backend_tokens_are_upper_snake_case():
@@ -120,19 +132,27 @@ def test_no_results_yet_does_not_search():
 
 def test_restore_sort_indicator_maps_token_to_its_column():
     # After a re-fill hides the arrow, the indicator is restored on the column matching the token.
-    plugin = _plugin(sort_by="CLOUD_COVER")
+    controller = _sort_controller(sort_by="CLOUD_COVER")
 
-    plugin._restore_search_sort_indicator()
+    controller.restore_sort_indicator()
 
-    plugin._update_search_sort_indicator.assert_called_once_with(_column("cloudCover"))
+    assert controller.search_view.show_sort_indicator.call_args.args == (_column("cloudCover"),)
+
+
+def test_restore_sort_indicator_carries_the_current_order():
+    controller = _sort_controller(sort_by="CLOUD_COVER", sort_order="ASC")
+
+    controller.restore_sort_indicator()
+
+    assert controller.search_view.show_sort_indicator.call_args.kwargs["descending"] is False
 
 
 def test_restore_sort_indicator_noop_without_active_sort():
-    plugin = _plugin(sort_by=None)
+    controller = _sort_controller(sort_by=None)
 
-    plugin._restore_search_sort_indicator()
+    controller.restore_sort_indicator()
 
-    plugin._update_search_sort_indicator.assert_not_called()
+    controller.search_view.show_sort_indicator.assert_not_called()
 
 
 def test_request_schema_serializes_sort_fields():

--- a/tests/qgis/test_startup_status_poll.py
+++ b/tests/qgis/test_startup_status_poll.py
@@ -1,12 +1,12 @@
-"""The startup /user/status retry loop.
+"""The startup /user/status retry loop, now `AccountService`'s.
 
 The loop exists because the plugin cannot configure itself until that response arrives, so
 it re-asks every 500 ms. What it must never do is re-ask forever: each tick issues a
 request, and nothing else in the plugin bounds it. Two ways it used to run away —
 
-* the response arrived but `set_processing_limit` raised part-way through, so the stop that
-  sat at the end of that callback never ran (the error guard swallows the exception, and
-  everything after the raise point is skipped);
+* the response arrived but applying it raised part-way through, so the stop that sat at the
+  end of that callback never ran (the error guard swallows the exception, and everything
+  after the raise point is skipped);
 * the response never arrived at all, because the error branch had no handler.
 
 Both left the plugin polling /user/status and /rasters/memory twice a second for the rest
@@ -16,28 +16,22 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from PyQt5.QtCore import QTimer
 from PyQt5.QtNetwork import QNetworkReply
 
 from mapflow.config import Config
+from mapflow.functional.service.account_service import AccountService
 from mapflow.mapflow import Mapflow
 
 
 @pytest.fixture
-def plugin():
-    instance = Mapflow.__new__(Mapflow)
+def service():
+    instance = AccountService(http=MagicMock(),
+                              app_context=SimpleNamespace(),
+                              config=Config,
+                              server="https://example.invalid/api",
+                              plugin_name="Mapflow")
     instance.tr = lambda text: text
-    instance.config = Config
-    instance.server = "https://example.invalid/api"
-    instance.http = MagicMock()
-    instance.alert = MagicMock()
-    instance.data_catalog_service = MagicMock()
-    instance.app_startup_user_update_timer = QTimer()
-    instance.app_startup_user_update_timer.setInterval(Config.STARTUP_STATUS_RETRY_INTERVAL)
-    instance._startup_status_attempts = 0
-    instance._startup_status_pending = False
-    instance._startup_status_given_up = False
-    instance.app_startup_user_update_timer.start()
+    instance.begin_startup_polling()
     return instance
 
 
@@ -47,92 +41,121 @@ def _failed_response():
     return response
 
 
-def test_a_tick_is_skipped_while_a_request_is_in_flight(plugin):
+def test_a_tick_is_skipped_while_a_request_is_in_flight(service):
     """Ticks are not synchronised with responses, so without this a slow server would
     accumulate one outstanding request per 500 ms."""
-    plugin.first_status_request()
-    plugin.first_status_request()
-    plugin.first_status_request()
+    service.request_startup_status()
+    service.request_startup_status()
+    service.request_startup_status()
 
-    assert plugin.http.get.call_count == 1
-
-
-def test_the_next_tick_retries_once_the_previous_request_failed(plugin):
-    plugin.first_status_request()
-    plugin.first_status_error_handler(_failed_response())
-    plugin.first_status_request()
-
-    assert plugin.http.get.call_count == 2
-    assert plugin.app_startup_user_update_timer.isActive(), "a single failure is not fatal"
+    assert service.http.get.call_count == 1
 
 
-def test_polling_stops_and_the_user_is_told_after_the_attempt_budget(plugin):
+def test_the_next_tick_retries_once_the_previous_request_failed(service):
+    service.request_startup_status()
+    service.startup_status_error_handler(_failed_response())
+    service.request_startup_status()
+
+    assert service.http.get.call_count == 2
+    assert service.startup_timer.isActive(), "a single failure is not fatal"
+
+
+def test_polling_stops_and_the_user_is_told_after_the_attempt_budget(service):
+    warnings = []
+    service.startupGaveUp.connect(warnings.append)
+
     for _ in range(Config.STARTUP_STATUS_MAX_ATTEMPTS):
-        plugin.first_status_request()
-        plugin.first_status_error_handler(_failed_response())
+        service.request_startup_status()
+        service.startup_status_error_handler(_failed_response())
 
-    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
-    assert plugin.app_startup_user_update_timer.isActive(), "the budget is not spent yet"
+    assert service.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
+    assert service.startup_timer.isActive(), "the budget is not spent yet"
 
-    plugin.first_status_request()
+    service.request_startup_status()
 
-    assert not plugin.app_startup_user_update_timer.isActive()
-    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS, "no further requests"
-    plugin.alert.assert_called_once()
+    assert not service.startup_timer.isActive()
+    assert service.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS, "no further requests"
+    assert len(warnings) == 1
 
 
-def test_no_further_requests_after_the_budget_is_spent(plugin):
+def test_no_further_requests_after_the_budget_is_spent(service):
+    warnings = []
+    service.startupGaveUp.connect(warnings.append)
+
     for _ in range(Config.STARTUP_STATUS_MAX_ATTEMPTS + 5):
-        plugin.first_status_request()
-        plugin.first_status_error_handler(_failed_response())
+        service.request_startup_status()
+        service.startup_status_error_handler(_failed_response())
 
-    assert plugin.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
-    assert plugin.alert.call_count == 1, "give up once, not once per tick"
+    assert service.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS
+    assert len(warnings) == 1, "give up once, not once per tick"
 
 
-def test_a_raising_configuration_still_stops_the_poll(plugin):
+def test_a_raising_configuration_still_stops_the_poll(service):
     """The regression: the stop must not depend on the configuration succeeding."""
-    plugin.set_processing_limit = MagicMock(side_effect=TimeoutError("injected"))
+    service.apply_status = MagicMock(side_effect=TimeoutError("injected"))
 
     with pytest.raises(TimeoutError):
-        plugin.first_status_callback(MagicMock())
+        service.startup_status_callback(MagicMock())
 
-    assert not plugin.app_startup_user_update_timer.isActive()
+    assert not service.startup_timer.isActive()
 
 
-def test_the_storage_quota_is_requested_once_on_success_not_per_retry(plugin):
-    """/rasters/memory used to be issued from every tick, doubling the runaway traffic."""
-    plugin.set_processing_limit = MagicMock()
+def test_a_successful_startup_stops_the_poll(service):
+    service.apply_status = MagicMock()
 
-    plugin.first_status_request()
-    plugin.first_status_error_handler(_failed_response())
-    plugin.first_status_request()
+    service.startup_status_callback(MagicMock())
+
+    assert not service.startup_timer.isActive()
+    service.apply_status.assert_called_once()
+    assert service.apply_status.call_args.kwargs == {"app_startup_request": True}
+
+
+def test_logging_in_again_after_giving_up_gets_a_full_budget(service):
+    for _ in range(Config.STARTUP_STATUS_MAX_ATTEMPTS + 1):
+        service.request_startup_status()
+        service.startup_status_error_handler(_failed_response())
+    assert not service.startup_timer.isActive()
+
+    service.begin_startup_polling()
+    service.request_startup_status()
+
+    assert service.http.get.call_count == Config.STARTUP_STATUS_MAX_ATTEMPTS + 1
+    assert service.startup_timer.isActive()
+
+
+def test_the_storage_quota_is_requested_once_on_success_not_per_retry():
+    """/rasters/memory used to be issued from every tick, doubling the runaway traffic. It now
+    hangs off `statusApplied`, which only a real response emits."""
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.data_catalog_service = MagicMock()
+    plugin.processing_service = MagicMock()
+    plugin.dlg = MagicMock()
+    plugin.app_context = SimpleNamespace(billing_type=None, review_workflow_enabled=False,
+                                         current_project=None)
+    plugin.project_processing_controller = MagicMock()
+    plugin.project_service = MagicMock()
+    plugin.setup_providers = MagicMock()
+    plugin.setup_search_providers = MagicMock()
+    plugin.on_provider_change = MagicMock()
+
+    plugin.on_account_status({}, app_startup_request=False)
     plugin.data_catalog_service.get_user_limit.assert_not_called()
 
-    plugin.first_status_callback(MagicMock())
+    plugin.on_account_status({}, app_startup_request=True)
     plugin.data_catalog_service.get_user_limit.assert_called_once()
 
 
-def test_a_successful_startup_stops_the_poll(plugin):
-    plugin.set_processing_limit = MagicMock()
-
-    plugin.first_status_callback(MagicMock())
-
-    assert not plugin.app_startup_user_update_timer.isActive()
-    plugin.set_processing_limit.assert_called_once()
-    assert plugin.set_processing_limit.call_args.kwargs == {"app_startup_request": True}
-
-
-def test_logout_stops_a_startup_poll_that_never_finished(plugin):
+def test_logout_stops_a_startup_poll_that_never_finished(service):
     """Otherwise a failed startup keeps polling the account endpoint after logging out."""
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.account_service = service
     plugin.app_context = SimpleNamespace(settings=MagicMock(), logged_in=True)
     plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
-    plugin.user_status_update_timer = MagicMock()
+    plugin.http = MagicMock()
     plugin.dlg = MagicMock()
     plugin.dlg_login = MagicMock()
 
     plugin.logout()
 
-    assert not plugin.app_startup_user_update_timer.isActive()
+    assert not service.startup_timer.isActive()
+    assert not service.refresh_timer.isActive()

--- a/tests/qgis/test_template_area_limit.py
+++ b/tests/qgis/test_template_area_limit.py
@@ -9,11 +9,12 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from PyQt5.QtCore import QObject
 from qgis.core import QgsGeometry
 
 from mapflow.functional.app_context import AppContext
+from mapflow.functional.service.account_service import AccountService
 from mapflow.functional.service.template_service import TemplateService
-from mapflow.mapflow import Mapflow
 
 
 def _user_status_response(**overrides):
@@ -30,35 +31,35 @@ def _user_status_response(**overrides):
     return response
 
 
-def test_set_processing_limit_stores_template_area_limit_in_sq_km():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
-    plugin.app_context = AppContext()
-    plugin.dlg = MagicMock()
-
-    plugin.set_processing_limit(_user_status_response())
-
-    assert plugin.app_context.template_area_limit == 2.0
+def _account_service():
+    service = AccountService.__new__(AccountService)
+    QObject.__init__(service)
+    service.tr = lambda text: text
+    service.plugin_name = "Mapflow"
+    service.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
+    service.app_context = AppContext()
+    return service
 
 
-def test_set_processing_limit_defaults_template_area_limit_to_zero_when_absent():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.config = SimpleNamespace(MAX_AOIS_PER_PROCESSING=1)
-    plugin.app_context = AppContext()
-    plugin.dlg = MagicMock()
+def test_template_area_limit_is_stored_in_sq_km():
+    service = _account_service()
+
+    service.apply_status(_user_status_response())
+
+    assert service.app_context.template_area_limit == 2.0
+
+
+def test_template_area_limit_defaults_to_zero_when_absent():
+    service = _account_service()
 
     response = _user_status_response()
     payload = json.loads(response.readAll.return_value.data.return_value)
     payload.pop("templateAreaLimit")
     response.readAll.return_value.data.return_value = json.dumps(payload).encode()
 
-    plugin.set_processing_limit(response)
+    service.apply_status(response)
 
-    assert plugin.app_context.template_area_limit == 0.0
+    assert service.app_context.template_area_limit == 0.0
 
 
 def _template_service(app_context):

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -274,8 +274,11 @@ def _seen_setup(selected_rows=None, open_id="tpl-1", active_template=None):
         "img-3": SimpleNamespace(id="img-3", isNew=True, productType="Mosaic")}
     view = TemplateView(dlg=dlg, iface=MagicMock(), config=config)
     controller = TemplateController.__new__(TemplateController)
+    QObject.__init__(controller)
     controller.template_service = service
     controller.template_view = view
+    # The markers are drawn only while the results on screen are a template's.
+    controller.app_context = app_context
     template_dto = processing_service.templates[template_dto.id]
     return controller, service, view, marker_cells, template_dto
 


### PR DESCRIPTION
Two more Phase C extractions, in separate commits so they can be reviewed one at a time. `mapflow.py`: **1930 → 1584 lines**. Gates green throughout — functional 87, qgis 651, lint clean.

**Phase C is not finished.** What remains is enumerated in the third commit; see the bottom of this description.

## 1. The local filter → `SearchController`

The largest block left in `mapflow.py`, ~230 lines of instant filtering over results already fetched. `SearchView` takes the widget reads and writes, `SearchService` takes hiding the filtered-out footprints (layer work on the metadata layer it already owns), `SearchController` takes the orchestration and the criteria assembly.

`FilterCriteria` is built in the controller rather than returned by the view, because a view may not import a service and `FilterCriteria` lives in `local_filter_service`. The view hands over plain values.

**The one part that could not simply move** is restoring the template view's 'new image' icons after a refill: the local filter is `SearchController`'s and the markers are `TemplateController`'s, and a controller may not call another (`spec/007_architecture.md:167`). `SearchView` now emits `tableRefilled` and `TemplateController` subscribes, so the rule "after any refill, redraw the markers" holds for every refill path rather than the two that remembered to ask.

**Moving that guard exposed a bug in the guard itself.** It read `in_template_mode`, but a template's results are also shown from the project list via "See search results", *without* entering the template view — so on that path the markers would have vanished on every filter change. The condition is `open_template_results_id`. An existing test caught my first attempt.

## 2. `/user/status` → `AccountService`

The WAL's "split auth from account status" item, account side. One endpoint had grown two callers with different needs and no owner: a steady refresh keeping the limit and balance current, and a separate post-login retry, because the billing mode, review workflow, provider lists and area caps cannot be configured until the first response lands — and that request can fail on a slow or offline start.

Both polls, both timers, the retry budget and the response parsing are now `AccountService`. It holds no widget. Its timers are parented to the service rather than the dialog, so nothing about it needs a dialog to exist — which is also what lets the retry-budget tests drive it directly instead of through a half-built plugin.

The startup *configuration* stays in `mapflow.py`, on `statusApplied`. Deliberate: it is the sequence that wires providers, billing and the first table together, and `mapflow.py` is the composition root.

**A reset nobody was testing**: the startup retry's "give up" is latched, and the latch was cleared three hundred lines away in `log_in_callback`. It is now `begin_startup_polling`, next to the latch, with a test.

## 3. What is left of Phase C

The acceptance says *"no `self.dlg.<widget>` access in `mapflow.py`"*. That cannot be literally true while `mapflow.py` is the composition root — building a controller means handing it widgets. Recorded in the WAL as **no widget access outside construction and wiring**, rather than edited into `spec/`, which is not this step's to change. Flagging it for your call.

The other half — emptying the layering allowlist — is a much larger body of work than its one line suggests: removing the `dlg` constructor argument from five services and two api modules, ~140 accesses, each changing a constructor and every test that builds it. Enumerated as its own sequence.

Four `mapflow.py` clusters also remain, listed in the WAL in the order worth doing, each with the obstacle it carries: the search/metadata sync pair juggles bidirectional signal connections and wants tests before it moves, and the provider cluster needs a `ProviderService` signal because `on_provider_change` ends by refreshing the Start button, which would otherwise be a controller-to-controller call.

## Manual test

**Local filter.** Run an imagery search, then drag the cloud-cover or intersection sliders and change the date range: rows that no longer fit go grey, become unselectable and drop to the bottom of the page, and their footprints disappear from the map — with no new request. Widen a filter past what the search fetched and the (!) button appears; click it and it names which settings will not apply. Press Reset and the widgets return to what the search used. Click a sortable column header: the arrow appears, survives the filter re-filling the table, and the server re-sorts. Clear the search and the table and the (!) button both empty.

Inside a template, **and also via "See search results" on a template row in the project list**, the 'new image' icons must survive every filter change — that is the path this rewired.

**Account status.** Log in: the balance line fills in, the model list, provider lists and Mosaic/Image filters populate, and either the projects or the processings table opens. Leave the plugin open a few minutes and the balance keeps refreshing. Start a processing and the remaining limit drops on the next refresh. Log out and back in — the balance and provider lists must repopulate, not stay from the previous account.

**Regression surface.** The preview cell must still preview exactly once per click after a filter change (a stacked connection there previously added several preview layers), and dragging a slider through a range where no image flips fit/unfit must not re-fill the table. With the server unreachable at login, the plugin must retry the account status a bounded number of times and then warn *once* — not once per tick, and not forever. Logging out mid-retry must stop the polling. On a custom (non-Mapflow) plugin build the balance line stays empty and no limit is enforced.
