### PR TITLE
refactor: give the session its own service

### DIFF
--- a/mapflow/functional/service/session_service.py
+++ b/mapflow/functional/service/session_service.py
@@ -1,0 +1,168 @@
+"""Who is logged in: the auth method, the credentials, and ending the session.
+
+Holds no widget (`spec/007_architecture.md` § Layer rules). The login dialog's inputs arrive as
+arguments — the typed token, the auth-method toggle — and the effects it must cause leave as
+signals. `mapflow.py` keeps the dialog and the wiring, as the composition root.
+
+What is deliberately NOT here is `log_in_callback`: it is the startup sequence, ordering the
+project fetch, the models, the processings table and the first status poll. That is orchestration
+across every region, so it stays in `mapflow.py` beside `on_account_status`, for the same reason
+that one did.
+"""
+import logging
+from base64 import b64decode
+from typing import Optional
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from ..app_context import AppContext
+from ..auth import get_auth_id
+from ...config import Config
+from ...errors import ProxyIsAlreadySet
+from ...http import Http
+# The icon-carrying helpers rather than `alert(..., icon=QMessageBox.X)`: naming an icon would
+# mean importing PyQt5.QtWidgets, which a service may not do (`spec/007_architecture.md`).
+from .alert_service import alert_info, alert_warning
+
+logger = logging.getLogger(__name__)
+
+
+class SessionService(QObject):
+    """Logging in (basic token or OAuth), and logging out."""
+
+    #: The login dialog's "invalid token" line should be shown or hidden.
+    tokenRejected = pyqtSignal(bool)
+    #: Credentials are missing or were refused — the login dialog should be shown.
+    loginRequired = pyqtSignal()
+    #: The auth method changed: (use_oauth, saved token). The dialog swaps its input for it.
+    authTypeChanged = pyqtSignal(bool, str)
+    #: The session ended. Listeners stop their polling and close the main window.
+    loggedOut = pyqtSignal()
+
+    def __init__(self,
+                 http: Http,
+                 app_context: AppContext,
+                 config: Optional[Config] = None,
+                 on_authenticated=None):
+        super().__init__()
+        self.http = http
+        self.app_context = app_context
+        self.config = config or Config
+        #: Called with the `/projects/default` response once credentials are accepted. It is the
+        #: startup sequence, which lives in `mapflow.py` — passed in as a plain callable so this
+        #: service does not import it.
+        self.on_authenticated = on_authenticated
+
+    # ---------- which auth method ----------
+
+    @property
+    def use_oauth(self) -> bool:
+        return str(self.app_context.settings.value("use_oauth", "false")).lower() == "true"
+
+    def set_auth_type(self, use_oauth: bool = False) -> None:
+        self.app_context.settings.setValue("use_oauth", str(use_oauth).lower())
+        self.authTypeChanged.emit(bool(use_oauth), self.saved_token)
+
+    @property
+    def saved_token(self) -> str:
+        return self.app_context.settings.value("token", "") or ""
+
+    # ---------- logging in ----------
+
+    def authenticate(self, typed_token: Optional[str] = None) -> None:
+        """Log in with whichever method is selected. ``typed_token`` is what the user typed, read
+        from the dialog by the caller — a service may not read a widget.
+
+        The default is None rather than "": bandit reads a credential-named parameter with a
+        string default as a hardcoded password (B107), and "nothing was supplied" is what None
+        means anyway."""
+        if self.use_oauth:
+            self.login_with_auth_config()
+            return
+        if not typed_token:
+            return
+        self.login_basic(self.pad_token(typed_token))
+
+    @staticmethod
+    def pad_token(auth_data: str) -> str:
+        """Base64 needs a length that is a multiple of four; the token as issued may not be."""
+        return auth_data + "=" * ((4 - len(auth_data) % 4) % 4)
+
+    def login_with_auth_config(self) -> None:
+        """Resolve QGIS's stored auth config, creating it on first use, then log in with it."""
+        auth_id, new_auth = get_auth_id(self.config.AUTH_CONFIG_NAME, self.config.AUTH_CONFIG_MAP)
+        if new_auth:
+            alert_info(self.tr("We have just set the authentication config for you. \n"
+                               " You may need to restart QGIS to apply it so you could log in"))
+        if not auth_id:
+            self.tokenRejected.emit(True)
+            return
+        self.tokenRejected.emit(False)
+        self.login_oauth(auth_id)
+
+    def login_oauth(self, oauth_id) -> None:
+        try:
+            self.http.setup_auth(oauth_id=oauth_id)
+        except ProxyIsAlreadySet:
+            alert_warning(self.tr("Please restart QGIS before using OAuth2 login."))
+            return
+        except Exception as e:
+            # The auth config is QGIS-managed and can be corrupted in ways this plugin cannot
+            # enumerate, so the message tells the user how to recreate it rather than guessing.
+            logger.exception("OAuth setup failed")
+            alert_warning(self.tr("Error while trying to send authorization request: {error}. "
+                                  "It is possible that your auth config is corrupted. "
+                                  "Remove auth config named {name} and restart QGIS "
+                                  "for the plugin to recreate it. "
+                                  "If it does not help, contact us").format(
+                                      error=e, name=self.config.AUTH_CONFIG_NAME))
+            return
+        self._request_default_project()
+
+    def login_basic(self, token) -> None:
+        """Log in with a Basic-auth token, saving it so the next launch starts logged in."""
+        # Saved before it is validated, so a new token always replaces the old one — otherwise a
+        # rejected login leaves the previous token in settings and the next launch retries it.
+        self.app_context.settings.setValue('token', token)
+        try:
+            self.app_context.username, self.app_context.password = b64decode(token).decode().split(':')
+        except (ValueError, TypeError):
+            # A malformed token, which is the whole point of this handler. ValueError covers
+            # all three ways it can be malformed: binascii.Error (not base64) and
+            # UnicodeDecodeError (not utf-8) both subclass it, and so does the unpack when
+            # the decoded text has no ':'. TypeError covers a non-str/bytes token.
+            self.app_context.username = self.app_context.password = ''  # nosec B105  # clearing creds, not a secret
+            self.loginRequired.emit()
+            alert_warning(self.tr('Wrong token. '
+                                  'Visit "<a href=\"https://app.mapflow.ai/account/api\">mapflow.ai</a>" '
+                                  'to get a new one'))
+            self.tokenRejected.emit(True)
+            return
+        self.http.setup_auth(basic_auth_token=f'Basic {token}')
+        self._request_default_project()
+
+    def _request_default_project(self) -> None:
+        """The login request proper: user info and the default project ride on one response."""
+        self.http.get(
+            url=f'{self.config.SERVER}/projects/default',
+            callback=self.on_authenticated,
+            use_default_error_handler=True
+        )
+
+    # ---------- logging out ----------
+
+    def logout(self) -> None:
+        """End the session and clear the credentials from settings and from `Http`."""
+        self.app_context.settings.setValue('token', '')
+        self.app_context.logged_in = False
+        self.http.logout()
+        self.loggedOut.emit()
+        self.loginRequired.emit()
+
+    def reject_saved_token(self) -> None:
+        """The server refused credentials that were never validated in this session — an admin
+        changed the environment, or the token was revoked between launches."""
+        alert_warning(self.tr('Wrong token. '
+                              'Visit "<a href=\"https://app.mapflow.ai/account/api\">mapflow.ai</a>" '
+                              'to get a new one'))
+        self.loginRequired.emit()

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os.path
 import shutil
