### PR TITLE
refactor: move the result actions to ProjectProcessingController

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -55,17 +55,19 @@ The last large widget block in `mapflow.py` (instant filtering over fetched resu
 account-status polling both leave it. `SearchView` emits `tableRefilled` so the template view's
 new-image markers survive a refill without one controller calling another.
 
-[ ] Move the start fork out of `ProcessingService`
-`handle_processing_submission` still forks on `template_to_run()`, and `template_to_run` still
-lives in the service because `planned_processing_selection_error` calls it and is itself called
-from `update_processing_cost` — service-internal, on no path a controller drives. Moving the fork
-means moving the cost estimate with it, which is its own step. Nothing is blocked on it: the seam
-that made this urgent is already gone.
-
-Still in `mapflow.py` from this area: `load_results`, `download_results_file` and
-`download_aoi_file`, which are `ResultService`'s — Phase D names them separately. (`show_details`
-was listed with them, but it is a processings-table action rather than result loading, so it went
-to `ProjectProcessingController` with the rest of the table's actions in 2c.)
+**The start fork stays in `ProcessingService`, and this item is closed rather than done.**
+`handle_processing_submission` forks on `template_to_run()`, and moving that fork out means moving
+`template_to_run` — which `planned_processing_selection_error` calls, which `update_processing_cost`
+calls in turn. One of `update_processing_cost`'s callers is `AreaCalculatorService`
+(`area_calculator_service.py:191`), a **service**, which cannot compute a template and has no
+business knowing templates exist. So the parameter would have to be threaded through it, or the
+rule duplicated. The alternative shape — a controller calling `service.run_template(params)` or
+`service.create(params)` — splits one operation across two layers and gives the controller nothing
+it needs.
+`template_to_run` reads only `_open_template` (pushed to it), its own `selected_template()` and
+`app_context`; it reaches into no other service, so it is not a layering violation. The seam that
+made this urgent was deleted in 2c. Re-open only with a concrete reason the current shape blocks
+something.
 
 [ ] Session: login, logout and the token → `SessionService`
 The account half of this item is done (`AccountService`). What is left is `read_mapflow_token`,
@@ -74,23 +76,24 @@ fifth is startup orchestration and stays in `mapflow.py` beside `on_account_stat
 reason that one did.
 
 [ ] Reduce what remains of `mapflow.py` to initGui/unload, wiring and construction
-Four clusters left, in the order they are worth doing:
-1. **Imagery search / metadata** → `SearchController` + `SearchView`: `get_metadata`,
-   `handle_metadata_button_click`, `on_metadata_header_clicked`, the Search/Plan and Seen
-   dropdowns, the pager, and the three `sync_*` methods that keep the table and the footprint
-   layer in step. The sync pair is the delicate part — it disconnects and reconnects both
-   directions to avoid a signal loop, so it wants its own tests before it moves.
-2. **Providers** → a new `ProviderController` (`spec/007_architecture.md:165` names it):
-   `on_provider_change`, `on_zoom_change`, add/edit/remove provider, `setup_providers`,
-   `setup_search_providers`, `toggle_imagery_search`, `replace_search_provider`.
-   `on_provider_change` ends by refreshing the Start button's text, which would be a
-   controller-to-controller call — it needs a `ProviderService` signal that
-   `ProcessingController` subscribes to.
-3. **Results loading** → `ResultService`: `load_results`, `download_results_file`,
-   `download_aoi_file`, `_open_template`. Phase D also names this one.
-4. **Output directory and the error handlers**: `select_output_directory`,
+Search, providers and results loading are done. What is left:
+
+1. **Output directory and the error handlers**: `select_output_directory`,
    `check_if_output_directory_is_selected`, `prompt_output_directory`, `ensure_output_directory`,
-   `default_error_handler`, `report_http_error`.
+   `default_error_handler`, `report_http_error`. Two controllers currently take the directory
+   check as an injected callable (`SearchController.ensure_output_dir`,
+   `ProjectProcessingController.ensure_output_directory`); extracting this cluster is what turns
+   those into real collaborators.
+2. **Startup configuration**: `setup_providers`, `setup_search_providers`,
+   `_register_provider_min_areas`, `toggle_imagery_search`, `on_provider_change`, `log_in_callback`,
+   `on_account_status`, `main`. These are composition-root work and mostly *stay* — they sequence
+   several regions. What they must not keep is widget access; that is the acceptance below.
+
+**Cross-region forks that stay in `mapflow.py` by design**, not by omission:
+`handle_metadata_button_click`, `on_metadata_header_clicked`, `_show_search_page` (search vs an
+open template's results) and `on_provider_change` / `toggle_imagery_search` (search + catalog +
+processing at once). Each chooses between two controllers, which is exactly what a controller may
+not do (`spec/007_architecture.md:167`). None touches a widget any more, so none blocks acceptance.
 
 Acceptance for the phase: no `self.dlg.<widget>` access in `mapflow.py`, and the layering test's
 allowlist is empty (`spec/007_architecture.md` invariants 1 and 5).
@@ -111,6 +114,11 @@ Mechanical, and cheaper here than earlier: the god object is gone, so fewer file
 [ ] `functional/` dissolved: `api/`, `controller/`, `service/`, `view/` to the root; `app_context`
     → `context.py`; `geometry`, `helpers`, `styles` to the root; `auth` → `SessionService`;
     `layer_utils` → `ResultService` plus the layer-tree helpers in `view/`
+    Note: `ResultService` here means **`ResultsLoader`** — the requests, the layer building and the
+    styles. The user-facing result *actions* (`load_results`, `download_results_file`,
+    `download_aoi_file`) are not part of it: they read the table selection, read the tiles/local
+    radio and prompt for a working directory, which is controller work, and they now live in
+    `ProjectProcessingController` beside the other processings-table actions.
 [ ] `http`, `error_guard`, `report_throttle`, `log_config` → `infra/`
 Note: the `schema/` ⇄ `model/` split already happened in Phase A, so this phase is package
 moves only — no type is reclassified here.

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -33,7 +33,8 @@ class ProjectProcessingController(QObject):
                  aoi_service=None,
                  data_catalog_service=None,
                  result_loader=None,
-                 processing_view=None):
+                 processing_view=None,
+                 ensure_output_directory=None):
         super().__init__()
         self.dlg = dlg
         self.processing_service = processing_service
@@ -48,6 +49,10 @@ class ProjectProcessingController(QObject):
         self.data_catalog_service = data_catalog_service
         self.result_loader = result_loader
         self.processing_view = processing_view
+        #: "Is there a usable working directory, prompting with this reason if not." A callable
+        #: because the prompt is still `mapflow.py`'s; it becomes a real collaborator when the
+        #: output-directory cluster is extracted. Defaults to yes so tests need not stub it.
+        self.ensure_output_directory = ensure_output_directory or (lambda reason: True)
 
         self._setup_processing_bindings()
         self._setup_project_bindings()
@@ -345,6 +350,61 @@ class ProjectProcessingController(QObject):
         self.dlg.deleteProcessings.setToolTip(
             "" if can_delete
             else self.tr("Contributors can only delete their own planned processings"))
+
+    # ==== LOADING A PROCESSING'S RESULTS ==== #
+
+    def load_results(self, *args) -> None:
+        """Double-click, or the Download button. A template row means "open it" rather than
+        "load it": a template has no results of its own, only the processings under it."""
+        template = self.processing_service.selected_template()
+        if template:
+            self.enter_template(template)
+            return
+        processing = self.processing_service.selected_processing()
+        if not self._loadable(processing):
+            return
+        if self.processing_view.results_as_tiles():
+            self.result_loader.load_result_tiles(processing=processing)
+        elif self.processing_view.results_as_local_file():
+            # Downloading writes to the working directory, so ask for one before starting.
+            if not self.ensure_output_directory(
+                    self.tr("A working directory is required to save the processing results "
+                            "on your computer.")):
+                return  # the user chose 'Later' — cancel the action that needed it
+            self.result_loader.download_results(processing=processing)
+
+    def download_results_file(self, *args) -> None:
+        """'Save result' — write the GeoJSON straight to disk. The fallback when adding the layer
+        by either other route has failed."""
+        processing = self.processing_service.selected_processing()
+        if not self._loadable(processing):
+            return
+        self.result_loader.download_results_file(pid=processing.id)
+
+    def download_aoi_file(self, *args) -> None:
+        """'Download AOI' — the processing's area of interest, as GeoJSON.
+
+        No status check, unlike the two above: an AOI exists as soon as the processing does, so it
+        is worth having even when the run failed — often *because* it failed.
+        """
+        processing = self.processing_service.selected_processing()
+        if not processing:
+            return
+        if not self.ensure_output_directory(
+                self.tr("A working directory is required to save the area of interest "
+                        "on your computer.")):
+            return
+        self.result_loader.download_aoi_file(
+            pid=processing.id, callback=self.result_loader.download_aoi_file_callback)
+
+    def _loadable(self, processing) -> bool:
+        """Results exist only for a run that finished cleanly."""
+        if not processing:
+            return False
+        if not processing.status.is_ok:
+            alert(self.tr("Only the results of correctly finished processing can be loaded"))
+            return False
+        return True
 
     # ==== THE DETAILS DIALOG ==== #
 

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -373,6 +373,16 @@ class ProcessingView:
     def enable_restart_action(self, enabled: bool) -> None:
         self.dlg.enable_restart_action(enabled)
 
+    # ---------- how results should be loaded ----------
+
+    def results_as_tiles(self) -> bool:
+        """Stream the result from the server as vector tiles, without downloading it."""
+        return self.dlg.viewAsTiles.isChecked()
+
+    def results_as_local_file(self) -> bool:
+        """Download the result to the working directory and add it from disk."""
+        return self.dlg.viewAsLocal.isChecked()
+
     def set_processing_cost(self, cost: int):
         self.dlg.processingProblemsLabel.setPalette(self.dlg.default_palette)
         self.dlg.processingProblemsLabel.setText(self.tr("Processing cost: {cost} credits").format(cost=cost))

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -374,7 +374,8 @@ class Mapflow(QObject):
             aoi_service=self.aoi_service,
             data_catalog_service=self.data_catalog_service,
             result_loader=self.result_loader,
-            processing_view=self.processing_service.view)
+            processing_view=self.processing_service.view,
+            ensure_output_directory=self.ensure_output_directory)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -423,7 +424,8 @@ class Mapflow(QObject):
         # Connect buttons
         self.dlg.logoutButton.clicked.connect(self.session_service.logout)
         self.dlg.selectOutputDirectory.clicked.connect(self.select_output_directory)
-        self.dlg.downloadResultsButton.clicked.connect(self.load_results)
+        self.dlg.downloadResultsButton.clicked.connect(
+            self.project_processing_controller.load_results)
         # Calculate AOI size
         self.dlg.polygonCombo.layerChanged.connect(self.area_calculator_service.calculate_aoi_area_polygon_layer)
         self.dlg.mosaicTable.itemSelectionChanged.connect(self.area_calculator_service.calculate_aoi_area_catalog)
@@ -434,7 +436,8 @@ class Mapflow(QObject):
         self.app_context.project.layersAdded.connect(self.setup_layers_context_menu)
         self.app_context.project.layersAdded.connect(self.monitor_polygon_layer_feature_selection)
         # Processings
-        self.dlg.processingsTable.cellDoubleClicked.connect(self.load_results)
+        self.dlg.processingsTable.cellDoubleClicked.connect(
+            self.project_processing_controller.load_results)
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
         self.processing_service.connect_processings_pagination()
         # Entering and leaving a template is TemplateController's entirely — it owns the layers,
@@ -554,8 +557,10 @@ class Mapflow(QObject):
         self.dlg.addAoiButton.setMenu(self.add_layer_menu)
 
     def setup_options_menu_connections(self):
-        self.dlg.save_result_action.triggered.connect(self.download_results_file)
-        self.dlg.download_aoi_action.triggered.connect(self.download_aoi_file)
+        self.dlg.save_result_action.triggered.connect(
+            self.project_processing_controller.download_results_file)
+        self.dlg.download_aoi_action.triggered.connect(
+            self.project_processing_controller.download_aoi_file)
         # 'See details' and the menu's own aboutToShow are wired by ProjectProcessingController,
         # which owns what the processings table offers for the current selection.
         self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
@@ -879,65 +884,6 @@ class Mapflow(QObject):
         return
 
     # =================== Results management ==================== #
-    def _open_template(self, template):
-        """Navigate into a template ('one step right').
-
-        The actual hydration (the poll omits ``searchParams``) and state switch happen in
-        the service; the layers, results and view state follow from ``templateOpened``, which
-        `TemplateController` listens to.
-        """
-        self.project_processing_controller.enter_template(template)
-
-    def load_results(self):
-        # Check if it's a template first
-        template = self.processing_service.selected_template()
-        if template:
-            self._open_template(template)
-            return
-
-        # Otherwise, it's a processing
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        if not processing.status.is_ok:
-            self.alert(self.tr("Only the results of correctly finished processing can be loaded"))
-            return
-
-        if self.dlg.viewAsTiles.isChecked():
-            self.result_loader.load_result_tiles(processing=processing)
-        elif self.dlg.viewAsLocal.isChecked():
-            if not self.ensure_output_directory(
-                    self.tr("A working directory is required to save the processing results "
-                            "on your computer.")):
-                return  # user chose 'Later' — cancel the action that needs the directory
-            self.result_loader.download_results(processing=processing)
-
-    def download_results_file(self) -> None:
-        """
-        Download result and save directly to a geojson file
-        It is the most reliable way to get results, applicable if everything else failed
-        """
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        if not processing.status.is_ok:
-            self.alert(self.tr("Only the results of correctly finished processing can be loaded"))
-            return
-        self.result_loader.download_results_file(pid=processing.id)
-
-    def download_aoi_file(self) -> None:
-        """
-        Download area of interest and save to a geojson file
-        """
-        processing = self.processing_service.selected_processing()
-        if not processing:
-            return
-        if not self.ensure_output_directory(
-                self.tr("A working directory is required to save the area of interest "
-                        "on your computer.")):
-            return  # user chose 'Later' — cancel the action that needs the directory
-        self.result_loader.download_aoi_file(pid=processing.id, callback=self.result_loader.download_aoi_file_callback)
-
     def alert(self, message: str, icon: QMessageBox.Icon = QMessageBox.Critical, blocking=True) -> None:
         return alert(message, icon, blocking)
 

--- a/tests/qgis/test_result_actions.py
+++ b/tests/qgis/test_result_actions.py
@@ -1,0 +1,144 @@
+"""QGIS-tier tests for loading and saving a processing's results.
+
+`tests/qgis/behavioral/test_results_loading.py` drives the happy path end to end. These cover the
+guards in front of it, which that journey never reaches: a selection that is a template rather
+than a processing, a run that did not finish cleanly, and the working-directory prompt that any
+action writing to disk has to pass first.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import project_processing_controller as ppc_mod
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
+
+
+@pytest.fixture(autouse=True)
+def alerts(monkeypatch):
+    """Autouse: an unstubbed `alert` opens a modal that never closes in the test container."""
+    said = []
+    monkeypatch.setattr(ppc_mod, "alert", lambda message, *a, **k: said.append(message))
+    return said
+
+
+def _processing(is_ok=True):
+    return SimpleNamespace(id="p-1", status=SimpleNamespace(is_ok=is_ok))
+
+
+def _controller(processing=None, template=None, as_tiles=True, output_dir_ok=True):
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.processing_service = MagicMock()
+    controller.processing_service.selected_template.return_value = template
+    controller.processing_service.selected_processing.return_value = processing
+    controller.processing_view = MagicMock()
+    controller.processing_view.results_as_tiles.return_value = as_tiles
+    controller.processing_view.results_as_local_file.return_value = not as_tiles
+    controller.result_loader = MagicMock()
+    controller.enter_template = MagicMock()
+    controller.ensure_output_directory = lambda reason: output_dir_ok
+    return controller
+
+
+# ---------- load_results ----------
+
+def test_a_template_row_is_opened_rather_than_loaded():
+    template = SimpleNamespace(id="t-1")
+    controller = _controller(template=template)
+
+    controller.load_results()
+
+    controller.enter_template.assert_called_once_with(template)
+    controller.result_loader.load_result_tiles.assert_not_called()
+
+
+def test_tiles_are_streamed_without_touching_the_working_directory():
+    """The tile route adds a remote layer, so it must not demand a directory."""
+    processing = _processing()
+    controller = _controller(processing=processing, as_tiles=True, output_dir_ok=False)
+
+    controller.load_results()
+
+    controller.result_loader.load_result_tiles.assert_called_once_with(processing=processing)
+
+
+def test_the_local_route_downloads_after_the_directory_is_confirmed():
+    processing = _processing()
+    controller = _controller(processing=processing, as_tiles=False)
+
+    controller.load_results()
+
+    controller.result_loader.download_results.assert_called_once_with(processing=processing)
+
+
+def test_declining_the_directory_prompt_cancels_the_download():
+    controller = _controller(processing=_processing(), as_tiles=False, output_dir_ok=False)
+
+    controller.load_results()
+
+    controller.result_loader.download_results.assert_not_called()
+
+
+def test_an_unfinished_processing_has_no_results_to_load(alerts):
+    controller = _controller(processing=_processing(is_ok=False))
+
+    controller.load_results()
+
+    controller.result_loader.load_result_tiles.assert_not_called()
+    assert "correctly finished" in alerts[0]
+
+
+def test_no_selection_loads_nothing():
+    controller = _controller(processing=None)
+
+    controller.load_results()
+
+    controller.result_loader.load_result_tiles.assert_not_called()
+
+
+# ---------- save result / download AOI ----------
+
+def test_saving_the_result_file_needs_a_finished_processing(alerts):
+    controller = _controller(processing=_processing(is_ok=False))
+
+    controller.download_results_file()
+
+    controller.result_loader.download_results_file.assert_not_called()
+    assert "correctly finished" in alerts[0]
+
+
+def test_saving_the_result_file_sends_the_processing_id():
+    controller = _controller(processing=_processing())
+
+    controller.download_results_file()
+
+    assert controller.result_loader.download_results_file.call_args.kwargs["pid"] == "p-1"
+
+
+def test_the_aoi_can_be_downloaded_for_a_failed_processing():
+    """Deliberately not gated on status, unlike the result: the AOI exists as soon as the
+    processing does, and is most wanted when the run failed."""
+    controller = _controller(processing=_processing(is_ok=False))
+
+    controller.download_aoi_file()
+
+    assert controller.result_loader.download_aoi_file.call_args.kwargs["pid"] == "p-1"
+
+
+def test_downloading_the_aoi_still_needs_a_working_directory():
+    controller = _controller(processing=_processing(), output_dir_ok=False)
+
+    controller.download_aoi_file()
+
+    controller.result_loader.download_aoi_file.assert_not_called()
+
+
+def test_downloading_the_aoi_without_a_selection_does_nothing():
+    controller = _controller(processing=None)
+
+    controller.download_aoi_file()
+
+    controller.result_loader.download_aoi_file.assert_not_called()

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -151,18 +151,21 @@ def test_a_reason_from_another_check_is_not_cleared():
 
 
 def test_load_results_double_click_template_enters_template_view():
-    """Double-clicking a template navigates 'one step right' via the controller."""
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.processing_service = MagicMock()
-    plugin.template_service = MagicMock()
-    plugin.template_service.in_template_mode = False
+    """Double-clicking a template navigates 'one step right'. A template has no results of its
+    own — only the processings under it — so this is an open, not a load."""
+    from mapflow.functional.controller.project_processing_controller import (
+        ProjectProcessingController)
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    controller.processing_service = MagicMock()
     template = SimpleNamespace(id="template-1")
-    plugin.processing_service.selected_template.return_value = template
-    plugin.project_processing_controller = MagicMock()
+    controller.processing_service.selected_template.return_value = template
+    controller.result_loader = MagicMock()
+    controller.enter_template = MagicMock()
 
-    plugin.load_results()
+    controller.load_results()
 
-    plugin.project_processing_controller.enter_template.assert_called_once_with(template)
+    controller.enter_template.assert_called_once_with(template)
+    controller.result_loader.load_result_tiles.assert_not_called()
 
 
 def test_enter_template_view_hydrated_skips_refetch():


### PR DESCRIPTION
load_results, download_results_file and download_aoi_file join the other processings-table
actions. The fork that made load_results look awkward dissolves on the way: it branches to
enter_template, which is that controller's own method, so there is no cross-controller call left
to design around. _open_template was a one-line forwarder to exactly that and is deleted.

This corrects the plan, not just the code. The WAL assigned these three to a ResultService in
Phase D. That is the wrong home for them: they read the table selection, read the tiles/local
radio and prompt for a working directory, all of which is controller work. What Phase D should
move is ResultsLoader in layer_utils - the requests, the layer building, the styles - which these
delegate to. Both WAL entries now say so.

The start-fork item is closed rather than deferred, with the reason recorded. Moving that fork
requires moving template_to_run, which planned_processing_selection_error calls, which
update_processing_cost calls - and one of *that* method's callers is AreaCalculatorService, a
service, which cannot compute a template and should not know templates exist. Threading the
parameter through it, or duplicating the rule, both make the design worse than leaving it.
template_to_run reaches into no other service, so it is not a layering violation; the seam that
made the item urgent was deleted in 2c.

Eleven tests. The behavioral suite already drives the happy path end to end but never reaches the
guards, and two of them encode decisions that look like inconsistencies worth "fixing":

Tiles must NOT require a working directory. That route adds a remote layer and writes nothing, so
gating it would stop a user with no directory from viewing results they can perfectly well view.
The test asks for tiles with the directory check failing, so restoring the gate fails loudly.

download_aoi_file deliberately has no status check, unlike the other two. An AOI exists as soon as
the processing does, and it is most wanted when the run failed - often *because* it failed.
Aligning it with its neighbours would remove the feature's main use.

## Manual test
Double-click a finished processing: with "tiles" selected the result layer appears; with "local
file" it downloads into the working directory first. Double-click a planned processing (template)
row and it opens the template instead of loading anything. Try either on a failed processing:
refused with "only the results of correctly finished processing can be loaded". With no working
directory configured, the local route asks for one and "Later" cancels the load - but the tiles
route must still work without one. From the context menu, "Save result" writes the GeoJSON, and
"Download AOI" works even for a failed processing, asking for a directory first. Regression
surface: the Download button and double-click share this handler, so check both.
