### PR TITLE
refactor: give providers a controller and a view

### DIFF
--- a/mapflow/functional/controller/provider_controller.py
+++ b/mapflow/functional/controller/provider_controller.py
@@ -1,0 +1,121 @@
+"""Adding, editing and removing imagery providers, and the zoom that goes with one.
+
+`spec/007_architecture.md` names this controller for "provider add/edit/remove dialogs and the
+provider combos". What is deliberately NOT here is `on_provider_change`: switching source has
+effects in the search, processing and catalog regions at once, and reaching into those from here
+would be controller-to-controller. It stays in the composition root, driving views.
+"""
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QMessageBox
+
+from ..service.alert_service import alert, alert_warning
+from ..service.provider_service import ProviderService
+from ..view.provider_view import ProviderView
+from ...model.provider import create_provider
+
+
+class ProviderController(QObject):
+    """The provider dialog's lifecycle, and the zoom combo."""
+
+    def __init__(self,
+                 provider_service: ProviderService,
+                 provider_view: ProviderView,
+                 provider_dialog,
+                 app_context,
+                 processing_service=None,
+                 add_button=None,
+                 edit_button=None,
+                 remove_button=None,
+                 zoom_combo=None):
+        super().__init__()
+        self.provider_service = provider_service
+        self.provider_view = provider_view
+        self.provider_dialog = provider_dialog
+        self.app_context = app_context
+        #: Asked to re-price when the zoom changes; the cost is the service's to compute.
+        self.processing_service = processing_service
+
+        if add_button is not None:
+            add_button.clicked.connect(self.add_provider)
+        if edit_button is not None:
+            edit_button.clicked.connect(self.edit_provider)
+        if remove_button is not None:
+            remove_button.clicked.connect(self.remove_provider)
+        if zoom_combo is not None:
+            zoom_combo.currentIndexChanged.connect(self.on_zoom_change)
+        if provider_dialog is not None:
+            provider_dialog.accepted.connect(self.commit_provider)
+
+    # ---------- the zoom ----------
+
+    def on_zoom_change(self, *args) -> None:
+        """Remember the chosen zoom and re-price: for tiled sources the cost depends on it.
+
+        The default entry stores None rather than its label — it means "the provider's own
+        resolution", and writing the label would send a zoom the user never chose.
+        """
+        if self.provider_view.zoom_is_default():
+            self.app_context.settings.setValue('zoom', None)
+        else:
+            self.app_context.settings.setValue('zoom', str(self.provider_view.zoom_text()))
+        self.processing_service.update_processing_cost()
+
+    # ---------- add / edit / remove ----------
+
+    def add_provider(self, *args) -> None:
+        self.provider_dialog.setup(None, self.tr("Add new provider"))
+
+    def edit_provider(self, *args) -> None:
+        provider = self.provider_service.providers[self.provider_view.provider_index()]
+        if provider.is_default:
+            alert_warning(self.tr("This is a default provider, it cannot be edited"))
+            return
+        self.provider_dialog.setup(provider)
+
+    def remove_provider(self, *args) -> None:
+        """The red minus beside the source combo. Built-in providers are protected; a user's own
+        is removed only after confirmation, because there is no undo."""
+        provider = self.provider_service.providers[self.provider_view.provider_index()]
+        if provider.is_default:
+            alert_warning(self.tr("This provider is default and cannot be removed"))
+            return
+        if alert(self.tr('Permanently remove {}?').format(provider.name),
+                 icon=QMessageBox.Question):
+            self.provider_service.user_providers.remove(provider)
+            self.provider_service.update_providers()
+
+    def commit_provider(self, *args) -> None:
+        """The provider dialog was accepted: add the new provider, or replace the edited one.
+
+        Names are the identity here — the combo and every saved setting key off them — so a
+        collision is refused and the dialog reopened with the user's input intact, rather than
+        silently overwriting whichever provider already had that name.
+        """
+        if not self.provider_dialog.result:
+            return  # dialog closed without changes
+        old_provider = self.provider_dialog.current_provider
+        new_provider = create_provider(**self.provider_dialog.result)
+
+        if not old_provider:
+            if self._name_taken(new_provider.name):
+                return
+            self.provider_service.user_providers.append(new_provider)
+            provider_index = len(self.provider_service.providers)
+        else:
+            provider_index = self.provider_service.providers.index(old_provider)
+            # A rename onto another provider's name is the collision; keeping its own name is not.
+            if new_provider.name != old_provider.name and self._name_taken(new_provider.name):
+                return
+            user_index = self.provider_service.user_providers.index(old_provider)
+            self.provider_service.user_providers[user_index] = new_provider
+
+        self.provider_service.update_providers()
+        self.provider_view.set_provider_index(provider_index)
+
+    def _name_taken(self, name: str) -> bool:
+        if name not in self.provider_service.providers:
+            return False
+        alert_warning(self.tr("Provider name must be unique. {name} already exists, "
+                              "select another or delete/edit existing").format(name=name))
+        self.provider_dialog.show()
+        return True