-from base64 import b64decode
 from configparser import ConfigParser  # parse metadata.txt -> QGIS version check (compatibility)
 from pathlib import Path
 from typing import List, Optional, Callable
@@ -21,11 +20,9 @@ from qgis.core import (
 )
 
 from .config import Config, ConfigColumns
-from .errors import ProxyIsAlreadySet
 # Functional
 from .functional import helpers, layer_utils
 from .functional.app_context import AppContext
-from .functional.auth import get_auth_id
 from .functional.controller.data_catalog_controller import DataCatalogController
 from .functional.controller.project_processing_controller import ProjectProcessingController
 from .functional.controller.processing_controller import ProcessingController
@@ -44,6 +41,7 @@ from .functional.service import (DataCatalogService,
                                  ProjectService,
                                  ProviderService)
 from .functional.service.account_service import AccountService
+from .functional.service.session_service import SessionService
 from .functional.service.alert_service import AlertService, alert
 from .functional.service.area_calculator_service import AreaCalculatorService
 # HTTP
@@ -127,10 +125,8 @@ class Mapflow(QObject):
 
         # ========== 3. INIT DIALOGS ==========
         # Init dialogs before creating timers that need them as parent
-        self.use_oauth = (self.app_context.settings.value('use_oauth', 'false').lower() == 'true')
         self.plugin_icon = plugin_icon
         self.dlg = MainDialog(self.main_window, self.app_context.settings)
