### PR TITLE
refactor: move the table <-> footprint selection sync to SearchController

### DIFF
--- a/mapflow/functional/controller/search_controller.py
+++ b/mapflow/functional/controller/search_controller.py
@@ -33,7 +33,9 @@ class SearchController(QObject):
                  app_context=None,
                  widen_warning_button=None,
                  reset_filters_button=None,
-                 clear_search_button=None):
+                 clear_search_button=None,
+                 area_calculator_service=None,
+                 aoi_view=None):
         super().__init__()
         self.search_service = search_service
         self.search_view = search_view
@@ -41,6 +43,13 @@ class SearchController(QObject):
         self.provider_service = provider_service
         self.local_filter_service = local_filter_service
         self.app_context = app_context
+        #: Selecting a search result changes the processing area, so the cost is recomputed from
+        #: the AOI layer the combo currently names.
+        self.area_calculator_service = area_calculator_service
+        self.aoi_view = aoi_view
+        #: The table->layer connection handle, so the layer->table direction can take it down
+        #: while it drives. Set by `connect_table_selection`.
+        self._table_selection_connection = None
 
         #: Guards the ``metadataTableFilled`` -> ``apply_local_filter`` -> ``fill_table`` ->
         #: ``metadataTableFilled`` loop: the re-fill below re-emits the signal that called us.
@@ -92,6 +101,73 @@ class SearchController(QObject):
     def reconnect_cell_preview(self) -> None:
         """Rewire the Preview-cell click after a table refill."""
         self.search_view.connect_cell_preview(self.preview_search_from_cell)
+
+    # ---------- table <-> footprint layer, both directions ----------
+    #
+    # Each direction writes the selection the other listens to, so each disconnects the opposite
+    # handler before touching a selection and reconnects afterwards. Without that, one click
+    # ping-pongs between them until the stack runs out.
+
+    def on_metadata_layer_ready(self, layer) -> None:
+        """A new footprint layer: selecting a footprint should select its table row."""
+        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
+            self.sync_layer_selection_with_table)
+
+    def connect_table_selection(self) -> None:
+        """Wire the table->layer direction, remembering the handle so the other direction can
+        take it down while it drives."""
+        self._table_selection_connection = self.search_view.connect_table_selection(
+            self.sync_table_selection_with_layer)
+
+    def sync_table_selection_with_layer(self, *args) -> None:
+        """Rows were selected: highlight their footprints and adopt the image's zoom."""
+        local_indices = self.search_view.selected_local_indices()
+        layer = self.app_context.metadata_layer
+        try:
+            layer.selectionChanged.disconnect(self.app_context.meta_layer_table_connection)
+        except (RuntimeError, AttributeError, TypeError):
+            # No layer yet (nothing searched), or it has been removed. Nothing to sync to.
+            return
+        self.search_view.ensure_search_provider(self.provider_service)
+        try:
+            layer.selectByExpression("local_index in {}".format(tuple(local_indices)))
+        except RuntimeError:  # layer deleted between the check and here
+            pass
+        except Exception:
+            # Reconnect before propagating, or the map silently stops driving the table.
+            self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
+                self.sync_layer_selection_with_table)
+            raise
+        # The zoom is adopted BEFORE the cost is recomputed, and with the combo silent — see
+        # `set_zoom_silently` for why the order and the blocking both matter.
+        self.search_view.set_zoom_silently(self.search_view.selected_zoom())
+        self.area_calculator_service.calculate_aoi_area_polygon_layer(self.aoi_view.current_layer())
+        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
+            self.sync_layer_selection_with_table)
+
+    def sync_layer_selection_with_table(self, selected_ids: List[int]) -> None:
+        """Footprints were selected on the map: select the matching rows.
+
+        ``selected_ids`` are feature ids, not image ids, so each is resolved to its `local_index`
+        before the table is searched for it.
+        """
+        self.search_view.disconnect_table_selection(self._table_selection_connection)
+        try:
+            if not selected_ids:
+                self.search_view.clear_metadata_selection()
+                return
+            local_indices = []
+            for selected_id in selected_ids:
+                local_indices.append(
+                    self.app_context.metadata_layer.getFeature(selected_id)["local_index"])
+            self.search_view.select_rows_by_local_index(local_indices)
+        finally:
+            self.connect_table_selection()
+
+    def sync_image_id_with_table(self, image_id: str) -> None:
+        """An image id typed or cleared elsewhere: clear the table selection when it names no row."""
+        if not image_id or not self.search_view.has_row_with_text(image_id):
+            self.search_view.clear_metadata_selection()
 
     # ---------- the local filter ----------
 

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
 from PyQt5.QtGui import QBrush, QColor
