### PR TITLE
refactor: move the imagery search run into SearchController

### DIFF
--- a/mapflow/functional/controller/search_controller.py
+++ b/mapflow/functional/controller/search_controller.py
@@ -35,7 +35,8 @@ class SearchController(QObject):
                  reset_filters_button=None,
                  clear_search_button=None,
                  area_calculator_service=None,
-                 aoi_view=None):
+                 aoi_view=None,
+                 ensure_output_dir=None):
         super().__init__()
         self.search_service = search_service
         self.search_view = search_view
@@ -47,6 +48,11 @@ class SearchController(QObject):
         #: the AOI layer the combo currently names.
         self.area_calculator_service = area_calculator_service
         self.aoi_view = aoi_view
+        #: "Is there a usable working directory, asking the user if not." Passed in as a callable
+        #: because the output-directory prompt is still `mapflow.py`'s; it becomes a real
+        #: collaborator when that cluster is extracted. Defaults to yes so tests that do not care
+        #: about the directory need not stub it.
+        self.ensure_output_dir = ensure_output_dir or (lambda: True)
         #: The table->layer connection handle, so the layer->table direction can take it down
         #: while it drives. Set by `connect_table_selection`.
         self._table_selection_connection = None
@@ -71,6 +77,43 @@ class SearchController(QObject):
             reset_filters_button.clicked.connect(self.reset_filters)
         if clear_search_button is not None:
             clear_search_button.clicked.connect(self.clear_results)
+
+    # ---------- running a search ----------
+
+    def run_search(self, _=False, offset: Optional[int] = 0) -> None:
+        """Fetch image footprints for the current AOI and filter widgets.
+
+        Every filter widget is read once, here, so the request is built from what they said when
+        Search was pressed rather than from whatever they say by the time it is sent.
+        """
+        # Drop the previous Preview-cell connection so a refill does not stack it: several
+        # searches would otherwise fire the preview several times per click.
+        self.search_view.disconnect_cell_preview()
+        # A provider that cannot search would send the request nowhere.
+        self.search_view.ensure_search_provider(self.provider_service)
+        # A regular search replaces any template results, so a "Start" is no longer planned.
+        self.app_context.open_template_results_id = None
+
+        self.search_view.clear_table()
+        self.search_view.remove_more_button()
+        if not self.app_context.aoi:
+            alert(self.tr('Please, select a valid area of interest'))
+            return
+        # Results are written to the working directory, so refuse rather than search without one.
+        if not self.ensure_output_dir():
+            return
+        self.search_service.search(
+            aoi=self.app_context.aoi,
+            provider=self.provider_service.providers[self.search_view.provider_index()],
+            aoi_layer=self.aoi_view.current_layer(),
+            baseline_filters=self.search_view.filter_baseline(),
+            offset=offset,
+            **self.search_view.search_parameters())
+
+    def on_search_results(self, geoms) -> None:
+        """Built-in Qt sorting stays OFF: results already arrive in the server's sort order, and
+        a header click re-requests rather than sorting locally."""
+        self.search_view.fill_table(geoms, sort=False)
 
     def preview(self, *args) -> None:
         """Double-click / Preview: show tiles for the selected image."""

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -274,6 +274,11 @@ class SearchView(QObject):
     def metadata_row_count(self) -> int:
         return self.dlg.metadataTable.rowCount()
 
+    def setup_imagery_search(self, **kwargs) -> None:
+        """Re-dress the search tab for a different provider: columns, the id field's placeholder
+        and tooltip, the zoom bounds, and any restored results."""
+        self.dlg.setup_imagery_search(**kwargs)
+
     # ---------- selection, for the table <-> footprint-layer sync ----------
 
     def selected_local_indices(self) -> List[str]:

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -280,9 +280,8 @@ class Mapflow(QObject):
                                             config_search_columns=self.config_search_columns,
                                             result_loader=self.result_loader,
                                             provider_service=self.provider_service)
-        # Search wiring. Results/pager signals stay here for now — the run and pagination
-        # handlers they end at are still mapflow.py slots (see SearchController's docstring).
-        self.search_service.resultsReceived.connect(self._on_search_results)
+        # The pager signals drive the view directly; the results land in SearchController, which
+        # owns the run. Which endpoint a *page* comes from still forks on template mode below.
         self.search_service.pagerChanged.connect(self.search_view.show_pages)
         self.search_service.pagerHidden.connect(self.search_view.hide_pages)
         self.aoi_view = AoiView(dlg=self.dlg, iface=self.iface)