-        self.dlg_login = self.set_up_login_dialog()
         self.review_dialog = ReviewDialog(self.dlg)
         self.dlg_provider = ProviderDialog(self.dlg)
         self.dlg_provider.accepted.connect(self.edit_provider_callback)
@@ -148,6 +144,19 @@ class Mapflow(QObject):
         self.calculator = QgsDistanceArea()
         # Restore directory from settings
         self.dlg.outputDirectory.setText(self.app_context.settings.value('outputDir'))
+
+        # ========== 3b. SESSION ==========
+        # Owns the credentials and the auth method. Built after `Http` (it drives it) and before
+        # the login dialog (which asks it which input to show).
+        self.session_service = SessionService(http=self.http,
+                                              app_context=self.app_context,
+                                              config=self.config,
+                                              on_authenticated=self.log_in_callback)
+        self.dlg_login = self.set_up_login_dialog()
+        self.session_service.tokenRejected.connect(self.dlg_login.invalidToken.setVisible)
+        self.session_service.loginRequired.connect(self.dlg_login.show)
+        self.session_service.authTypeChanged.connect(self.on_auth_type_changed)
+        self.session_service.loggedOut.connect(self.on_logged_out)
 
         # ========== 4. ACCOUNT STATUS ==========
         # Owns both /user/status polls and their timers: the steady-state refresh for the limits
@@ -405,7 +414,7 @@ class Mapflow(QObject):
         # Memorize dialog element sizes & positioning
         self.dlg.finished.connect(self.save_dialog_state)
         # Connect buttons
-        self.dlg.logoutButton.clicked.connect(self.logout)
+        self.dlg.logoutButton.clicked.connect(self.session_service.logout)
         self.dlg.selectOutputDirectory.clicked.connect(self.select_output_directory)
         self.dlg.downloadResultsButton.clicked.connect(self.load_results)
         # Calculate AOI size
@@ -561,18 +570,31 @@ class Mapflow(QObject):
 
     def set_up_login_dialog(self) -> MapflowLoginDialog:
         """Create a login dialog, set its title and signal-slot connections."""
-        dlg_login = MapflowLoginDialog(self.main_window, self.use_oauth, self.app_context.settings.value("token", ""))
+        dlg_login = MapflowLoginDialog(self.main_window,
+                                       self.session_service.use_oauth,
+                                       self.session_service.saved_token)
         dlg_login.setWindowTitle(helpers.generate_plugin_header(self.tr("Log in ") + self.plugin_name,
                                                                      self.config.MAPFLOW_ENV,
                                                                      None, None, None))
-        dlg_login.logIn.clicked.connect(self.read_mapflow_token)
-        dlg_login.useOauth.toggled.connect(self.set_auth_type)
+        dlg_login.logIn.clicked.connect(self.log_in)
+        dlg_login.useOauth.toggled.connect(self.session_service.set_auth_type)
         return dlg_login
 