-from PyQt5.QtWidgets import QPushButton, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QPushButton, QWidget
 
 from ..helpers import utc_date_from_iso
 from ...dialogs.main_dialog import MainDialog
@@ -234,6 +234,76 @@ class SearchView(QObject):
 
     def metadata_row_count(self) -> int:
         return self.dlg.metadataTable.rowCount()
+
+    # ---------- selection, for the table <-> footprint-layer sync ----------
+
+    def selected_local_indices(self) -> List[str]:
+        """The `local_index` of every selected row — the key the footprint layer is keyed by."""
+        selected = self.dlg.metadataTable.selectedItems()
+        if not selected:
+            return []
+        return [self.dlg.metadataTable.item(cell.row(), self.config.LOCAL_INDEX_COLUMN).text()
+                for cell in selected]
+
+    def selected_zoom(self) -> Optional[str]:
+        """The zoom of the first selected row. Different zooms across a multi-selection are not
+        allowed, so the first one speaks for all of them."""
+        selected = self.dlg.metadataTable.selectedItems()
+        if not selected:
+            return None
+        return self.dlg.metadataTable.item(selected[0].row(), self.config.ZOOM_COLUMN_INDEX).text()
+
+    def set_zoom_silently(self, zoom: Optional[str]) -> None:
+        """Set the zoom combo without emitting `currentIndexChanged`.
+
+        Unblocked, that signal reaches `on_zoom_change` and fires a SECOND cost request — using
+        the zoom from before this call, so the two race and the stale one can win.
+        """
+        index = -1 if zoom is None else self.dlg.zoomCombo.findText(zoom)
+        self.dlg.zoomCombo.blockSignals(True)
+        self.dlg.zoomCombo.setCurrentIndex(0 if index == -1 else index)
+        self.dlg.zoomCombo.blockSignals(False)
+
+    def select_rows_by_local_index(self, local_indices: List[str]) -> None:
+        """Select the rows carrying these `local_index` values, clearing any other selection.
+
+        Multi-select is turned on for the duration because `selectRow` otherwise replaces the
+        previous selection instead of adding to it, and restored in a `finally` so an exception
+        cannot leave the results table in a mode the user cannot get out of.
+        """
+        table = self.dlg.metadataTable
+        table.setSelectionMode(QAbstractItemView.MultiSelection)
+        try:
+            rows = []
+            for local_index in local_indices:
+                rows += [item.row() for item in table.findItems(str(local_index), Qt.MatchExactly)
+                         if item.column() == self.config.LOCAL_INDEX_COLUMN]
+            table.clearSelection()
+            for row in rows:
+                table.selectRow(row)
+        finally:
+            table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+
+    def clear_metadata_selection(self) -> None:
+        self.dlg.metadataTable.clearSelection()
+
+    def has_row_with_text(self, text: str) -> bool:
+        return bool(self.dlg.metadataTable.findItems(text, Qt.MatchExactly))
+
+    def connect_table_selection(self, handler):
+        return self.dlg.metadataTable.itemSelectionChanged.connect(handler)
+
+    def disconnect_table_selection(self, connection) -> None:
+        """Drop the table->layer handler while the layer is driving the table.
+
+        Guarded, unlike the call this replaces: Qt raises `TypeError` when the handle was never
+        connected, and an unguarded raise here aborts the caller *after* it has switched the table
+        to multi-select, leaving the results table stuck in a mode the user cannot leave.
+        """
+        try:
+            self.dlg.metadataTable.itemSelectionChanged.disconnect(connection)
+        except (RuntimeError, TypeError):
+            pass
 
     # ---------- pagination ----------
 

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import (
 )
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
-    QAbstractItemView, QAction, QApplication, QFileDialog,
+    QAction, QApplication, QFileDialog,
     QMenu, QMessageBox, QWidget, QToolButton
 )
 from qgis.core import (
@@ -216,7 +216,6 @@ class Mapflow(QObject):
                                                             app_context=self.app_context,
                                                             config=self.config,
                                                             data_catalog_service=self.data_catalog_service)