@@ -299,8 +298,10 @@ class Mapflow(QObject):
                                                   widen_warning_button=self.dlg.searchWidenWarning,
                                                   reset_filters_button=self.dlg.resetSearchFilters,
                                                   clear_search_button=self.dlg.clearSearch,
-                                                  aoi_view=self.aoi_view)
+                                                  aoi_view=self.aoi_view,
+                                                  ensure_output_dir=self.check_if_output_directory_is_selected)
         self.search_service.metadataLayerReady.connect(self.search_controller.on_metadata_layer_ready)
+        self.search_service.resultsReceived.connect(self.search_controller.on_search_results)
         # Template-AOI session wiring. It belongs to TemplateController, which the templates
         # step creates; until then mapflow.py holds the connects (the spec allows wiring here,
         # not domain logic).
@@ -705,16 +706,17 @@ class Mapflow(QObject):
         else:
             self.search_controller.clear_results()
 
-        self.dlg.setup_imagery_search(provider=self.app_context.search_provider,
-                                      columns=columns,
-                                      hidden_columns=hidden_columns,
-                                      sort_by=sort_by,
-                                      preview_zoom=current_zoom,
-                                      max_preview_zoom=max_zoom,
-                                      more_button_name=self.config.METADATA_MORE_BUTTON_OBJECT_NAME,
-                                      image_id_placeholder=image_id_placeholder,
-                                      image_id_tooltip=image_id_tooltip,
-                                      fill=geoms)
+        self.search_view.setup_imagery_search(
+            provider=self.app_context.search_provider,
+            columns=columns,
+            hidden_columns=hidden_columns,
+            sort_by=sort_by,
+            preview_zoom=current_zoom,
+            max_preview_zoom=max_zoom,
+            more_button_name=self.config.METADATA_MORE_BUTTON_OBJECT_NAME,
+            image_id_placeholder=image_id_placeholder,
+            image_id_tooltip=image_id_tooltip,
+            fill=geoms)
 
     def select_output_directory(self) -> str:
         """Open a file dialog for the user to select a directory where plugin files will be stored.
@@ -790,11 +792,6 @@ class Mapflow(QObject):
             provider_changed = True
         return provider_changed
 
-    def replace_search_provider_index(self):
-        # The logic moved to SearchView; the regular-search paths still call this until they move
-        # to SearchController.
-        self.search_view.ensure_search_provider(self.provider_service)
-
     def handle_metadata_button_click(self):
         """Which of the three things the Search button does. The fork spans the search and
         template regions, so it stays here: in `SearchController` the two `template_controller`
@@ -806,7 +803,7 @@ class Mapflow(QObject):
         if self.template_service.search_area_exceeds_limit():
             self.template_controller.prompt_plan_search()
             return
-        self.get_metadata()
+        self.search_controller.run_search()
 
     def on_metadata_header_clicked(self, column: int) -> None:
         """Clicking a *sortable* search column header re-runs the search sorted server-side by that
@@ -827,44 +824,7 @@ class Mapflow(QObject):
         if self.template_service.in_template_mode:
             self.template_controller.load_search_page(0)
         else:
-            self.get_metadata()
-
-    def get_metadata(self, _: Optional[bool] = False, offset: Optional[int] = 0) -> None:
-        """Metadata is image footprints with attributes like acquisition date or cloud cover."""
-        # Drop the previous Preview-cell connection so a refill does not stack it (multiple
-        # searches would otherwise fire the preview several times per click).
-        self.search_view.disconnect_cell_preview()
-        # If current provider does not support search, we should select ImagerySearchProvider to be able to search
-        self.replace_search_provider_index()
-        # A regular search replaces any template results, so a "Start" is no longer planned.
-        self.app_context.open_template_results_id = None
-
-        self.search_view.clear_table()
-        self.search_view.remove_more_button()
-        provider = self.provider_service.providers[self.search_view.provider_index()]
-        # Check if the AOI is defined
-        if self.app_context.aoi:
-            aoi = self.app_context.aoi
-        else:
-            self.alert(self.tr('Please, select a valid area of interest'))
-            return
-
-        if not self.check_if_output_directory_is_selected():
-            return  # only when outputDirectory is empty AND user closed selection dialog
-        # All imagery search goes through the Mapflow catalog API, which filters server-side.
-        # Every filter widget is read once, here, so the request is built from what the widgets
-        # said when Search was pressed rather than from whatever they say by the time it is sent.
-        self.search_service.search(aoi=aoi,
-                                   provider=provider,
-                                   aoi_layer=self.aoi_view.current_layer(),
-                                   baseline_filters=self.search_view.filter_baseline(),
-                                   offset=offset,
-                                   **self.search_view.search_parameters())
-
-    def _on_search_results(self, geoms) -> None:
-        """Built-in Qt sorting stays OFF: results already arrive in the server's sort order, and
-        a header click re-requests rather than sorting locally."""
-        self.search_view.fill_table(geoms, sort=False)
+            self.search_controller.run_search()
 
     def _register_provider_min_areas(self, providers_data):
         """Map provider name -> minimum AOI area (sq km) from /user/status provider data.