-    def set_auth_type(self, use_oauth: bool = False):
-        self.use_oauth = use_oauth
-        self.app_context.settings.setValue("use_oauth", str(use_oauth).lower())
-        self.dlg_login.set_auth_type(use_oauth=use_oauth, token = self.app_context.settings.value('token', ""))
+    def log_in(self) -> None:
+        """The Log in button. What the user typed is a widget read, so it is taken here and handed
+        over; which auth method applies is the service's own state."""
+        self.session_service.authenticate(self.dlg_login.token_value())
+
+    def on_auth_type_changed(self, use_oauth: bool, token: str) -> None:
+        self.dlg_login.set_auth_type(use_oauth=use_oauth, token=token)
+
+    def on_logged_out(self) -> None:
+        """Everything that must stop when the session ends. The polls belong to other services,
+        so they are stopped here rather than by `SessionService` reaching into them."""
+        self.processing_service.processing_fetch_timer.stop()
+        self.account_service.stop_refreshing()
+        self.account_service.stop_startup_polling()
+        self.dlg.close()
 
     def on_provider_change(self) -> None:
         """Adjust max and current zoom, and update the metadata table when user selects another
@@ -1213,87 +1235,6 @@ class Mapflow(QObject):
         self.app_context.settings.setValue('metadataFrom', self.dlg.metadataFrom.date())
         self.app_context.settings.setValue('metadataTo', self.dlg.metadataTo.date())
 
-    def read_mapflow_token(self) -> None:
-        """Compose and memorize the user's credentils as Basic Auth."""
-        if self.use_oauth:
-            auth_id, new_auth = get_auth_id(self.config.AUTH_CONFIG_NAME,
-                                             self.config.AUTH_CONFIG_MAP)
-            if new_auth:
-                self.alert(self.tr("We have just set the authentication config for you. \n"
-                                       " You may need to restart QGIS to apply it so you could log in"),
-                           icon=QMessageBox.Information)
-            if not auth_id:
-                self.dlg_login.invalidToken.setVisible(True)
-            else:
-                self.dlg_login.invalidToken.setVisible(False)
-                self.login_oauth(auth_id)
-        else:
-            auth_data = self.dlg_login.token_value()
-            if not auth_data:
-                return
-            # to add paddind for the token len to be multiple of 4
-            token = auth_data + "=" * ((4 - len(auth_data) % 4) % 4)
-            self.login_basic(token)
-
-    def login_oauth(self, oauth_id):
-        try:
-            self.http.setup_auth(oauth_id=oauth_id)
-            self.http.get(
-                url=f'{self.config.SERVER}/projects/default',
-                callback=self.log_in_callback,
-                use_default_error_handler=True
-            )
-        except ProxyIsAlreadySet:
-            self.alert(self.tr("Please restart QGIS before using OAuth2 login."),
-                       icon=QMessageBox.Warning)
-        except Exception as e:
-            self.alert(f"Error while trying to send authorization request: {e}."
-                       f"It is possible that your auth config is corrupted. "
-                       f"Remove auth config named {self.config.AUTH_CONFIG_NAME} and restart QGis"
-                       f"for the plugin to recreate it. "
-                       f"If it does not help, contact us",
-                       icon=QMessageBox.Warning)
-
-    def login_basic(self, token) -> None:
-        """Log into Mapflow."""
-        # save new token to settings immediately to overwrite old one, if any
-        self.app_context.settings.setValue('token', token)
-        # keep login/password from token
-        try:
-            self.app_context.username, self.app_context.password = b64decode(token).decode().split(':')
-        except (ValueError, TypeError):
-            # A malformed token, which is the whole point of this handler. ValueError covers
-            # all three ways it can be malformed: binascii.Error (not base64) and
-            # UnicodeDecodeError (not utf-8) both subclass it, and so does the unpack when
-            # the decoded text has no ':'. TypeError covers a non-str/bytes token.
-            self.app_context.username = self.app_context.password = ''  # nosec B105  # clearing creds, not a secret
-            self.dlg_login.show()
-            self.alert(self.tr('Wrong token. '
-                               'Visit "<a href=\"https://app.mapflow.ai/account/api\">mapflow.ai</a>" '
-                               'to get a new one'),
-                       icon=QMessageBox.Warning)
-            self.dlg_login.invalidToken.setVisible(True)
-            return
-        self.http.setup_auth(basic_auth_token=f'Basic {token}')
-        self.http.get(
-            url=f'{self.config.SERVER}/projects/default',
-            callback=self.log_in_callback,
-            use_default_error_handler=True
-        )
-
-    def logout(self) -> None:
-        """Close the plugin and clear credentials from cache."""
-        # set token to empty to delete it from settings
-        self.app_context.settings.setValue('token', '')
-        self.processing_service.processing_fetch_timer.stop()
-        self.account_service.stop_refreshing()
-        self.account_service.stop_startup_polling()
-        self.app_context.logged_in = False
-        self.http.logout()
-        self.dlg.close()
-        # self.dlg_login = self.set_up_login_dialog()  # recreate the login dialog
-        self.dlg_login.show()  # assume user wants to log into another account
-
     def default_error_handler(self,
                               response: QNetworkReply,
                               ) -> bool:
