### PR TITLE
refactor: move the search-mode and Seen split-buttons into SearchView

### DIFF
--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -110,6 +110,20 @@ class TemplateController(QObject):
         name = (name_override or self.template_view.template_name())
         self.template_service.create_search_template(name, aoi_details, search_params)
 
+    def on_search_mode_changed(self, mode: str) -> None:
+        """The Search button switched mode. A planned search creates a template, and a template
+        needs a project — so in plan mode without one, say so in the message label.
+
+        The immediate search is never blocked by this, so the button stays usable; the label is
+        the only effect. Lives here rather than in the search tab because "a template needs a
+        project" is this region's rule, and `SearchView` announces the mode instead of asking.
+        """
+        message = self.template_service.project_required_message
+        if mode == "plan" and not self.app_context.current_project:
+            self.template_view.show_project_required(message)
+        else:
+            self.template_view.clear_project_required(message)
+
     def prompt_plan_search(self) -> None:
         """Offer a Planned Search for a too-large AOI (T8); on accept, create it with an
         auto-generated name."""

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
 from PyQt5.QtGui import QBrush, QColor
-from PyQt5.QtWidgets import QAbstractItemView, QPushButton, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QMenu, QPushButton, QToolButton, QWidget
 
 from ..helpers import utc_date_from_iso
 from ...dialogs.main_dialog import MainDialog
@@ -27,6 +27,10 @@ class SearchView(QObject):
     #: view's 'new image' icons. Emitting rather than calling keeps this view ignorant of who
     #: decorates its rows.
     tableRefilled = pyqtSignal()
+    #: The Search button switched between an immediate search and planning one ("search"/"plan").
+    #: A planned search creates a template, which needs a project — but that rule is the template
+    #: region's, so it is announced rather than checked here.
+    searchModeChanged = pyqtSignal(str)
 
     def __init__(self, dlg: MainDialog, config):
         super().__init__()
@@ -34,6 +38,41 @@ class SearchView(QObject):
         self.config = config
         #: The current cellClicked->preview connection, so it can be dropped before rewiring.
         self._cell_preview_connection = None
+        #: "search" (run it now) or "plan" (create a template that keeps searching).
+        self.search_mode = "search"
+
+    # ---------- the Search and Seen split-buttons ----------
+
+    def setup_search_mode_dropdown(self) -> None:
+        """Turn the Search button into a split button offering Search / Plan search."""
+        self._search_menu = QMenu(self.dlg.getMetadata)
+        search_action = self._search_menu.addAction(self.tr("Search"))
+        plan_action = self._search_menu.addAction(self.tr("Plan search"))
+        search_action.triggered.connect(lambda: self.set_search_mode("search"))
+        plan_action.triggered.connect(lambda: self.set_search_mode("plan"))
+        self.dlg.getMetadata.setPopupMode(QToolButton.MenuButtonPopup)
+        self.dlg.getMetadata.setMenu(self._search_menu)
+        self.set_search_mode("search")
+
+    def set_search_mode(self, mode: str) -> None:
+        self.search_mode = mode
+        self.dlg.getMetadata.setText(self.tr("Plan search") if mode == "plan" else self.tr("Search"))
+        self.searchModeChanged.emit(mode)
+
+    def setup_seen_dropdown(self, on_seen, on_seen_all) -> None:
+        """Turn the Seen button into a split button offering Seen / Seen all.
+
+        The handlers are passed in rather than looked up: marking images seen is the template
+        region's, and a view may not reach into a controller.
+        """
+        self._seen_menu = QMenu(self.dlg.markSeenButton)
+        seen_action = self._seen_menu.addAction(self.tr("Seen"))
+        seen_all_action = self._seen_menu.addAction(self.tr("Seen all"))
+        seen_action.triggered.connect(on_seen)
+        seen_all_action.triggered.connect(on_seen_all)
+        self.dlg.markSeenButton.setPopupMode(QToolButton.MenuButtonPopup)
+        self.dlg.markSeenButton.setMenu(self._seen_menu)
+        self.dlg.markSeenButton.setDefaultAction(seen_action)
 
     # ---------- what the user is asking for ----------
 

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
     QAction, QApplication, QFileDialog,