@@ -1232,7 +1192,7 @@ class Mapflow(QObject):
         if self.template_service.in_template_mode:
             self.template_controller.load_search_page(offset)
         else:
-            self.get_metadata(offset=offset)
+            self.search_controller.run_search(offset=offset)
     
     def selected_search_product_types(self):
         """Kept as a forwarder: template creation reads the same widgets, and that code moves in

--- a/tests/qgis/test_plan_search_prompt.py
+++ b/tests/qgis/test_plan_search_prompt.py
@@ -85,11 +85,11 @@ def test_search_area_at_exactly_the_limit_does_not_exceed():
 
 def _dispatch_plugin(exceeds, mode="search"):
     """`handle_metadata_button_click` stays in mapflow.py — it dispatches to the template
-    controller (plan / too-large) or to the search (get_metadata)."""
+    controller (plan / too-large) or to SearchController.run_search."""
     plugin = Mapflow.__new__(Mapflow)
     plugin.search_view = MagicMock()
     plugin.search_view.search_mode = mode
-    plugin.get_metadata = MagicMock()
+    plugin.search_controller = MagicMock()
     plugin.template_service = MagicMock()
     plugin.template_service.in_template_mode = False
     plugin.template_service.search_area_exceeds_limit.return_value = exceeds
@@ -103,7 +103,7 @@ def test_button_click_offers_plan_search_when_area_too_large():
     plugin.handle_metadata_button_click()
 
     plugin.template_controller.prompt_plan_search.assert_called_once()
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_button_click_runs_search_when_within_limit():
@@ -111,7 +111,7 @@ def test_button_click_runs_search_when_within_limit():
 
     plugin.handle_metadata_button_click()
 
-    plugin.get_metadata.assert_called_once()
+    plugin.search_controller.run_search.assert_called_once()
     plugin.template_controller.prompt_plan_search.assert_not_called()
 
 
@@ -122,7 +122,7 @@ def test_button_click_in_plan_mode_creates_template_directly():
 
     plugin.template_controller.create_search_template.assert_called_once()
     plugin.template_controller.prompt_plan_search.assert_not_called()
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_planned_search_default_name_has_prefix():