-        self.provider_service.selection_sync_callback = self.sync_layer_selection_with_table
 
         self.processing_service = ProcessingService(http=self.http,
                                                     dlg=self.dlg,
@@ -284,11 +283,11 @@ class Mapflow(QObject):
         # Search wiring. Results/pager signals stay here for now — the run and pagination
         # handlers they end at are still mapflow.py slots (see SearchController's docstring).
         self.search_service.resultsReceived.connect(self._on_search_results)
-        self.search_service.metadataLayerReady.connect(self._on_metadata_layer_ready)
         self.search_service.pagerChanged.connect(self.search_view.show_pages)
         self.search_service.pagerHidden.connect(self.search_view.hide_pages)
+        self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
         # Owns the preview-dispatch handlers (search button, cell/double click), the local filter
-        # over the fetched results, and their wiring.
+        # over the fetched results, the two-way table<->footprint selection sync, and their wiring.
         self.search_controller = SearchController(search_service=self.search_service,
                                                   search_view=self.search_view,
                                                   preview_service=self.preview_service,
@@ -299,8 +298,9 @@ class Mapflow(QObject):
                                                   app_context=self.app_context,
                                                   widen_warning_button=self.dlg.searchWidenWarning,
                                                   reset_filters_button=self.dlg.resetSearchFilters,
-                                                  clear_search_button=self.dlg.clearSearch)
-        self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
+                                                  clear_search_button=self.dlg.clearSearch,
+                                                  aoi_view=self.aoi_view)
+        self.search_service.metadataLayerReady.connect(self.search_controller.on_metadata_layer_ready)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
         # not domain logic).
@@ -397,7 +397,13 @@ class Mapflow(QObject):
                                                              provider_service=self.provider_service,
                                                              use_imagery_extent=self.use_imagery_extent)
         self.project_service.area_calculator_service = self.area_calculator_service
-        
+        # SearchController is built well before this service (it is needed by the search wiring
+        # above), so its cost-recompute collaborator is set here, as the other back-links are.
+        self.search_controller.area_calculator_service = self.area_calculator_service
+        # Restoring a provider's saved selection re-selects footprints, which must drive the table.
+        self.provider_service.selection_sync_callback = \
+            self.search_controller.sync_layer_selection_with_table
+
         # ========== 11. SETUP METADATA FILTERS ==========
         self.dlg.minIntersection.setValue(int(self.app_context.settings.value('metadataMinIntersection', 0)))
         self.dlg.maxCloudCover.setValue(int(self.app_context.settings.value('metadataMaxCloudCover', 100)))
@@ -445,8 +451,7 @@ class Mapflow(QObject):
         self.dlg.editProvider.clicked.connect(self.edit_provider)
         self.dlg.removeProvider.clicked.connect(self.remove_provider)
 
-        self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
-            self.sync_table_selection_with_image_id_and_layer)
+        self.search_controller.connect_table_selection()
         self.app_context.meta_layer_table_connection = None
         self.dlg.getMetadata.clicked.connect(self.handle_metadata_button_click)
         self.dlg.metadataTable.cellClicked.connect(self.on_metadata_table_cell_clicked)