-    QMenu, QMessageBox, QWidget, QToolButton
+    QMenu, QMessageBox, QWidget
 )
 from qgis.core import (
     QgsDistanceArea, QgsMapLayer, QgsMapLayerType, QgsProject
@@ -476,8 +476,11 @@ class Mapflow(QObject):
             signal.connect(self.search_controller.apply_local_filter)
         self.dlg.searchRightButton.clicked.connect(self.show_search_next_page)
         self.dlg.searchLeftButton.clicked.connect(self.show_search_previous_page)
-        self.setup_metadata_search_dropdown()
-        self.setup_metadata_seen_dropdown()
+        self.search_view.searchModeChanged.connect(self.template_controller.on_search_mode_changed)
+        self.search_view.setup_search_mode_dropdown()
+        self.search_view.setup_seen_dropdown(
+            on_seen=self.template_controller.mark_selected_images_seen,
+            on_seen_all=self.template_controller.mark_all_images_seen)
 
         # ========== 14. ZOOM SELECTOR CONFIGURATION ==========
         self.dlg.zoomCombo.currentIndexChanged.connect(self.on_zoom_change)
@@ -867,47 +870,11 @@ class Mapflow(QObject):
         # to SearchController.
         self.search_view.ensure_search_provider(self.provider_service)
 
-    def setup_metadata_search_dropdown(self):
-        """Set Search button as dropdown with Search and Plan search modes."""
-        self.metadata_search_mode = "search"
-        self.metadata_search_menu = QMenu(self.dlg.getMetadata)
-        search_action = self.metadata_search_menu.addAction(self.tr("Search"))
-        plan_action = self.metadata_search_menu.addAction(self.tr("Plan search"))
-        search_action.triggered.connect(lambda: self.set_metadata_search_mode("search"))
-        plan_action.triggered.connect(lambda: self.set_metadata_search_mode("plan"))
-        self.dlg.getMetadata.setPopupMode(QToolButton.MenuButtonPopup)
-        self.dlg.getMetadata.setMenu(self.metadata_search_menu)
-        self.set_metadata_search_mode("search")
-
-    def setup_metadata_seen_dropdown(self):
-        """Set Seen button as dropdown with Seen and Seen all actions."""
-        self.metadata_seen_menu = QMenu(self.dlg.markSeenButton)
-        self.metadata_seen_action = self.metadata_seen_menu.addAction(self.tr("Seen"))
-        self.metadata_seen_all_action = self.metadata_seen_menu.addAction(self.tr("Seen all"))
-        self.metadata_seen_action.triggered.connect(
-            self.template_controller.mark_selected_images_seen)
-        self.metadata_seen_all_action.triggered.connect(
-            self.template_controller.mark_all_images_seen)
-        self.dlg.markSeenButton.setPopupMode(QToolButton.MenuButtonPopup)
-        self.dlg.markSeenButton.setMenu(self.metadata_seen_menu)
-        self.dlg.markSeenButton.setDefaultAction(self.metadata_seen_action)
-
-    def set_metadata_search_mode(self, mode: str):
-        self.metadata_search_mode = mode
-        self.dlg.getMetadata.setText(self.tr("Plan search") if mode == "plan" else self.tr("Search"))
-        self.update_plan_search_message()
-
-    def update_plan_search_message(self) -> None:
-        """A template must belong to a project. In plan mode without one, prompt the user in
-        the cost/message label (the immediate search is never blocked, so the button stays usable)."""
-        message = self.template_service.project_required_message
-        if getattr(self, "metadata_search_mode", "search") == "plan" and not self.app_context.current_project:
-            self.template_view.show_project_required(message)
-        else:
-            self.template_view.clear_project_required(message)
-
     def handle_metadata_button_click(self):
-        if getattr(self, "metadata_search_mode", "search") == "plan":
+        """Which of the three things the Search button does. The fork spans the search and
+        template regions, so it stays here: in `SearchController` the two `template_controller`
+        calls below would be controller-to-controller (`spec/007_architecture.md` § Controllers)."""
+        if self.search_view.search_mode == "plan":
             self.template_controller.create_search_template()
             return
         # An immediate search over a too-large AOI is offered as a Planned Search instead (T8).
@@ -922,7 +889,7 @@ class Mapflow(QObject):
         (config.SEARCH_SORT_FIELDS) react; the rest (preview, product type, band order, image id)
         do nothing. Applies to both regular search (/catalog/meta) and template results (the
         template-images endpoint accepts the same sortBy/sortOrder)."""
-        if self.dlg.metadataTable.rowCount() == 0:
+        if self.search_view.metadata_row_count() == 0:
             return  # nothing searched yet
         sort_field = self.search_service.sort_column_field(column)
         if not sort_field:

--- a/tests/qgis/test_plan_search_prompt.py
+++ b/tests/qgis/test_plan_search_prompt.py
@@ -87,7 +87,8 @@ def _dispatch_plugin(exceeds, mode="search"):
     """`handle_metadata_button_click` stays in mapflow.py — it dispatches to the template
     controller (plan / too-large) or to the search (get_metadata)."""
     plugin = Mapflow.__new__(Mapflow)
-    plugin.metadata_search_mode = mode
+    plugin.search_view = MagicMock()
+    plugin.search_view.search_mode = mode
     plugin.get_metadata = MagicMock()
     plugin.template_service = MagicMock()
     plugin.template_service.in_template_mode = False

--- a/tests/qgis/test_search_mode_dropdown.py
+++ b/tests/qgis/test_search_mode_dropdown.py
@@ -1,0 +1,103 @@
+"""The Search button's two modes, and the Seen split-button.
+
+The Search button is a split button: "Search" runs an immediate search, "Plan search" creates a
+template that keeps searching. `SearchView` owns the mode and the label; what the mode *means* for
+a template — that one needs a project — is `TemplateController`'s, reached by signal so the search
+tab never has to know the template region exists.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtWidgets import QToolButton
+
+from mapflow.functional.view.search_view import SearchView
+
+
+@pytest.fixture
+def view():
+    """Real QToolButtons for the two split-buttons: `QMenu(parent)` rejects a MagicMock parent,
+    and `setDefaultAction` is what the Seen assertions read back."""
+    view = SearchView.__new__(SearchView)
+    dlg = MagicMock()
+    dlg.getMetadata = QToolButton()
+    dlg.markSeenButton = QToolButton()
+    SearchView.__init__(view, dlg=dlg, config=MagicMock())
+    return view
+
+
+def test_the_default_mode_is_an_immediate_search(view):
+    assert view.search_mode == "search"
+
+
+def test_switching_to_plan_relabels_the_button(view):
+    view.set_search_mode("plan")
+
+    assert view.search_mode == "plan"
+    assert view.dlg.getMetadata.text() == "Plan search"
+
+
+def test_switching_back_relabels_it_again(view):
+    view.set_search_mode("plan")
+    view.set_search_mode("search")
+
+    assert view.dlg.getMetadata.text() == "Search"
+
+
+def test_every_mode_change_is_announced(view):
+    announced = []
+    view.searchModeChanged.connect(announced.append)
+
+    view.set_search_mode("plan")
+    view.set_search_mode("search")
+
+    assert announced == ["plan", "search"]
+
+
+def test_building_the_dropdown_leaves_it_in_search_mode(view):
+    """The menu is built once at startup and must not leave the button in whichever mode the
+    last action happened to be."""
+    announced = []
+    view.searchModeChanged.connect(announced.append)
+
+    view.setup_search_mode_dropdown()
+
+    assert view.search_mode == "search"
+    assert announced == ["search"]
+    assert [action.text() for action in view.dlg.getMetadata.menu().actions()] == [
+        "Search", "Plan search"]
+
+
+def test_choosing_plan_search_from_the_menu_switches_mode(view):
+    view.setup_search_mode_dropdown()
+
+    plan_action = view.dlg.getMetadata.menu().actions()[1]
+    plan_action.trigger()
+
+    assert view.search_mode == "plan"
+
+
+def test_the_seen_button_wires_the_handlers_it_is_given(view):
+    """A view may not reach into a controller, so marking images seen arrives as callables."""
+    on_seen, on_seen_all = MagicMock(), MagicMock()
+
+    view.setup_seen_dropdown(on_seen=on_seen, on_seen_all=on_seen_all)
+
+    assert [action.text() for action in view.dlg.markSeenButton.menu().actions()] == [
+        "Seen", "Seen all"]
+    # The default action is the plain "Seen", so clicking the button body rather than the arrow
+    # marks the selection rather than everything.
+    assert view.dlg.markSeenButton.defaultAction().text() == "Seen"
+
+    view.dlg.markSeenButton.defaultAction().trigger()
+    on_seen.assert_called_once()
+    on_seen_all.assert_not_called()
+
+
+def test_seen_all_is_a_separate_action(view):
+    on_seen, on_seen_all = MagicMock(), MagicMock()
+    view.setup_seen_dropdown(on_seen=on_seen, on_seen_all=on_seen_all)
+
+    view.dlg.markSeenButton.menu().actions()[1].trigger()
+
+    on_seen_all.assert_called_once()
+    on_seen.assert_not_called()

--- a/tests/qgis/test_search_sort.py
+++ b/tests/qgis/test_search_sort.py
@@ -44,8 +44,9 @@ def _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC", in_template=False, ro
     plugin.search_service = _search_service(sort_by, sort_order)
     plugin.template_service = SimpleNamespace(in_template_mode=in_template)
     plugin.dlg = MagicMock()
-    plugin.dlg.metadataTable.rowCount.return_value = rows
     plugin.search_view = MagicMock()
+    # The "have we searched yet" guard reads the row count through the view, not the dialog.
+    plugin.search_view.metadata_row_count.return_value = rows
     plugin.get_metadata = MagicMock()
     plugin.template_controller = MagicMock()
     return plugin

--- a/tests/qgis/test_template_project_required.py
+++ b/tests/qgis/test_template_project_required.py
@@ -2,15 +2,17 @@
 
 Creating a planned search (template) is blocked without a selected project — the user is
 prompted in the cost/message label — but the immediate (non-template) search is never blocked.
-`TemplateService` emits `projectRequired` (the label) and alerts; `Mapflow.update_plan_search_message`
-drives the label through `TemplateView` based on the search/plan mode.
+`TemplateService` emits `projectRequired` (the label) and alerts;
+`TemplateController.on_search_mode_changed` drives the label through `TemplateView` when the
+Search button switches mode. The rule is the template region's, so the search tab announces the
+mode rather than deciding what it means.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.functional.controller.template_controller import TemplateController
 from mapflow.functional.service.template_service import TemplateService
 from mapflow.functional.view.template_view import TemplateView
-from mapflow.mapflow import Mapflow
 
 PROMPT = "Select a project to create a template"
 
@@ -24,13 +26,15 @@ def _service(current_project, aoi=None):
 
 
 def _plugin(mode, current_project):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.metadata_search_mode = mode
-    plugin.dlg = MagicMock()
-    plugin.template_view = TemplateView(dlg=plugin.dlg, iface=MagicMock(), config=MagicMock())
-    plugin.template_service = _service(current_project)
-    plugin.app_context = SimpleNamespace(current_project=current_project)
-    return plugin
+    """The controller, plus the mode the search tab would have announced."""
+    controller = TemplateController.__new__(TemplateController)
+    controller.dlg = MagicMock()
+    controller.template_view = TemplateView(dlg=controller.dlg, iface=MagicMock(),
+                                            config=MagicMock())
+    controller.template_service = _service(current_project)
+    controller.app_context = SimpleNamespace(current_project=current_project)
+    controller._mode = mode
+    return controller
 
 
 def test_create_search_template_blocks_without_project(monkeypatch):
@@ -49,38 +53,38 @@ def test_create_search_template_blocks_without_project(monkeypatch):
     assert warnings and "project" in warnings[0].lower()  # and the pop-up
 
 
-def test_update_plan_search_message_prompts_in_plan_mode_without_project():
+def test_on_search_mode_changed_prompts_in_plan_mode_without_project():
     plugin = _plugin(mode="plan", current_project=None)
 
-    plugin.update_plan_search_message()
+    plugin.on_search_mode_changed(plugin._mode)
 
     plugin.dlg.processingProblemsLabel.setText.assert_called_once_with(PROMPT)
 
 
-def test_update_plan_search_message_clears_prompt_when_project_selected():
+def test_on_search_mode_changed_clears_prompt_when_project_selected():
     plugin = _plugin(mode="plan", current_project=SimpleNamespace(id="p-1"))
     plugin.dlg.processingProblemsLabel.text.return_value = PROMPT
 
-    plugin.update_plan_search_message()
+    plugin.on_search_mode_changed(plugin._mode)
 
     plugin.dlg.processingProblemsLabel.clear.assert_called_once()
     plugin.dlg.processingProblemsLabel.setText.assert_not_called()
 
 
-def test_update_plan_search_message_clears_prompt_in_search_mode():
+def test_on_search_mode_changed_clears_prompt_in_search_mode():
     plugin = _plugin(mode="search", current_project=None)
     plugin.dlg.processingProblemsLabel.text.return_value = PROMPT
 
-    plugin.update_plan_search_message()
+    plugin.on_search_mode_changed(plugin._mode)
 
     plugin.dlg.processingProblemsLabel.clear.assert_called_once()
 
 
-def test_update_plan_search_message_leaves_other_label_text_untouched():
+def test_on_search_mode_changed_leaves_other_label_text_untouched():
     plugin = _plugin(mode="search", current_project=None)
     plugin.dlg.processingProblemsLabel.text.return_value = "Processing cost: 42 credits"
 
-    plugin.update_plan_search_message()
+    plugin.on_search_mode_changed(plugin._mode)
 
     plugin.dlg.processingProblemsLabel.clear.assert_not_called()
     plugin.dlg.processingProblemsLabel.setText.assert_not_called()


### PR DESCRIPTION
The Search button's two modes (search now / plan a template that keeps searching) and the Seen
split-button leave mapflow.py. SearchView owns the menus, the mode and the button label; the Seen
actions take their handlers as arguments, because marking images seen is the template region's and
a view may not reach into a controller.

The interesting half is what did NOT move with them. `update_plan_search_message` looked like part
of the mode switch, but the rule it enforces - a planned search creates a template, and a template
needs a project - belongs to the template region, and it reached into both template_service and
template_view to say so. Putting that in SearchView would have made the search tab depend on
templates; putting it in SearchController would have made it a controller-to-controller call. It
is now TemplateController.on_search_mode_changed, reached through a new searchModeChanged signal,
so the search tab announces what happened and the template region decides what it means.

handle_metadata_button_click stays in mapflow.py for the same reason inverted: its fork calls
TemplateController twice, which is legal from the composition root and would not be from
SearchController. The reason is in its docstring now rather than only in review comments.

The header-click guard now reads the row count through the view instead of the dialog, which was
mapflow.py's last direct metadataTable access on that path.

Nine tests, and two of them exist because the first versions were wrong in instructive ways.
QMenu(parent) rejects a MagicMock parent, so the fixture uses real QToolButtons - which means the
assertions read the widgets back (menu().actions(), defaultAction().text()) instead of inspecting
mock call args, and would now catch a menu built with the wrong labels or in the wrong order.

The other one is a genuine near-miss. test_no_results_yet_does_not_search set the row count on
dlg.metadataTable.rowCount, but the guard reads search_view.metadata_row_count() now, and a bare
MagicMock returns a truthy mock for that - so the "nothing searched yet" early return silently
stopped happening and the test caught it. Any seam moved from a dialog to a mocked view has this
shape, and it fails open rather than closed.

## Manual test
The Search button shows a dropdown arrow: pick "Plan search" and the button relabels to "Plan
search"; pick "Search" and it goes back. In plan mode with no project selected, the message label
says a project is needed - and switching back to Search clears it, while an unrelated message
(e.g. a processing cost) in that label is left alone. The Seen button likewise: clicking the
button body marks the selected images seen, and the arrow offers "Seen all". Regression surface:
clicking a sortable results column header must still re-sort; with an empty results table it must
do nothing at all rather than firing a search.