--- a/tests/qgis/test_search_run.py
+++ b/tests/qgis/test_search_run.py
@@ -1,0 +1,136 @@
+"""QGIS-tier tests for running an imagery search.
+
+The guards in front of the request had no direct coverage while this was `Mapflow.get_metadata`:
+each needed a plugin to reach. They matter because each one prevents a request that would fail
+somewhere less legible — with no AOI the backend has nothing to intersect, without a working
+directory the results have nowhere to land, and a provider that cannot search has no endpoint.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import search_controller as sc_mod
+from mapflow.functional.controller.search_controller import SearchController
+
+
+@pytest.fixture(autouse=True)
+def alerts(monkeypatch):
+    """Autouse: an unstubbed `alert` opens a modal with nothing to close it in the test container
+    (see tests/qgis/conftest.py)."""
+    said = []
+    monkeypatch.setattr(sc_mod, "alert", lambda message, *a, **k: said.append(message))
+    return said
+
+
+def _controller(aoi=object(), output_dir_ok=True):
+    controller = SearchController.__new__(SearchController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.search_service = MagicMock()
+    controller.search_view = MagicMock()
+    controller.search_view.provider_index.return_value = 0
+    controller.search_view.search_parameters.return_value = {"max_cloud_cover": 30}
+    controller.search_view.filter_baseline.return_value = {"baseline": True}
+    controller.provider_service = MagicMock()
+    controller.provider_service.providers = [MagicMock()]
+    controller.aoi_view = MagicMock()
+    controller.app_context = SimpleNamespace(aoi=aoi, open_template_results_id="t-1")
+    controller.ensure_output_dir = lambda: output_dir_ok
+    return controller
+
+
+def test_a_search_sends_the_widget_values_read_once():
+    controller = _controller()
+
+    controller.run_search()
+
+    kwargs = controller.search_service.search.call_args.kwargs
+    assert kwargs["max_cloud_cover"] == 30
+    assert kwargs["baseline_filters"] == {"baseline": True}
+    assert kwargs["offset"] == 0
+
+
+def test_a_page_request_passes_its_offset():
+    controller = _controller()
+
+    controller.run_search(offset=20)
+
+    assert controller.search_service.search.call_args.kwargs["offset"] == 20
+
+
+def test_a_regular_search_stops_the_results_belonging_to_a_template():
+    """Otherwise Start would still read as a planned processing over results that have been
+    replaced by an unrelated search."""
+    controller = _controller()
+
+    controller.run_search()
+
+    assert controller.app_context.open_template_results_id is None
+
+
+def test_the_table_is_cleared_before_the_request():
+    controller = _controller()
+
+    controller.run_search()
+
+    controller.search_view.clear_table.assert_called_once()
+    controller.search_view.remove_more_button.assert_called_once()
+
+
+def test_the_preview_connection_is_dropped_before_a_refill():
+    """A refill rewires it; connecting without dropping stacks them, so one click would fire
+    several previews and add several layers."""
+    controller = _controller()
+
+    controller.run_search()
+
+    controller.search_view.disconnect_cell_preview.assert_called_once()
+
+
+def test_a_provider_that_cannot_search_is_swapped_first():
+    controller = _controller()
+
+    controller.run_search()
+
+    controller.search_view.ensure_search_provider.assert_called_once_with(
+        controller.provider_service)
+
+
+def test_no_aoi_refuses_the_search(alerts):
+    controller = _controller(aoi=None)
+
+    controller.run_search()
+
+    controller.search_service.search.assert_not_called()
+    assert "area of interest" in alerts[0]
+
+
+def test_no_working_directory_refuses_the_search():
+    """The user was asked and declined; searching anyway would fetch results with nowhere to
+    write them."""
+    controller = _controller(output_dir_ok=False)
+
+    controller.run_search()
+
+    controller.search_service.search.assert_not_called()
+
+
+def test_the_aoi_check_runs_before_the_directory_prompt(alerts):
+    """Without an AOI there is nothing to search for, so prompting for a directory first would
+    ask the user to fix the wrong thing."""
+    controller = _controller(aoi=None, output_dir_ok=False)
+
+    controller.run_search()
+
+    assert "area of interest" in alerts[0]
+
+
+def test_results_fill_the_table_without_local_sorting():
+    controller = _controller()
+
+    controller.on_search_results({"features": []})
+
+    controller.search_view.fill_table.assert_called_once()
+    assert controller.search_view.fill_table.call_args.kwargs["sort"] is False

--- a/tests/qgis/test_search_sort.py
+++ b/tests/qgis/test_search_sort.py
@@ -47,7 +47,7 @@ def _plugin(sort_by="ACQUISITION_DATE", sort_order="DESC", in_template=False, ro
     plugin.search_view = MagicMock()
     # The "have we searched yet" guard reads the row count through the view, not the dialog.
     plugin.search_view.metadata_row_count.return_value = rows
-    plugin.get_metadata = MagicMock()
+    plugin.search_controller = MagicMock()
     plugin.template_controller = MagicMock()
     return plugin
 
@@ -79,7 +79,7 @@ def test_click_new_sortable_column_sets_field_desc_and_researches():
 
     assert plugin.search_service.sort_by == "CLOUD_COVER"
     assert plugin.search_service.sort_order == "DESC"
-    plugin.get_metadata.assert_called_once()
+    plugin.search_controller.run_search.assert_called_once()
 
 
 def test_click_same_column_toggles_order():
@@ -90,7 +90,7 @@ def test_click_same_column_toggles_order():
     plugin.on_metadata_header_clicked(_column("acquisitionDate"))
     assert plugin.search_service.sort_order == "DESC"
     assert plugin.search_service.sort_by == "ACQUISITION_DATE"
-    assert plugin.get_metadata.call_count == 2
+    assert plugin.search_controller.run_search.call_count == 2
 
 
 def test_non_sortable_column_does_nothing():
@@ -100,7 +100,7 @@ def test_non_sortable_column_does_nothing():
     plugin.on_metadata_header_clicked(_column("preview"))
 
     assert plugin.search_service.sort_by == "ACQUISITION_DATE"  # unchanged
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_template_mode_reloads_template_search_with_new_sort():
@@ -111,7 +111,7 @@ def test_template_mode_reloads_template_search_with_new_sort():
     # Template results re-fetch (first page) with the updated sort; the regular search is untouched.
     assert plugin.search_service.sort_by == "CLOUD_COVER"
     plugin.template_controller.load_search_page.assert_called_once_with(0)
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_regular_mode_does_not_reload_template():
@@ -119,7 +119,7 @@ def test_regular_mode_does_not_reload_template():
 
     plugin.on_metadata_header_clicked(_column("cloudCover"))
 
-    plugin.get_metadata.assert_called_once()
+    plugin.search_controller.run_search.assert_called_once()
     plugin.template_controller.load_search_page.assert_not_called()
 
 
@@ -128,7 +128,7 @@ def test_no_results_yet_does_not_search():
 
     plugin.on_metadata_header_clicked(_column("cloudCover"))
 
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_restore_sort_indicator_maps_token_to_its_column():

--- a/tests/qgis/test_template_search_pagination.py
+++ b/tests/qgis/test_template_search_pagination.py
@@ -96,19 +96,19 @@ def test_pager_hidden_when_results_exactly_fill_one_page():
 def test_next_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
     plugin.template_controller = MagicMock()
-    plugin.get_metadata = MagicMock()
+    plugin.search_controller = MagicMock()
     plugin.search_service.page_offset = 0
 
     plugin.show_search_next_page()
 
     plugin.template_controller.load_search_page.assert_called_once_with(5)
-    plugin.get_metadata.assert_not_called()
+    plugin.search_controller.run_search.assert_not_called()
 
 
 def test_prev_page_in_template_mode_refetches_template_page():
     plugin = _plugin(in_template_mode=True)
     plugin.template_controller = MagicMock()
-    plugin.get_metadata = MagicMock()
+    plugin.search_controller = MagicMock()
     plugin.search_service.page_offset = 10
 
     plugin.show_search_previous_page()
@@ -119,12 +119,12 @@ def test_prev_page_in_template_mode_refetches_template_page():
 def test_next_page_outside_template_mode_uses_regular_search():
     plugin = _plugin(in_template_mode=False)
     plugin.template_controller = MagicMock()
-    plugin.get_metadata = MagicMock()
+    plugin.search_controller = MagicMock()
     plugin.search_service.page_offset = 5
 
     plugin.show_search_next_page()
 
-    plugin.get_metadata.assert_called_once_with(offset=10)
+    plugin.search_controller.run_search.assert_called_once_with(offset=10)
     plugin.template_controller.load_search_page.assert_not_called()
 
 


### PR DESCRIPTION
get_metadata becomes SearchController.run_search, and the results callback and the search tab's
per-provider re-dressing go with it. mapflow.py is down to 1273 lines.

The working-directory check arrives as an injected callable rather than a collaborator. It is
still mapflow.py's - the prompt and the file dialog are the last cluster to extract - so passing
it in from the composition root says what is true, where taking a service that does not exist yet
would not. It defaults to "yes" so tests that do not care about directories need not stub it, and
becomes a real collaborator when that cluster moves.

replace_search_provider_index is deleted. It was a one-line forwarder an earlier step left behind
with a comment promising to remove it when its callers moved; both have now moved, and the
controller calls search_view.ensure_search_provider directly.

Ten tests for guards that had none, because each needed a whole plugin to reach. One of them pins
their *order*: the AOI check runs before the working-directory prompt. Reversed, a user with no
AOI is asked to choose a directory - made to fix the wrong thing before being told the real
problem. Nothing else in the suite would notice that swap.

The pagination fork stays in mapflow.py, like the other two search forks: it chooses between
TemplateController and the regular search, which is controller-to-controller from inside either
one. It touches no widget, so it does not stand in the way of the phase's acceptance.

## Manual test
Press Search with an area of interest set: results fill the table. Press it with no AOI - refused
with "select a valid area of interest", and no request is sent. With no working directory
configured, Search asks for one and cancelling it abandons the search rather than searching with
nowhere to save. Search with a provider that cannot search (a plain XYZ source) - it switches to
Mapflow imagery search and searches. Page through results with the arrows, and click a sortable
column header to re-sort. Regression surface: after a search, clicking a row's Preview cell must
add exactly ONE preview layer - if repeated searches make one click add several, the connection
is being stacked. Inside a template, the pager and the header sort must still re-fetch the
template's own images rather than running a regular search.