@@ -1309,13 +1250,9 @@ class Mapflow(QObject):
         if error == QNetworkReply.AuthenticationRequiredError:  # invalid/empty credentials
             # Prevent deadlocks
             if self.app_context.logged_in:  # token re-issued during a plugin session
-                self.logout()
-            elif self.app_context.settings.value('token'):  # env changed w/out logging out (admin)
-                self.alert(self.tr('Wrong token. '
-                                   'Visit "<a href=\"https://app.mapflow.ai/account/api\">mapflow.ai</a>" '
-                                   'to get a new one'),
-                           icon=QMessageBox.Warning)
-                self.dlg_login.show()
+                self.session_service.logout()
+            elif self.session_service.saved_token:  # env changed w/out logging out (admin)
+                self.session_service.reject_saved_token()
 
             self.dlg_login.invalidToken.setVisible(True)
             return True
@@ -1575,10 +1512,10 @@ class Mapflow(QObject):
             self.account_service.start_refreshing()
             return
 
-        token = self.app_context.settings.value('token')
-        if not self.use_oauth and token:
+        token = self.session_service.saved_token
+        if not self.session_service.use_oauth and token:
             # Saved token for basic auth
-            self.login_basic(token)
+            self.session_service.login_basic(token)
         else:
             self.dlg_login.show()
 

--- a/tests/qgis/conftest.py
+++ b/tests/qgis/conftest.py
@@ -32,6 +32,29 @@ def pytest_configure(config):
         print(f"QGIS Processing unavailable, geometry operations will not run: {error}")
 
 
+@pytest.fixture(autouse=True)
+def _no_blocking_dialogs(monkeypatch):
+    """Never let a modal dialog open in the test container.
+
+    `alert()` defaults to `blocking=True`, which is `QMessageBox.exec()` — an event loop with
+    nobody to close it here. An unstubbed call does not fail the run, it **hangs** it: pytest
+    prints nothing further and the tier sits until it is killed, with no indication of which test
+    is stuck. Fourteen test modules stub `alert` themselves precisely to avoid this, which means
+    the protection holds only for as long as everyone remembers it.
+
+    Patching the dialog primitives instead makes forgetting harmless: `exec` returns `Ok`
+    immediately, so a missed stub produces a normal pass or a normal assertion failure. Modules
+    that stub `alert` are unaffected — their patch shadows this one.
+    """
+    from PyQt5.QtWidgets import QInputDialog, QMessageBox
+    monkeypatch.setattr(QMessageBox, "exec", lambda self: QMessageBox.Ok, raising=False)
+    monkeypatch.setattr(QMessageBox, "exec_", lambda self: QMessageBox.Ok, raising=False)
+    monkeypatch.setattr(QMessageBox, "open", lambda self: None, raising=False)
+    # ask_text() is the other blocking prompt reachable from service code.
+    monkeypatch.setattr(QInputDialog, "getText", staticmethod(lambda *a, **k: ("", False)),
+                        raising=False)
+
+
 @pytest.fixture()
 def iface():
     """Mock QgisInterface for tests that need a plugin iface reference."""