@@ -968,111 +973,6 @@ class Mapflow(QObject):
         """Built-in Qt sorting stays OFF: results already arrive in the server's sort order, and
         a header click re-requests rather than sorting locally."""
         self.search_view.fill_table(geoms, sort=False)
-
-    def _on_metadata_layer_ready(self, layer) -> None:
-        """Selecting a footprint on the map selects the matching table row (and triggers preview)."""
-        self.app_context.meta_layer_table_connection = layer.selectionChanged.connect(
-            self.sync_layer_selection_with_table)
-
-    def sync_table_selection_with_image_id_and_layer(self) -> None:
-        """
-        Every time user selects a row in the metadata table, select the
-        corresponding feature in the metadata layer and put the selected image's
-        id into the "Image ID" field.
-        """
-        local_index_column = self.config.LOCAL_INDEX_COLUMN
-        key = 'local_index'
-
-        selected_cells = self.dlg.metadataTable.selectedItems()
-        if not selected_cells:
-            selected_rows = local_indices = []
-        else:
-            selected_rows = [cell.row() for cell in selected_cells]
-            local_indices = [self.dlg.metadataTable.item(row, local_index_column).text() for row in selected_rows]
-        try:
-            self.app_context.metadata_layer.selectionChanged.disconnect(self.app_context.meta_layer_table_connection)
-            # disconnect to prevent loop of signals
-        except (RuntimeError, AttributeError, TypeError):
-            # metadata layer was removed or not initialized
-            return
-        self.replace_search_provider_index()
-
-        try:
-            self.app_context.metadata_layer.selectByExpression(f"{key} in {tuple(local_indices)}")
-        except RuntimeError:  # layer has been deleted
-            pass
-        except Exception as e:
-            self.app_context.meta_layer_table_connection = self.app_context.metadata_layer.selectionChanged.connect(
-                self.sync_layer_selection_with_table)
-            raise e
-        # Set the zoom from the selected image BEFORE recomputing cost, with the combo's
-        # signals blocked. Otherwise zoomCombo.currentIndexChanged -> on_zoom_change fires a
-        # SECOND, duplicate cost request (and the first one below would use the stale zoom).
-        if selected_rows:
-            zooms = [self.dlg.metadataTable.item(row, self.config.ZOOM_COLUMN_INDEX).text() for row in selected_rows]
-            zoom_index = self.dlg.zoomCombo.findText(zooms[0])  # different zooms are not allowed
-        else:
-            zoom_index = -1
-        self.dlg.zoomCombo.blockSignals(True)
-        self.dlg.zoomCombo.setCurrentIndex(0 if zoom_index == -1 else zoom_index)
-        self.dlg.zoomCombo.blockSignals(False)
-        self.area_calculator_service.calculate_aoi_area_polygon_layer(self.dlg.polygonCombo.currentLayer())
-        self.app_context.meta_layer_table_connection = self.app_context.metadata_layer.selectionChanged.connect(
-            self.sync_layer_selection_with_table)
-
-    def sync_layer_selection_with_table(self, selected_ids: List[int]) -> None:
-        """
-        Every time user selects an image in the metadata layer, select the corresponding
-        row in the table and fill out the image id in the providers tab.
-
-        :param selected_ids: The selected feature IDs. These aren't the image IDs, but rather
-            the primary keys of the features.
-        """
-        self.dlg.metadataTable.setSelectionMode(QAbstractItemView.MultiSelection)
-        # Disconnect to avoid backwards signal and possible infinite loop;
-        # connection is restored before return
-        key = 'local_index'
-        id_column_index = self.config.LOCAL_INDEX_COLUMN
-
-        self.dlg.metadataTable.itemSelectionChanged.disconnect(self.meta_table_layer_connection)
-
-        try:
-            if not selected_ids:
-                self.dlg.metadataTable.clearSelection()
-                return
-            found_items = []
-            for selected_id in selected_ids:
-                selected_local_index = self.app_context.metadata_layer.getFeature(selected_id)[key]
-                for item in self.dlg.metadataTable.findItems(str(selected_local_index), Qt.MatchExactly):
-                    if item.column() == id_column_index:
-                        found_items.append(item)
-            self.dlg.metadataTable.clearSelection()
-            if not found_items:
-                return
-            for item in found_items:
-                self.dlg.metadataTable.selectRow(item.row())
-        finally:
-            self.dlg.metadataTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
-            self.meta_table_layer_connection = self.dlg.metadataTable.itemSelectionChanged.connect(
-                self.sync_table_selection_with_image_id_and_layer)
-
-    def sync_image_id_with_table_and_layer(self, image_id: str) -> None:
-        """
-        Select a footprint in the current metadata layer when user selects it in the table.
-
-        :param image_id: The new image ID.
-        """
-
-        if not image_id:
-            self.dlg.metadataTable.clearSelection()
-            return
-        items = self.dlg.metadataTable.findItems(image_id, Qt.MatchExactly)
-        if not items:
-            self.dlg.metadataTable.clearSelection()
-            return
-        #if items[0] not in self.dlg.metadataTable.selectedItems():
-            #self.dlg.metadataTable.selectRow(items[0].row())
-        # Redundant since imageId is temorary removed
 
     def _register_provider_min_areas(self, providers_data):
         """Map provider name -> minimum AOI area (sq km) from /user/status provider data.

--- a/tests/qgis/test_search_selection_sync.py
+++ b/tests/qgis/test_search_selection_sync.py
@@ -1,0 +1,203 @@
+"""The two-way selection sync between the search results table and the footprint layer.
+
+Selecting a row highlights its footprint; selecting a footprint highlights its row. Each direction
+writes the selection the other listens to, so both disconnect the opposite handler before touching
+a selection and reconnect afterwards — without that, one click ping-pongs until the stack runs out.
+
+Written against `mapflow.py` *before* the move and re-pointed at `SearchController` afterwards,
+with the assertions untouched — so a difference here would have meant the move changed behaviour.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtWidgets import QAbstractItemView, QTableWidget, QTableWidgetItem
+
+from mapflow.config import Config
+from mapflow.functional.controller.search_controller import SearchController
+from mapflow.functional.view.search_view import SearchView
+
+
+LOCAL_INDEX_COLUMN = Config.LOCAL_INDEX_COLUMN
+ZOOM_COLUMN = Config.ZOOM_COLUMN_INDEX
+
+
+def _table(rows):
+    """A real QTableWidget: the sync code uses findItems, selectRow and selection modes, which
+    MagicMock cannot model faithfully enough for these assertions to mean anything."""
+    table = QTableWidget(len(rows), max(LOCAL_INDEX_COLUMN, ZOOM_COLUMN) + 1)
+    for row, (local_index, zoom) in enumerate(rows):
+        table.setItem(row, LOCAL_INDEX_COLUMN, QTableWidgetItem(str(local_index)))
+        table.setItem(row, ZOOM_COLUMN, QTableWidgetItem(str(zoom)))
+    table.setSelectionBehavior(QAbstractItemView.SelectRows)
+    table.setSelectionMode(QAbstractItemView.ExtendedSelection)
+    return table
+
+
+@pytest.fixture
+def plugin():
+    """A `SearchController` with a real results table and real `SearchView` widget access.
+
+    The view is real because the sync is almost entirely widget manipulation — selection modes,
+    findItems, selectRow. Mocking it would leave the assertions checking the mock.
+    """
+    dlg = MagicMock()
+    dlg.metadataTable = _table([(10, "16"), (11, "17"), (12, "18")])
+    dlg.zoomCombo = MagicMock()
+    dlg.zoomCombo.findText.return_value = -1
+
+    view = SearchView.__new__(SearchView)
+    view.dlg = dlg
+    view.config = Config
+    view.ensure_search_provider = MagicMock()
+
+    controller = SearchController.__new__(SearchController)
+    controller.search_view = view
+    controller.provider_service = MagicMock()
+    controller.app_context = SimpleNamespace(metadata_layer=MagicMock(),
+                                             meta_layer_table_connection=MagicMock())
+    controller.area_calculator_service = MagicMock()
+    controller.aoi_view = MagicMock()
+    # A real connection, not a mock: the layer->table direction disconnects this handle, and Qt
+    # raises TypeError if it was never connected. Production always has one — faking it would
+    # only prove the fake works.
+    controller.connect_table_selection()
+    # Kept for the assertions that reach for the dialog directly.
+    controller.dlg = dlg
+    return controller
+
+
+# ---------- table -> layer ----------
+
+def test_the_layer_handler_is_disconnected_while_the_table_drives(plugin):
+    """The selectByExpression below fires the layer's selectionChanged; if the table handler is
+    still attached it calls straight back into this method."""
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_table_selection_with_layer()
+
+    layer = plugin.app_context.metadata_layer
+    layer.selectionChanged.disconnect.assert_called_once()
+    # ...and put back, or the map stops driving the table from here on.
+    layer.selectionChanged.connect.assert_called_once()
+
+
+def test_the_selected_rows_local_indices_reach_the_layer(plugin):
+    plugin.dlg.metadataTable.selectRow(1)
+
+    plugin.sync_table_selection_with_layer()
+
+    expression = plugin.app_context.metadata_layer.selectByExpression.call_args.args[0]
+    assert "local_index in" in expression
+    assert "11" in expression
+
+
+def test_an_empty_selection_still_reconnects(plugin):
+    """Clearing the table selection must not leave the layer handler detached."""
+    plugin.dlg.metadataTable.clearSelection()
+
+    plugin.sync_table_selection_with_layer()
+
+    plugin.app_context.metadata_layer.selectionChanged.connect.assert_called_once()
+
+
+def test_a_missing_layer_returns_without_touching_the_combo(plugin):
+    """Before any search there is no metadata layer; the disconnect raises and the method stops."""
+    plugin.app_context.metadata_layer = None
+
+    plugin.sync_table_selection_with_layer()  # must not raise
+
+    plugin.dlg.zoomCombo.setCurrentIndex.assert_not_called()
+
+
+def test_the_zoom_combo_is_written_with_signals_blocked(plugin):
+    """zoomCombo.currentIndexChanged -> on_zoom_change fires a second, duplicate cost request,
+    and it would use the stale zoom. The block is the fix; this pins it."""
+    plugin.dlg.zoomCombo.findText.return_value = 2
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_table_selection_with_layer()
+
+    calls = [call.args[0] for call in plugin.dlg.zoomCombo.blockSignals.call_args_list]
+    assert calls == [True, False]
+    plugin.dlg.zoomCombo.setCurrentIndex.assert_called_once_with(2)
+
+
+def test_an_unknown_zoom_falls_back_to_the_first_entry(plugin):
+    plugin.dlg.zoomCombo.findText.return_value = -1
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_table_selection_with_layer()
+
+    plugin.dlg.zoomCombo.setCurrentIndex.assert_called_once_with(0)
+
+
+def test_the_cost_is_recomputed_after_the_zoom_is_set(plugin):
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_table_selection_with_layer()
+
+    plugin.area_calculator_service.calculate_aoi_area_polygon_layer.assert_called_once()
+
+
+# ---------- layer -> table ----------
+
+def test_selecting_a_footprint_selects_its_row(plugin):
+    plugin.app_context.metadata_layer.getFeature.return_value = {"local_index": 12}
+
+    plugin.sync_layer_selection_with_table([7])
+
+    assert {index.row() for index in plugin.dlg.metadataTable.selectionModel().selectedRows()} == {2}
+
+
+def test_the_table_handler_is_disconnected_while_the_layer_drives(plugin):
+    plugin.app_context.metadata_layer.getFeature.return_value = {"local_index": 10}
+
+    plugin.sync_layer_selection_with_table([1])
+
+    # Reconnected in a finally, so it survives an exception mid-selection.
+    assert plugin._table_selection_connection is not None
+    assert plugin.dlg.metadataTable.selectionMode() == QAbstractItemView.ExtendedSelection
+
+
+def test_no_selected_features_clears_the_table(plugin):
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_layer_selection_with_table([])
+
+    assert plugin.dlg.metadataTable.selectionModel().selectedRows() == []
+
+
+def test_a_footprint_with_no_matching_row_clears_rather_than_raising(plugin):
+    plugin.app_context.metadata_layer.getFeature.return_value = {"local_index": 999}
+
+    plugin.sync_layer_selection_with_table([3])
+
+    assert plugin.dlg.metadataTable.selectionModel().selectedRows() == []
+
+
+def test_several_footprints_select_several_rows(plugin):
+    plugin.app_context.metadata_layer.getFeature.side_effect = [
+        {"local_index": 10}, {"local_index": 12}]
+
+    plugin.sync_layer_selection_with_table([1, 3])
+
+    assert {index.row() for index in plugin.dlg.metadataTable.selectionModel().selectedRows()} == {0, 2}
+
+
+# ---------- image id -> table ----------
+
+def test_an_empty_image_id_clears_the_selection(plugin):
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_image_id_with_table("")
+
+    assert plugin.dlg.metadataTable.selectionModel().selectedRows() == []
+
+
+def test_an_unknown_image_id_clears_the_selection(plugin):
+    plugin.dlg.metadataTable.selectRow(0)
+
+    plugin.sync_image_id_with_table("no-such-image")
+
+    assert plugin.dlg.metadataTable.selectionModel().selectedRows() == []