--- a/mapflow/functional/view/provider_view.py
+++ b/mapflow/functional/view/provider_view.py
@@ -1,0 +1,63 @@
+"""Every widget read and write for choosing an imagery source and its zoom.
+
+Holds no service (`spec/007_architecture.md` § Layer rules). The provider combo, the zoom combo
+and the two tabs the source selection switches between live here; which provider that index means
+is `ProviderService`'s, and what to do about it is `ProviderController`'s.
+"""
+from typing import Optional
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtWidgets import QWidget
+
+from ...dialogs.main_dialog import MainDialog
+
+
+class ProviderView(QObject):
+    """The source combo, the zoom combo, and the tabs a source change brings forward."""
+
+    #: Object names of the tabs in the .ui file. "providersTab" is the imagery-search tab —
+    #: historical, and renaming it in Designer would break every findChild that uses it.
+    CATALOG_TAB = "catalogTab"
+    IMAGERY_SEARCH_TAB = "providersTab"
+
+    def __init__(self, dlg: MainDialog):
+        super().__init__()
+        self.dlg = dlg
+
+    # ---------- the source combo ----------
+
+    def provider_index(self) -> int:
+        return self.dlg.providerIndex()
+
+    def set_provider_index(self, index: int) -> None:
+        self.dlg.setProviderIndex(index)
+
+    # ---------- the zoom combo ----------
+
+    def enable_zoom(self, enabled: bool) -> None:
+        """Only tiled sources take a zoom: imagery search and My Imagery serve fixed resolutions,
+        so the combo is disabled rather than ignored, to say so."""
+        self.dlg.zoomCombo.setEnabled(enabled)
+
+    def reset_zoom(self) -> None:
+        self.dlg.zoomCombo.setCurrentIndex(0)
+
+    def zoom_is_default(self) -> bool:
+        """Index 0 is the 'native/maximum' entry, which means 'do not send a zoom'."""
+        return self.dlg.zoomCombo.currentIndex() == 0
+
+    def zoom_text(self) -> Optional[str]:
+        return self.dlg.zoomCombo.currentText()
+
+    # ---------- tabs ----------
+
+    def show_catalog_tab(self) -> None:
+        self._show_tab(self.CATALOG_TAB)
+
+    def show_imagery_search_tab(self) -> None:
+        self._show_tab(self.IMAGERY_SEARCH_TAB)
+
+    def _show_tab(self, object_name: str) -> None:
+        tab = self.dlg.tabWidget.findChild(QWidget, object_name)
+        if tab is not None:
+            self.dlg.tabWidget.setCurrentWidget(tab)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -13,7 +13,7 @@ from PyQt5.QtCore import (
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
     QAction, QApplication, QFileDialog,
-    QMenu, QMessageBox, QWidget
+    QMenu, QMessageBox
 )
 from qgis.core import (
     QgsDistanceArea, QgsMapLayer, QgsMapLayerType, QgsProject
@@ -26,6 +26,8 @@ from .functional.app_context import AppContext
 from .functional.controller.data_catalog_controller import DataCatalogController
 from .functional.controller.project_processing_controller import ProjectProcessingController
 from .functional.controller.processing_controller import ProcessingController
+from .functional.controller.provider_controller import ProviderController
+from .functional.view.provider_view import ProviderView
 from .functional.controller.search_controller import SearchController
 from .functional.controller.template_controller import TemplateController
 from .functional.service.template_service import TemplateService
@@ -59,8 +61,7 @@ from .dialogs import (ErrorMessageWidget,
                       ReviewDialog)
 from .dialogs.icons import plugin_icon
 # Providers
-from .model.provider import (create_provider,
-                              DefaultProvider,
+from .model.provider import (DefaultProvider,
                               ImagerySearchProvider,
                               MyImageryProvider,
                               ProviderInterface,
@@ -129,7 +130,6 @@ class Mapflow(QObject):
         self.dlg = MainDialog(self.main_window, self.app_context.settings)
         self.review_dialog = ReviewDialog(self.dlg)
         self.dlg_provider = ProviderDialog(self.dlg)
-        self.dlg_provider.accepted.connect(self.edit_provider_callback)
         # todo: Move to Maindialog
         metadata_parser = ConfigParser()
         metadata_parser.read(os.path.join(self.plugin_dir, 'metadata.txt'))
@@ -446,10 +446,19 @@ class Mapflow(QObject):
 
         # ========== 13. PROVIDERS ==========
         # searchImageryButton and the metadata table's double/cell-click previews are wired by
-        # SearchController (constructed above).
-        self.dlg.addProvider.clicked.connect(self.add_provider)
-        self.dlg.editProvider.clicked.connect(self.edit_provider)
-        self.dlg.removeProvider.clicked.connect(self.remove_provider)
+        # SearchController (constructed above); the add/edit/remove buttons and the zoom combo by
+        # ProviderController, which owns those handlers.
+        self.provider_view = ProviderView(dlg=self.dlg)
+        self.provider_controller = ProviderController(
+            provider_service=self.provider_service,
+            provider_view=self.provider_view,
+            provider_dialog=self.dlg_provider,
+            app_context=self.app_context,
+            processing_service=self.processing_service,
+            add_button=self.dlg.addProvider,
+            edit_button=self.dlg.editProvider,
+            remove_button=self.dlg.removeProvider,
+            zoom_combo=self.dlg.zoomCombo)
 
         self.search_controller.connect_table_selection()
         self.app_context.meta_layer_table_connection = None
@@ -483,7 +492,7 @@ class Mapflow(QObject):
             on_seen_all=self.template_controller.mark_all_images_seen)
 
         # ========== 14. ZOOM SELECTOR CONFIGURATION ==========
-        self.dlg.zoomCombo.currentIndexChanged.connect(self.on_zoom_change)
+        # currentIndexChanged is wired by ProviderController, which owns the handler.
         saved_zoom = self.app_context.settings.value('zoom')
         if saved_zoom is None:
             self.dlg.zoomCombo.setCurrentIndex(0)
@@ -605,124 +614,40 @@ class Mapflow(QObject):
         self.dlg.close()
 
     def on_provider_change(self) -> None:
-        """Adjust max and current zoom, and update the metadata table when user selects another
-        provider.
+        """A different imagery source was picked.
 
-        :param index: The currently selected provider index
+        Stays in the composition root rather than moving to `ProviderController`: the effects land
+        in the search, catalog and processing regions at once, and reaching into those controllers
+        from one of them would be controller-to-controller (`spec/007_architecture.md`
+        § Controllers). Everything it touches here is a view or a service.
         """
-        # This is done after area calculation, because there the provider list is updated?
-        provider_index = self.dlg.providerIndex()
-        provider = self.provider_service.providers[provider_index]
+        provider = self.provider_service.providers[self.provider_view.provider_index()]
         self.app_context.data_provider = provider
         # Changes in search tab
         self.toggle_imagery_search(provider)
-        # re-calculate AOI because it may change due to intersection of image/area
-        polygon_layer = self.dlg.polygonCombo.currentLayer()
         if isinstance(provider, MyImageryProvider):
-            my_imagery_tab = self.dlg.tabWidget.findChild(QWidget, "catalogTab") 
-            self.dlg.tabWidget.setCurrentWidget(my_imagery_tab)
+            self.provider_view.show_catalog_tab()
             self.area_calculator_service.calculate_aoi_area_catalog()
             self.processing_service.validate_all_processing_params(allow_empty_name=True)
-            self.dlg.zoomCombo.setEnabled(False)
-            self.dlg.zoomCombo.setCurrentIndex(0)
+            # Fixed-resolution source: no zoom to choose.
+            self.provider_view.enable_zoom(False)
+            self.provider_view.reset_zoom()
         else:
-            if isinstance(provider, ImagerySearchProvider):
-                self.dlg.zoomCombo.setEnabled(False)
-            else:
-                self.dlg.zoomCombo.setEnabled(True)
-            self.area_calculator_service.calculate_aoi_area_polygon_layer(polygon_layer)
+            self.provider_view.enable_zoom(not isinstance(provider, ImagerySearchProvider))
+            # Re-calculate the AOI: it can change where an image and the area intersect.
+            self.area_calculator_service.calculate_aoi_area_polygon_layer(
+                self.aoi_view.current_layer())
         if provider.requires_image_id:
-            imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
-            self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
+            self.provider_view.show_imagery_search_tab()
         # A planned (template) start only applies with the imagery-search source, so the Start
-        # button label depends on the data source: refresh it here (e.g. switching an open template
-        # to My imagery must drop the "planned" wording). Text only — the enabled state is managed
-        # by the validation above.
+        # button label depends on the data source: switching an open template to My imagery must
+        # drop the "planned" wording. Text only — the enabled state comes from the validation above.
         self.processing_controller.update_start_processing_button_text()
-
-    def on_zoom_change(self):
-        """ Set chosen zoom and update cost (if it depends on zoom for provider).
-        """
-        if self.dlg.zoomCombo.currentIndex() != 0:
-            self.app_context.settings.setValue('zoom', str(self.dlg.zoomCombo.currentText()))
-        else:
-            self.app_context.settings.setValue('zoom', None)
-        self.processing_service.update_processing_cost()
 
     def save_dialog_state(self):
         """Memorize dialog element sizes & positioning to allow user to customize the look."""
         # Save main dialog size & position
         self.app_context.settings.setValue('mainDialogState', self.dlg.saveGeometry())
-
-    # ========= Providers ============ #
-    def remove_provider(self) -> None:
-        """Delete a web tile provider from the list of registered providers.
-
-        Is called by clicking the red minus button near the provider dropdown list.
-        """
-        provider_index = self.dlg.providerCombo.currentIndex()
-        provider = self.provider_service.providers[provider_index]
-        if provider.is_default:
-            # We want to protect built in providers!
-            self.alert(self.tr("This provider is default and cannot be removed"),
-                       icon=QMessageBox.Warning)
-            return
-        # Ask for confirmation
-        elif self.alert(self.tr('Permanently remove {}?').format(provider.name),
-                        icon=QMessageBox.Question):
-            self.provider_service.user_providers.remove(provider)
-            self.provider_service.update_providers()
-
-    def edit_provider_callback(self) -> None:
-        """Add a web imagery provider or commit edits to an existing one."""
-        old_provider = self.dlg_provider.current_provider
-        if self.dlg_provider.result:
-            new_provider = create_provider(**self.dlg_provider.result)
-        else:
-            # returned empty provider - i.e. nothing was changed
-            return
-
-        if not old_provider:
-            # we have added new one - without current one
-            if new_provider.name in self.provider_service.providers:
-                self.alert(self.tr("Provider name must be unique. {name} already exists, "
-                                   "select another or delete/edit existing").format(name=new_provider.name),
-                           icon=QMessageBox.Warning)
-                self.dlg_provider.show()
-                return
-            else:
-                self.provider_service.user_providers.append(new_provider)
-                provider_index = len(self.provider_service.providers)
-        else:
-            # we replace old provider with a new one
-            # if self.dlg_provider.property('mode') == 'edit':  #
-            provider_index = self.provider_service.providers.index(old_provider)
-            user_provider_index = self.provider_service.user_providers.index(old_provider)
-            if new_provider.name != old_provider.name and new_provider.name in self.provider_service.providers:
-                # we do not want user to replace another provider when editing this one
-                self.alert(self.tr("Provider name must be unique. {name} already exists,"
-                                   " select another or delete/edit existing").format(name=new_provider.name),
-                           icon=QMessageBox.Warning)
-                self.dlg_provider.show()
-                return
-            else:
-                self.provider_service.user_providers[user_provider_index] = new_provider
-        self.provider_service.update_providers()
-        self.dlg.setProviderIndex(provider_index)
-
-    def add_provider(self) -> None:
-        self.dlg_provider.setup(None, self.tr("Add new provider"))
-
-    def edit_provider(self) -> None:
-        """Prepare and show the provider edit dialog.
-        Is called by the corresponding button.
-        """
-        provider = self.provider_service.providers[self.dlg.providerIndex()]
-        if provider.is_default:
-            self.alert(self.tr("This is a default provider, it cannot be edited"),
-                       icon=QMessageBox.Warning)
-        else:
-            self.dlg_provider.setup(provider)
 
     def monitor_polygon_layer_feature_selection(self, layers: List[QgsMapLayer]) -> None:
         """Set up connection between feature selection in polygon layers and AOI area calculation.

--- a/tests/qgis/test_planned_processing_mode.py
+++ b/tests/qgis/test_planned_processing_mode.py
@@ -153,7 +153,9 @@ def test_provider_change_refreshes_start_button_text():
     provider = MagicMock()  # not an ImagerySearchProvider/MyImageryProvider -> the generic branch
     provider.requires_image_id = False
     plugin.dlg = MagicMock()
-    plugin.dlg.providerIndex.return_value = 0
+    plugin.provider_view = MagicMock()
+    plugin.provider_view.provider_index.return_value = 0
+    plugin.aoi_view = MagicMock()
     plugin.provider_service = MagicMock()
     plugin.provider_service.providers = [provider]
     plugin.app_context = SimpleNamespace(data_provider=None)
@@ -165,3 +167,5 @@ def test_provider_change_refreshes_start_button_text():
 
     assert plugin.app_context.data_provider is provider
     plugin.processing_controller.update_start_processing_button_text.assert_called_once()
+    # A tiled source keeps its zoom selectable; only imagery-search and My Imagery lock it.
+    plugin.provider_view.enable_zoom.assert_called_once_with(True)

--- a/tests/qgis/test_provider_controller.py
+++ b/tests/qgis/test_provider_controller.py
@@ -1,0 +1,202 @@
+"""QGIS-tier tests for adding, editing and removing imagery providers, and the zoom combo.
+
+Untested while this lived in `mapflow.py`: every path needs the provider dialog, and the dialog
+needed a plugin. With the widget reads in `ProviderView` and the decisions in the controller, the
+name-collision rules and the default-provider guards can be driven directly.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import provider_controller as pc_mod
+from mapflow.functional.controller.provider_controller import ProviderController
+
+
+class _Providers(list):
+    """`providers` is a list that also answers `name in providers`, as ProvidersList does."""
+
+    def __contains__(self, item):
+        if isinstance(item, str):
+            return any(p.name == item for p in self)
+        return list.__contains__(self, item)
+
+
+def _provider(name, is_default=False):
+    return SimpleNamespace(name=name, is_default=is_default)
+
+
+def _controller(providers=(), user_providers=None, dialog_result=None, current=None):
+    controller = ProviderController.__new__(ProviderController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.provider_service = MagicMock()
+    controller.provider_service.providers = _Providers(providers)
+    controller.provider_service.user_providers = list(
+        user_providers if user_providers is not None else providers)
+    controller.provider_view = MagicMock()
+    controller.provider_view.provider_index.return_value = 0
+    controller.provider_dialog = MagicMock()
+    controller.provider_dialog.result = dialog_result
+    controller.provider_dialog.current_provider = current
+    controller.app_context = SimpleNamespace(settings=MagicMock())
+    controller.processing_service = MagicMock()
+    return controller
+
+
+@pytest.fixture(autouse=True)
+def alerts(monkeypatch):
+    """Everything the user was told. Autouse — an unstubbed `alert` opens a modal that never
+    closes in the test container (see tests/qgis/conftest.py)."""
+    said = []
+    monkeypatch.setattr(pc_mod, "alert", lambda message, *a, **k: said.append(message) or True)
+    monkeypatch.setattr(pc_mod, "alert_warning", lambda message, *a, **k: said.append(message))
+    return said
+
+
+@pytest.fixture(autouse=True)
+def created(monkeypatch):
+    """`create_provider` builds a model from the dialog's dict; only its name matters here."""
+    monkeypatch.setattr(pc_mod, "create_provider",
+                        lambda **kwargs: _provider(kwargs.get("name", "new")))
+
+
+# ---------- the zoom ----------
+
+def test_a_chosen_zoom_is_saved_and_re_prices():
+    controller = _controller()
+    controller.provider_view.zoom_is_default.return_value = False
+    controller.provider_view.zoom_text.return_value = "16"
+
+    controller.on_zoom_change()
+
+    controller.app_context.settings.setValue.assert_called_once_with('zoom', "16")
+    controller.processing_service.update_processing_cost.assert_called_once()
+
+
+def test_the_default_zoom_entry_stores_nothing():
+    """Index 0 means 'the provider's own resolution'. Storing its label would send a zoom the
+    user never picked."""
+    controller = _controller()
+    controller.provider_view.zoom_is_default.return_value = True
+
+    controller.on_zoom_change()
+
+    controller.app_context.settings.setValue.assert_called_once_with('zoom', None)
+
+
+# ---------- removing ----------
+
+def test_a_default_provider_cannot_be_removed(alerts):
+    controller = _controller([_provider("Mapflow", is_default=True)])
+
+    controller.remove_provider()
+
+    controller.provider_service.update_providers.assert_not_called()
+    assert "cannot be removed" in alerts[0]
+
+
+def test_removing_asks_first_and_then_removes(alerts):
+    mine = _provider("Mine")
+    controller = _controller([mine])
+
+    controller.remove_provider()
+
+    assert "Permanently remove Mine?" in alerts[0]
+    assert mine not in controller.provider_service.user_providers
+    controller.provider_service.update_providers.assert_called_once()
+
+
+def test_declining_the_confirmation_keeps_the_provider(monkeypatch):
+    mine = _provider("Mine")
+    controller = _controller([mine])
+    monkeypatch.setattr(pc_mod, "alert", lambda *a, **k: False)
+
+    controller.remove_provider()
+
+    assert mine in controller.provider_service.user_providers
+    controller.provider_service.update_providers.assert_not_called()
+
+
+# ---------- editing ----------
+
+def test_a_default_provider_cannot_be_edited(alerts):
+    controller = _controller([_provider("Mapflow", is_default=True)])
+
+    controller.edit_provider()
+
+    controller.provider_dialog.setup.assert_not_called()
+    assert "cannot be edited" in alerts[0]
+
+
+def test_editing_opens_the_dialog_on_the_selected_provider():
+    mine = _provider("Mine")
+    controller = _controller([mine])
+
+    controller.edit_provider()
+
+    controller.provider_dialog.setup.assert_called_once_with(mine)
+
+
+# ---------- committing the dialog ----------
+
+def test_a_dialog_closed_without_changes_does_nothing():
+    controller = _controller([_provider("Mine")], dialog_result=None)
+
+    controller.commit_provider()
+
+    controller.provider_service.update_providers.assert_not_called()
+
+
+def test_a_new_provider_is_appended_and_selected():
+    controller = _controller([_provider("Mine")], dialog_result={"name": "Second"})
+
+    controller.commit_provider()
+
+    assert [p.name for p in controller.provider_service.user_providers] == ["Mine", "Second"]
+    controller.provider_service.update_providers.assert_called_once()
+    controller.provider_view.set_provider_index.assert_called_once()
+
+
+def test_a_new_provider_may_not_reuse_a_name(alerts):
+    controller = _controller([_provider("Mine")], dialog_result={"name": "Mine"})
+
+    controller.commit_provider()
+
+    assert "must be unique" in alerts[0]
+    controller.provider_service.update_providers.assert_not_called()
+    # Reopened with the user's input, rather than discarding what they typed.
+    controller.provider_dialog.show.assert_called_once()
+
+
+def test_an_edited_provider_replaces_the_old_one():
+    old = _provider("Mine")
+    controller = _controller([old], dialog_result={"name": "Renamed"}, current=old)
+
+    controller.commit_provider()
+
+    assert [p.name for p in controller.provider_service.user_providers] == ["Renamed"]
+    controller.provider_service.update_providers.assert_called_once()
+
+
+def test_keeping_its_own_name_while_editing_is_not_a_collision():
+    """The name is unchanged, so it collides with itself — which must be allowed, or no provider
+    could ever be edited without renaming it."""
+    old = _provider("Mine")
+    controller = _controller([old], dialog_result={"name": "Mine"}, current=old)
+
+    controller.commit_provider()
+
+    controller.provider_service.update_providers.assert_called_once()
+
+
+def test_renaming_onto_another_providers_name_is_refused(alerts):
+    old = _provider("Mine")
+    controller = _controller([old, _provider("Other")],
+                             dialog_result={"name": "Other"}, current=old)
+
+    controller.commit_provider()
+
+    assert "must be unique" in alerts[0]
+    controller.provider_service.update_providers.assert_not_called()


### PR DESCRIPTION
spec/007_architecture.md:165 has named ProviderController since the plan was written; this creates
it, along with the ProviderView it drives. The controller owns the provider dialog's lifecycle
(add / edit / remove / commit) and the zoom combo. The view owns the source combo, the zoom combo
and the two tabs a source change brings forward.

Fourteen tests where there were none. Every path here needed the provider dialog, and the dialog
needed a plugin, so none of it was reachable before - the extraction is what makes it testable.

Writing them made one rule explicit that had been hiding inside a compound condition. Committing
an edited provider guarded a name collision with `new.name != old.name and new.name in providers`,
which is correct but says nothing about *why* the first half is there: without it, editing a
provider without renaming it collides with itself and no edit could ever be saved. That is now
_name_taken() with the self-collision case named and covered, because getting it wrong breaks
every edit and nothing in the old suite would have noticed.

on_provider_change and toggle_imagery_search stay in mapflow.py, deliberately. Their effects land
in the search, catalog and processing regions at once - the first ends by refreshing the Start
button's text, the second clears the search results - so from ProviderController either would be a
controller-to-controller call, which spec/007_architecture.md forbids. What they lost is their
widget access: on_provider_change now goes through ProviderView and AoiView, which is what the
phase's acceptance criterion actually measures. The WAL suggested a ProviderService signal for the
Start-button refresh; that is the same coupling with a level of indirection added, and the
composition root is where cross-region sequencing legitimately lives, so it stays a direct call
from there.

One recurring hazard, now hit twice in this phase and worth naming: a read moved from `dlg` to a
view does not fail loudly in tests that mock the view. test_provider_change_refreshes_start_button
_text set dlg.providerIndex, the code now asks provider_view.provider_index(), and a bare
MagicMock answered with a truthy stand-in - so the fixture line became inert rather than wrong.
The same shape broke test_no_results_yet_does_not_search one commit earlier. After moving a widget
read behind a view, the old dlg.<widget> fixture lines have to be found by hand; they fail open.
That test now also asserts the zoom combo stays enabled for a tiled source, which the original
would have passed with the whole zoom branch broken.

## Manual test
Add a provider: the dialog opens, and a name already in use is refused with the dialog reopened
and your input intact rather than silently overwriting the other one. Edit a provider and save it
without changing the name - that must work (it collides with itself, which is allowed). Rename one
onto another provider's name - refused. Try edit or remove on a built-in provider - both refused
with a message. Remove your own provider - it asks first, and declining keeps it. Switch the zoom
on a tiled source and the cost updates; the default zoom entry means "the provider's own
resolution" and stores nothing. Regression surface: switching the imagery source must still swap
tabs (My Imagery -> catalog tab, an id-requiring provider -> imagery search), disable the zoom for
imagery search and My Imagery, re-price the AOI, and re-label the Start button (an open template
switched to My Imagery must drop the "planned" wording).