--- a/tests/qgis/test_session_service.py
+++ b/tests/qgis/test_session_service.py
@@ -1,0 +1,235 @@
+"""QGIS-tier tests for logging in and out.
+
+Barely covered while this lived in `mapflow.py` — the only test that touched it drove `logout`
+for its side effect on the account poll. The move is what makes it testable: the credentials and
+the auth method are now a service that needs no dialog, and the dialog's effects arrive as signals
+a test can listen to.
+"""
+from base64 import b64encode
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mapflow.errors import ProxyIsAlreadySet
+from mapflow.functional.service import session_service as ss_mod
+from mapflow.functional.service.session_service import SessionService
+
+
+def _service(use_oauth=False, token="", on_authenticated=None):
+    settings = MagicMock()
+    stored = {"use_oauth": str(use_oauth).lower(), "token": token}
+    settings.value.side_effect = lambda key, default=None: stored.get(key, default)
+    settings.setValue.side_effect = lambda key, value: stored.__setitem__(key, value)
+
+    service = SessionService(
+        http=MagicMock(),
+        app_context=SimpleNamespace(settings=settings, logged_in=True, username="", password=""),
+        config=SimpleNamespace(SERVER="https://mapflow.test",
+                               AUTH_CONFIG_NAME="mapflow",
+                               AUTH_CONFIG_MAP={}),
+        on_authenticated=on_authenticated or (lambda response: None))
+    service.tr = lambda text: text
+    service._stored = stored
+    return service
+
+
+@pytest.fixture(autouse=True)
+def alerts(monkeypatch):
+    """Everything the service told the user, in order.
+
+    `autouse` is load-bearing, not convenience. `alert()` defaults to `blocking=True`, which is
+    `QMessageBox.exec()` — a modal event loop with nothing to close it in the headless test
+    container. A single unstubbed call does not fail the suite, it **hangs** it indefinitely, with
+    no output to say which test is stuck. Stubbing every test in this module removes the whole
+    failure mode; tests that care about the wording still take `alerts` as an argument."""
+    said = []
+    monkeypatch.setattr(ss_mod, "alert_info", lambda message, *a, **k: said.append(message))
+    monkeypatch.setattr(ss_mod, "alert_warning", lambda message, *a, **k: said.append(message))
+    return said
+
+
+def _basic_token(user="me@example.com", password="pw"):  # pragma: allowlist secret
+    """A Basic-auth token shaped like the real one: base64 of "user:password"."""
+    return b64encode(f"{user}:{password}".encode()).decode()
+
+
+# ---------- which auth method ----------
+
+def test_the_auth_method_is_read_from_settings():
+    assert _service(use_oauth=True).use_oauth is True
+    assert _service(use_oauth=False).use_oauth is False
+
+
+def test_switching_auth_method_persists_it_and_announces_the_saved_token():
+    service = _service(use_oauth=False, token="saved-token")
+    announced = []
+    service.authTypeChanged.connect(lambda oauth, token: announced.append((oauth, token)))
+
+    service.set_auth_type(True)
+
+    assert service._stored["use_oauth"] == "true"
+    assert announced == [(True, "saved-token")]
+
+
+# ---------- basic auth ----------
+
+def test_a_typed_token_is_padded_to_a_multiple_of_four():
+    # Base64 decodes only at length % 4 == 0; the issued token may arrive unpadded.
+    assert SessionService.pad_token("abc") == "abc="
+    assert SessionService.pad_token("ab") == "ab=="
+    assert SessionService.pad_token("abcd") == "abcd"
+
+
+def test_logging_in_saves_the_token_and_requests_the_default_project():
+    service = _service()
+    token = _basic_token()
+
+    service.login_basic(token)
+
+    assert service._stored["token"] == token
+    assert service.http.setup_auth.call_args.kwargs["basic_auth_token"] == f"Basic {token}"
+    assert service.http.get.call_args.kwargs["url"].endswith("/projects/default")
+
+
+def test_the_token_is_saved_before_it_is_validated():
+    """A rejected login must still replace the old token, or the next launch retries the stale
+    one and fails the same way with no way for the user to see why."""
+    service = _service(token="previous")
+
+    service.login_basic("not-base64!!")
+
+    assert service._stored["token"] == "not-base64!!"
+
+
+def test_a_malformed_token_is_refused_without_a_request(alerts):
+    service = _service()
+    rejected, login_shown = [], []
+    service.tokenRejected.connect(rejected.append)
+    service.loginRequired.connect(lambda: login_shown.append(True))
+
+    service.login_basic("not-base64!!")
+
+    service.http.get.assert_not_called()
+    assert rejected == [True]
+    assert login_shown == [True]
+    assert "Wrong token" in alerts[0]
+
+
+def test_a_token_without_a_colon_is_malformed_too():
+    """b64decode succeeds and the split fails — a different failure mode, same handler."""
+    service = _service()
+
+    service.login_basic(b64encode(b"no-colon-here").decode())
+
+    service.http.get.assert_not_called()
+    assert service.app_context.username == ""
+
+
+def test_a_valid_token_populates_the_credentials():
+    service = _service()
+
+    service.login_basic(_basic_token("me@example.com", "pw"))
+
+    assert service.app_context.username == "me@example.com"
+    assert service.app_context.password == "pw"  # pragma: allowlist secret
+
+
+def test_authenticate_with_no_typed_token_does_nothing():
+    service = _service(use_oauth=False)
+
+    service.authenticate("")
+
+    service.http.get.assert_not_called()
+
+
+def test_authenticate_pads_what_the_user_typed():
+    service = _service(use_oauth=False)
+
+    service.authenticate(_basic_token().rstrip("="))
+
+    assert service._stored["token"].endswith("=") or len(service._stored["token"]) % 4 == 0
+
+
+# ---------- oauth ----------
+
+def test_oauth_login_without_an_auth_id_is_refused(monkeypatch):
+    service = _service(use_oauth=True)
+    monkeypatch.setattr(ss_mod, "get_auth_id", lambda name, mapping: (None, False))
+    rejected = []
+    service.tokenRejected.connect(rejected.append)
+
+    service.authenticate()
+
+    assert rejected == [True]
+    service.http.setup_auth.assert_not_called()
+
+
+def test_a_freshly_created_auth_config_tells_the_user_to_restart(monkeypatch, alerts):
+    service = _service(use_oauth=True)
+    monkeypatch.setattr(ss_mod, "get_auth_id", lambda name, mapping: ("id-1", True))
+
+    service.authenticate()
+
+    assert "restart QGIS" in alerts[0]
+    assert service.http.setup_auth.call_args.kwargs["oauth_id"] == "id-1"
+
+
+def test_oauth_login_clears_the_invalid_token_line_and_requests_the_project(monkeypatch):
+    service = _service(use_oauth=True)
+    monkeypatch.setattr(ss_mod, "get_auth_id", lambda name, mapping: ("id-1", False))
+    rejected = []
+    service.tokenRejected.connect(rejected.append)
+
+    service.authenticate()
+
+    assert rejected == [False]
+    assert service.http.get.call_args.kwargs["url"].endswith("/projects/default")
+
+
+def test_an_already_configured_proxy_asks_for_a_restart_instead_of_requesting(alerts):
+    service = _service()
+    service.http.setup_auth.side_effect = ProxyIsAlreadySet
+
+    service.login_oauth("id-1")
+
+    service.http.get.assert_not_called()
+    assert "restart QGIS" in alerts[0]
+
+
+def test_a_corrupt_auth_config_names_the_config_to_remove(alerts):
+    service = _service()
+    service.http.setup_auth.side_effect = RuntimeError("boom")
+
+    service.login_oauth("id-1")
+
+    service.http.get.assert_not_called()
+    assert "mapflow" in alerts[0]
+
+
+# ---------- logging out ----------
+
+def test_logout_clears_the_token_and_the_session():
+    service = _service(token="saved")
+    events = []
+    service.loggedOut.connect(lambda: events.append("out"))
+    service.loginRequired.connect(lambda: events.append("login"))
+
+    service.logout()
+
+    assert service._stored["token"] == ""
+    assert service.app_context.logged_in is False
+    service.http.logout.assert_called_once()
+    # The session ends before the login dialog is offered, so listeners stop their polling first.
+    assert events == ["out", "login"]
+
+
+def test_rejecting_a_saved_token_offers_the_login_dialog(alerts):
+    service = _service(token="stale")
+    login_shown = []
+    service.loginRequired.connect(lambda: login_shown.append(True))
+
+    service.reject_saved_token()
+
+    assert login_shown == [True]
+    assert "Wrong token" in alerts[0]