### PR DESCRIPTION
The two-way sync between the search results table and the footprint layer leaves mapflow.py.
SearchView takes the widget manipulation (selection modes, findItems, selectRow, the zoom combo),
SearchController keeps the connect/disconnect dance that stops the two directions calling each
other forever.

Tests first, deliberately. The WAL flagged this as the delicate part of the search cluster, so the
fourteen tests were written against the OLD implementation in mapflow.py and run green there
before anything moved; the move then re-pointed them at SearchController with the assertions
untouched. A diff in those assertions would have meant the move changed behaviour, and there was
none. It is the only way to move code whose whole job is signal bookkeeping and still know it
survived.

Writing them surfaced an asymmetry worth fixing rather than relocating. The layer->table direction
disconnected its counterpart handle with no guard, while the table->layer direction caught
(RuntimeError, AttributeError, TypeError) around the same operation. Qt raises TypeError when the
handle was never connected, and the unguarded raise landed *after* the table had been switched to
MultiSelection - leaving the results table in a selection mode the user cannot get out of. Now
both are guarded, and the mode is restored in a finally. My own test fixture tripped this by
passing a mock where production stores a real connection, which is how it came to light.

The blockSignals pair around the zoom combo is now `set_zoom_silently`, with the reason in its
docstring instead of a comment three lines from the code it protects: unblocked, that write
reaches on_zoom_change and fires a second cost request built from the pre-call zoom, so the two
race and the stale one can win.

Construction order moved with it. SearchController now needs AoiView (hoisted above it - it takes
nothing the controller provides) and AreaCalculatorService, which is built much later and so
arrives as a back-link, like aoi_service.template_service already does. ProviderService's
selection_sync_callback moves down to the same place, since it now points at the controller.

## Manual test
Run an imagery search, then click a row: its footprint highlights on the map and the zoom combo
adopts that image's zoom. Click a footprint on the map: its row is selected in the table.
Ctrl-click several rows, and several footprints highlight; select several footprints, and several
rows do. Clear the map selection and the table selection clears with it. Regression surface: this
is the pair that can loop - a single click must not flicker or freeze the plugin, and selecting a
row must produce exactly ONE cost recalculation, not two (watch the cost label settle once). Also
check the results table still allows normal drag/ctrl multi-selection afterwards: if it ever ends
up stuck selecting one row at a time, or selecting every row you touch, this is the code at fault.