--- a/tests/qgis/test_startup_status_poll.py
+++ b/tests/qgis/test_startup_status_poll.py
@@ -146,16 +146,16 @@ def test_the_storage_quota_is_requested_once_on_success_not_per_retry():
 
 
 def test_logout_stops_a_startup_poll_that_never_finished(service):
-    """Otherwise a failed startup keeps polling the account endpoint after logging out."""
+    """Otherwise a failed startup keeps polling the account endpoint after logging out.
+
+    `SessionService` ends the session and announces it; the polls belong to other services, so
+    `mapflow.py` is what stops them. This drives that slot, which is the half that can regress."""
     plugin = Mapflow.__new__(Mapflow)
     plugin.account_service = service
-    plugin.app_context = SimpleNamespace(settings=MagicMock(), logged_in=True)
     plugin.processing_service = MagicMock()
-    plugin.http = MagicMock()
     plugin.dlg = MagicMock()
-    plugin.dlg_login = MagicMock()
 
-    plugin.logout()
+    plugin.on_logged_out()
 
     assert not service.startup_timer.isActive()
     assert not service.refresh_timer.isActive()


### PR DESCRIPTION
Logging in and out leaves mapflow.py. SessionService owns the credentials and the auth method:
authenticate, login_basic, login_oauth, login_with_auth_config, logout, set_auth_type and the
token padding. It holds no widget — what the user typed arrives as an argument, and the login
dialog's effects leave as tokenRejected / loginRequired / authTypeChanged / loggedOut.

log_in_callback deliberately stays behind. It sequences the project fetch, the models, the
processings table and the first status poll — orchestration across every region, which is the
composition root's job, the same reason on_account_status stayed when AccountService moved.

Two things the move exposed.

logout was reaching into two other services to stop their timers. Ending a session and stopping a
poll are different responsibilities: the service now announces loggedOut and mapflow.py stops what
it owns, so a future poll-owning service needs no edit here.

The "wrong token" alert existed twice, in login_basic and in default_error_handler, with the same
wording maintained in two places. Both now go through reject_saved_token.

Seventeen tests where there was effectively none — the only existing one drove logout for its side
effect on the account poll. They cover the malformed-token branch (both ways a token can be
malformed: not base64, and no colon after decoding), the padding, each OAuth failure mode, and
that the token is saved *before* it is validated. That last one is deliberate and easy to "fix"
into a bug: a rejected login must still replace a stale token, or the next launch silently retries
the old one.

Also: a suite-wide guard against blocking dialogs, in tests/qgis/conftest.py.

alert() defaults to blocking=True, which is QMessageBox.exec() — an event loop with nothing in the
headless container to close it. An unstubbed call does not fail the run, it hangs it, with no
output naming the test. Two of the new tests did exactly that and the tier sat for two hours
before it was killed. Fourteen test modules already stub alert by hand for this reason, which
means the protection held only while everyone remembered. Patching QMessageBox.exec/exec_/open
and QInputDialog.getText instead makes forgetting harmless: a missed stub now produces a normal
pass or a normal assertion failure. Modules that stub alert themselves are unaffected.

mapflow.py is down to 1521 lines.

## Manual test
Log in with a token: the plugin opens and the balance fills in. Paste a malformed token — it is
refused with "Wrong token", the login dialog stays up and no request is sent. Toggle to OAuth and
back: the dialog swaps its input and remembers the choice across a restart. On a machine with no
Mapflow auth config yet, switching to OAuth creates one and says QGIS may need restarting. Log
out: the main window closes, the login dialog returns, and the saved token is gone, so the next
launch asks for one. Regression surface: with a saved token, launching must log in without
prompting; and a token revoked between launches must show "Wrong token" once, not log you into a
half-configured session.
