### PR TITLE
refactor: split the working directory into a service and a view

### DIFF
--- a/mapflow/functional/service/workdir_service.py
+++ b/mapflow/functional/service/workdir_service.py
@@ -1,0 +1,72 @@
+"""The working directory: where the plugin writes results, AOIs and cached search layers.
+
+Holds no widget (`spec/007_architecture.md` § Layer rules). Choosing a directory is a file dialog
+and explaining why one is needed is a message box; both are `WorkdirView`'s. What is here is the
+part with no UI in it — what the configured path currently is, whether it can actually be written
+to, and creating the ``Temp`` subdirectory under it.
+"""
+import logging
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from ..app_context import AppContext
+
+logger = logging.getLogger(__name__)
+
+#: Everything the plugin writes goes under this subdirectory of the user's chosen output
+#: directory, so cleaning up never touches anything of theirs that sits alongside it.
+TEMP_SUBDIRECTORY = "Temp"
+
+
+class WorkdirService:
+    """Where the plugin may write, and whether it currently can."""
+
+    def __init__(self, app_context: AppContext):
+        self.app_context = app_context
+
+    @property
+    def configured_path(self) -> str:
+        """What the user last chose, whether or not it still exists."""
+        return self.app_context.settings.value('outputDir') or ""
+
+    def remember(self, path: str) -> None:
+        self.app_context.settings.setValue('outputDir', path)
+
+    def is_usable(self) -> bool:
+        """Whether results can be written right now.
+
+        Checks the directory still exists rather than trusting the setting: it is remembered
+        across sessions, and an external drive or a deleted folder makes it stale.
+        """
+        temp_dir = self.app_context.temp_dir
+        return temp_dir is not None and temp_dir.exists()
+
+    def setup_tempdir(self) -> Optional[str]:
+        """Create the working ``Temp`` directory under the configured output directory.
+
+        Returns ``None`` on success (or when no output directory is configured), or a
+        human-readable error string when the directory is unavailable. **Never raises**: this runs
+        during plugin startup (``classFactory``), and a failure here must not abort the whole
+        plugin. The directory can be unusable for several reasons — an external drive that is not
+        mounted (its ``/Volumes/<name>`` stub is left root-owned and unwritable -> PermissionError),
+        a deleted parent (FileNotFoundError), a read-only or full filesystem — so it catches
+        broadly and falls back to "no working directory", letting the user pick another.
+        """
+        output_dir = self.configured_path
+        if not output_dir:
+            return None  # don't ask for a directory at plugin start
+        temp_dir = Path(output_dir, TEMP_SUBDIRECTORY)
+        try:
+            shutil.rmtree(temp_dir)  # remove the previous session's temp dir
+        except Exception as e:
+            # Best-effort cleanup of a stale directory; the run continues either way.
+            logger.warning("Could not remove old temp dir '%s': %s", temp_dir, e)
+        try:
+            temp_dir.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            self.app_context.temp_dir = None
+            logger.exception("Working directory '%s' is unavailable", output_dir)
+            return str(e)
+        self.app_context.temp_dir = temp_dir
+        return None

--- a/mapflow/functional/view/workdir_view.py
+++ b/mapflow/functional/view/workdir_view.py
@@ -1,0 +1,48 @@
+"""The two dialogs for choosing a working directory, and the field that shows it.
+
+Holds no service (`spec/007_architecture.md` § Layer rules): it asks, and returns what the user
+answered. Whether the answer is usable is `WorkdirService`'s.
+"""
+from typing import Optional
+
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtWidgets import QApplication, QFileDialog, QMessageBox
+
+from ...dialogs.main_dialog import MainDialog
+
+
+class WorkdirView(QObject):
+    """Picking a directory, and explaining why one is needed."""
+
+    def __init__(self, dlg: MainDialog, main_window=None, plugin_name: str = "Mapflow"):
+        super().__init__()
+        self.dlg = dlg
+        #: Parent for the 'why' prompt, so it is modal to QGIS rather than to the plugin panel —
+        #: the panel is dockable and can be hidden while the prompt is up.
+        self.main_window = main_window
+        self.plugin_name = plugin_name
+
+    def shown_path(self) -> str:
+        return self.dlg.outputDirectory.text()
+
+    def show_path(self, path: str) -> None:
+        self.dlg.outputDirectory.setText(path)
+
+    def ask_for_directory(self) -> Optional[str]:
+        """The file dialog. Returns the chosen path, or an empty string if the user closed it."""
+        return QFileDialog.getExistingDirectory(
+            QApplication.activeWindow(), self.tr('Select output directory'))
+
+    def offer_to_choose(self, message: str) -> bool:
+        """Explain why a directory is needed and offer to pick one now.
+
+        Returns True if the user chose to select one, False if they postponed — which the caller
+        treats as cancelling whatever action needed the directory. Rich text, because the callers
+        pass messages containing links.
+        """
+        box = QMessageBox(QMessageBox.Warning, self.plugin_name, message, parent=self.main_window)
+        box.setTextFormat(Qt.RichText)
+        select_button = box.addButton(self.tr("Select directory…"), QMessageBox.AcceptRole)
+        box.addButton(self.tr("Later"), QMessageBox.RejectRole)
+        box.exec()
+        return box.clickedButton() is select_button

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1,9 +1,7 @@
 import json
 import logging
 import os.path
-import shutil
 from configparser import ConfigParser  # parse metadata.txt -> QGIS version check (compatibility)
-from pathlib import Path
 from typing import List, Optional, Callable
 
 from PyQt5.QtCore import (
@@ -12,8 +10,7 @@ from PyQt5.QtCore import (
 )
 from PyQt5.QtNetwork import QNetworkReply
 from PyQt5.QtWidgets import (
-    QAction, QApplication, QFileDialog,
-    QMenu, QMessageBox
+    QAction, QApplication, QMenu, QMessageBox
 )
 from qgis.core import (
     QgsDistanceArea, QgsMapLayer, QgsMapLayerType, QgsProject
@@ -44,6 +41,8 @@ from .functional.service import (DataCatalogService,
                                  ProviderService)
 from .functional.service.account_service import AccountService
 from .functional.service.session_service import SessionService
+from .functional.service.workdir_service import WorkdirService
+from .functional.view.workdir_view import WorkdirView
 from .functional.service.alert_service import AlertService, alert
 from .functional.service.area_calculator_service import AreaCalculatorService
 # HTTP
@@ -175,15 +174,20 @@ class Mapflow(QObject):
         # AlertService must exist before setup_tempdir: an unavailable working directory below (and
         # select_output_directory on a bad pick) shows a modal, and both run before section 6.
         AlertService(self.plugin_name)
-        tempdir_error = self.setup_tempdir()
+        self.workdir_service = WorkdirService(app_context=self.app_context)
+        self.workdir_view = WorkdirView(dlg=self.dlg,
+                                        main_window=self.main_window,
+                                        plugin_name=self.plugin_name)
+        tempdir_error = self.workdir_service.setup_tempdir()
         if tempdir_error:
             # Working directory is configured but unavailable (e.g. an unmounted external drive).
             # It's only needed to save results locally, so let the user fix it now or postpone —
             # a modal with an action beats a transient status-bar line for a blocking problem.
-            self.prompt_output_directory(
-                self.tr("The working directory '{dir}' is unavailable:<br>{error}<br><br>"
-                        "It is needed to save processing results on your computer.").format(
-                            dir=self.app_context.settings.value('outputDir'), error=tempdir_error))
+            if self.workdir_view.offer_to_choose(
+                    self.tr("The working directory '{dir}' is unavailable:<br>{error}<br><br>"
+                            "It is needed to save processing results on your computer.").format(
+                                dir=self.workdir_service.configured_path, error=tempdir_error)):
+                self.select_output_directory()
 
         # ========== 6. INITIALIZE INDEPENDENT SERVICES ==========
         self.result_loader = layer_utils.ResultsLoader(iface=self.iface,
@@ -723,63 +727,52 @@ class Mapflow(QObject):
             image_id_tooltip=image_id_tooltip,
             fill=geoms)
 
-    def select_output_directory(self) -> str:
-        """Open a file dialog for the user to select a directory where plugin files will be stored.
+    # ========= The working directory ============ #
+    #
+    # These four stay in the composition root rather than becoming a controller of their own:
+    # SearchController and ProjectProcessingController both need "is there a directory, ask if
+    # not", and a controller may not call another (`spec/007_architecture.md` § Controllers). They
+    # are handed `ensure_output_directory` as a callable instead. Nothing here touches a widget —
+    # the dialogs are WorkdirView's and the filesystem is WorkdirService's.
 
-        Returns the selected path, or None if user closed the dialog.
-        """
-        path = QFileDialog.getExistingDirectory(
-            QApplication.activeWindow(),
-            self.tr('Select output directory')
-        )
-        if path:
-            self.dlg.outputDirectory.setText(path)
-            self.app_context.settings.setValue('outputDir', path)
-            error = self.setup_tempdir()
-            if error:
-                # The chosen directory exists but is not usable (e.g. no write permission, or it
-                # lives on an unmounted volume). Tell the user exactly why and let them pick another.
-                self.alert(self.tr("Cannot use '{dir}' as the working directory:\n{error}\n\n"
-                                   "Please choose another directory.").format(dir=path, error=error),
-                           QMessageBox.Warning)
-            return path
+    def select_output_directory(self) -> str:
+        """Ask for a directory and adopt it. Returns the chosen path, or None if cancelled."""
+        path = self.workdir_view.ask_for_directory()
+        if not path:
+            return None
+        self.workdir_view.show_path(path)
+        self.workdir_service.remember(path)
+        error = self.workdir_service.setup_tempdir()
+        if error:
+            # The chosen directory exists but cannot be written to — no permission, or it lives on
+            # an unmounted volume. Name the reason so the user can pick a better one.
+            self.alert(self.tr("Cannot use '{dir}' as the working directory:\n{error}\n\n"
+                               "Please choose another directory.").format(dir=path, error=error),
+                       QMessageBox.Warning)
+        return path
 
     def check_if_output_directory_is_selected(self) -> bool:
-        """Check if the user specified an existing output dir.
-
-        Returns True if an existing directory is specified or a new directory has been selected, else False.
-        """
-        if os.path.exists(self.dlg.outputDirectory.text()) or self.select_output_directory():
+        """True if a directory is configured and present, or the user picks one now."""
+        if os.path.exists(self.workdir_view.shown_path()) or self.select_output_directory():
             return True
         self.alert(self.tr('Please, specify an existing output directory'))
         return False
 
-    def prompt_output_directory(self, message: str) -> bool:
-        """Modal prompt to set the working directory, explaining why it is needed.
-
-        Shows `message` with 'Select directory…' / 'Later' buttons. Returns True if the user picked
-        a usable directory (``temp_dir`` is now set), False if they postponed or the pick failed.
-        Used both at startup (a configured directory turned out unavailable) and before any action
-        that needs the directory (so 'Later' cancels that action)."""
-        box = QMessageBox(QMessageBox.Warning, self.plugin_name, message, parent=self.main_window)
-        box.setTextFormat(Qt.RichText)
-        select_button = box.addButton(self.tr("Select directory…"), QMessageBox.AcceptRole)
-        box.addButton(self.tr("Later"), QMessageBox.RejectRole)
-        box.exec()
-        if box.clickedButton() is not select_button:
-            return False
-        self.select_output_directory()  # alerts by itself if the newly picked directory is unusable
-        return self.app_context.temp_dir is not None
-
     def ensure_output_directory(self, reason: str) -> bool:
-        """Ensure a usable working directory exists before an action that writes to it.
+        """Ensure results can be written before starting an action that writes them.
 
-        Returns True if results can be saved (directory set and present); if not, prompts the user
-        with `reason` and returns whether they selected a usable directory (False = postponed)."""
-        temp_dir = self.app_context.temp_dir
-        if temp_dir is not None and temp_dir.exists():
+        Returns True when the directory is usable; otherwise explains why one is needed and
+        returns whether the user supplied one. False means "postponed", and every caller treats
+        that as cancelling the action.
+        """
+        if self.workdir_service.is_usable():
             return True
-        return self.prompt_output_directory(reason)
+        if not self.workdir_view.offer_to_choose(reason):
+            return False
+        # select_output_directory alerts by itself if the newly picked directory is unusable, so
+        # the answer is whether it actually became usable — not whether the user picked anything.
+        self.select_output_directory()
+        return self.workdir_service.is_usable()
 
     def replace_search_provider(self, provider: ProviderInterface):
         if not provider:
@@ -1147,35 +1140,6 @@ class Mapflow(QObject):
 
     def selected_search_providers(self):
         return self.search_view.search_providers()
-
-    def setup_tempdir(self) -> Optional[str]:
-        """Create the working ``Temp`` directory under the configured output directory.
-
-        Returns ``None`` on success (or when no output directory is configured), or a human-readable
-        error string when the directory is unavailable. Never raises: this runs during plugin startup
-        (``classFactory``), and any failure here must not abort the whole plugin. The directory can be
-        unusable for several reasons — an external drive that is not mounted (its ``/Volumes/<name>``
-        stub is left root-owned and unwritable -> ``PermissionError``), a deleted parent
-        (``FileNotFoundError``), a read-only or full filesystem, etc. — so we catch broadly and fall
-        back to "no working directory", letting the user pick another one.
-        """
-        output_dir = self.app_context.settings.value('outputDir')
-        if not output_dir:
-            return None # don't ask to specify tempdir at the plugin start
-        temp_dir = Path(output_dir, "Temp")
-        try:
-            shutil.rmtree(temp_dir) # remove old tempdir
-        except Exception as e:
-            # Best-effort cleanup of a stale directory; the run continues either way.
-            logger.warning("Could not remove old temp dir '%s': %s", temp_dir, e)
-        try:
-            temp_dir.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            self.app_context.temp_dir = None
-            logger.exception("Working directory '%s' is unavailable", output_dir)
-            return str(e)
-        self.app_context.temp_dir = temp_dir
-        return None
 
     def check_dir_and_duplicate_processing(self):
         if not self.check_if_output_directory_is_selected():

--- a/tests/qgis/test_setup_tempdir.py
+++ b/tests/qgis/test_setup_tempdir.py
@@ -1,164 +1,133 @@
-"""QGIS-tier tests for Mapflow.setup_tempdir startup resilience.
+"""QGIS-tier tests for the working directory: startup resilience, and the prompt before writing.
 
 A working directory on an unmounted external drive leaves a root-owned, unwritable stub at
 ``/Volumes/<name>``; ``mkdir(parents=True)`` then raises ``PermissionError`` partway up. Before
 the fix this propagated out of ``classFactory`` and the plugin could not start at all (and
 reinstalling did not help, because ``outputDir`` lives in QgsSettings). ``setup_tempdir`` must
-now survive it and fall back to "no working directory".
+survive it and fall back to "no working directory".
+
+The filesystem half is `WorkdirService`; the two dialogs are `WorkdirView`; `mapflow.py` keeps the
+coordination, because two controllers need "is there a directory, ask if not" and neither may call
+the other.
 """
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from mapflow.functional.service.workdir_service import WorkdirService
 from mapflow.mapflow import Mapflow
 
 
-def _plugin(output_dir, temp_dir_sentinel="sentinel"):
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.app_context = SimpleNamespace(
+def _service(output_dir, temp_dir_sentinel="sentinel"):
+    return WorkdirService(app_context=SimpleNamespace(
         settings=SimpleNamespace(value=lambda key: output_dir if key == 'outputDir' else None),
         temp_dir=temp_dir_sentinel,
-    )
-    return plugin
+    ))
 
 
 def test_creates_temp_dir_under_configured_output(tmp_path):
-    plugin = _plugin(str(tmp_path / "work"))
+    service = _service(str(tmp_path / "work"))
 
     # No error string -> success.
-    assert plugin.setup_tempdir() is None
-    assert plugin.app_context.temp_dir == tmp_path / "work" / "Temp"
+    assert service.setup_tempdir() is None
+    assert service.app_context.temp_dir == tmp_path / "work" / "Temp"
     assert (tmp_path / "work" / "Temp").exists()
 
 
 def test_survives_permission_error_and_returns_reason(tmp_path, monkeypatch):
-    plugin = _plugin(str(tmp_path / "Volumes" / "Seagate Exp" / "mapflow"))
+    service = _service(str(tmp_path / "Volumes" / "Seagate Exp" / "mapflow"))
 
     # Simulate the unmounted-drive stub: mkdir refused with Errno 13 on the root-owned parent.
     def deny(self, *args, **kwargs):
         raise PermissionError(13, "Permission denied")
     monkeypatch.setattr(Path, "mkdir", deny)
 
-    error = plugin.setup_tempdir()  # must not raise (this is what previously killed classFactory)
+    error = service.setup_tempdir()  # must not raise (this previously killed classFactory)
     assert error and "Permission denied" in error  # reason is surfaced to the caller
-    assert plugin.app_context.temp_dir is None
+    assert service.app_context.temp_dir is None
 
 
 def test_survives_other_exceptions(tmp_path, monkeypatch):
     # An unmounted volume can also fail differently (e.g. FileNotFoundError) — handle any failure.
-    plugin = _plugin(str(tmp_path / "gone"))
+    service = _service(str(tmp_path / "gone"))
 
     def boom(self, *args, **kwargs):
         raise FileNotFoundError(2, "No such file or directory")
     monkeypatch.setattr(Path, "mkdir", boom)
 
-    error = plugin.setup_tempdir()
+    error = service.setup_tempdir()
     assert error and "No such file" in error
-    assert plugin.app_context.temp_dir is None
+    assert service.app_context.temp_dir is None
 
 
 def test_no_output_dir_is_a_noop():
-    plugin = _plugin(output_dir=None, temp_dir_sentinel="unchanged")
+    service = _service(output_dir=None, temp_dir_sentinel="unchanged")
 
     # Nothing configured: early return, temp_dir left untouched, no failure signal.
-    assert plugin.setup_tempdir() is None
-    assert plugin.app_context.temp_dir == "unchanged"
+    assert service.setup_tempdir() is None
+    assert service.app_context.temp_dir == "unchanged"
+
+
+def test_usable_only_when_the_directory_still_exists(tmp_path):
+    """The setting survives across sessions, so an existing path is not enough — the directory
+    itself can have been deleted or unmounted since."""
+    service = _service(str(tmp_path))
+    service.app_context.temp_dir = tmp_path / "gone"
+    assert service.is_usable() is False
+
+    (tmp_path / "there").mkdir()
+    service.app_context.temp_dir = tmp_path / "there"
+    assert service.is_usable() is True
+
+
+def test_usable_is_false_before_any_directory_is_chosen():
+    service = _service(output_dir=None, temp_dir_sentinel=None)
+    assert service.is_usable() is False
 
 
 # ---------------- ensure_output_directory: prompt only when needed ----------------
 
-def test_ensure_output_directory_skips_prompt_when_usable(tmp_path):
-    existing = tmp_path / "Temp"
-    existing.mkdir()
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(temp_dir=existing)
-    plugin.prompt_output_directory = MagicMock()
-
-    assert plugin.ensure_output_directory("need it") is True
-    plugin.prompt_output_directory.assert_not_called()
-
-
-def test_ensure_output_directory_prompts_when_not_set():
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(temp_dir=None)
-    plugin.prompt_output_directory = MagicMock(return_value=True)
-
-    assert plugin.ensure_output_directory("need a dir") is True
-    plugin.prompt_output_directory.assert_called_once_with("need a dir")
-
-
-def test_ensure_output_directory_prompts_when_dir_deleted(tmp_path):
-    gone = tmp_path / "gone" / "Temp"  # a stale path that no longer exists
-    plugin = Mapflow.__new__(Mapflow)
-    plugin.app_context = SimpleNamespace(temp_dir=gone)
-    plugin.prompt_output_directory = MagicMock(return_value=False)
-
-    # Postponed by the user -> caller must cancel.
-    assert plugin.ensure_output_directory("need it") is False
-    plugin.prompt_output_directory.assert_called_once()
-
-
-# ------------- prompt_output_directory: 'Later' cancels, 'Select' picks -------------
-
-class _FakeMessageBox:
-    """Stand-in for QMessageBox that records buttons and reports a preset click."""
-    Warning = 2
-    AcceptRole = 0
-    RejectRole = 1
-    click = "select"  # or "later"
-
-    def __init__(self, *args, **kwargs):
-        self._buttons = []
-
-    def setTextFormat(self, *args):
-        pass
-
-    def addButton(self, text, role):
-        button = object()
-        self._buttons.append(button)
-        return button
-
-    def exec(self):
-        pass
-
-    def clickedButton(self):
-        # buttons added in order: [Select directory…, Later]
-        return self._buttons[0] if _FakeMessageBox.click == "select" else self._buttons[1]
-
-
-def _prompt_plugin(monkeypatch, click):
-    monkeypatch.setattr("mapflow.mapflow.QMessageBox", _FakeMessageBox)
-    _FakeMessageBox.click = click
+def _plugin(usable, user_accepts=True):
+    """`mapflow.py` coordinating the two: the service says whether writing is possible, the view
+    asks when it is not."""
     plugin = Mapflow.__new__(Mapflow)
     plugin.tr = lambda text: text
-    plugin.plugin_name = "Mapflow"
-    plugin.main_window = None
-    plugin.app_context = SimpleNamespace(temp_dir=None)
+    plugin.workdir_service = MagicMock()
+    plugin.workdir_service.is_usable.side_effect = list(usable)
+    plugin.workdir_view = MagicMock()
+    plugin.workdir_view.offer_to_choose.return_value = user_accepts
     plugin.select_output_directory = MagicMock()
     return plugin
 
 
-def test_prompt_later_cancels_without_opening_file_dialog(monkeypatch):
-    plugin = _prompt_plugin(monkeypatch, click="later")
+def test_a_usable_directory_is_not_questioned():
+    plugin = _plugin(usable=[True])
 
-    assert plugin.prompt_output_directory("why") is False
-    plugin.select_output_directory.assert_not_called()
+    assert plugin.ensure_output_directory("need it") is True
+    plugin.workdir_view.offer_to_choose.assert_not_called()
 
 
-def test_prompt_select_opens_dialog_and_reports_success(monkeypatch):
-    plugin = _prompt_plugin(monkeypatch, click="select")
-    # Simulate the file dialog setting a usable directory.
-    plugin.select_output_directory.side_effect = lambda: setattr(
-        plugin.app_context, "temp_dir", "/some/Temp")
+def test_an_unusable_directory_explains_why_one_is_needed():
+    # Unusable, then usable after the user picks one.
+    plugin = _plugin(usable=[False, True])
 
-    assert plugin.prompt_output_directory("why") is True
+    assert plugin.ensure_output_directory("need a dir") is True
+    plugin.workdir_view.offer_to_choose.assert_called_once_with("need a dir")
     plugin.select_output_directory.assert_called_once()
 
 
-def test_prompt_select_reports_failure_when_dir_still_unset(monkeypatch):
-    plugin = _prompt_plugin(monkeypatch, click="select")
-    # User picked an unusable dir: select_output_directory alerted and left temp_dir None.
-    assert plugin.prompt_output_directory("why") is False
+def test_postponing_cancels_without_opening_the_file_dialog():
+    plugin = _plugin(usable=[False], user_accepts=False)
+
+    assert plugin.ensure_output_directory("need it") is False
+    plugin.select_output_directory.assert_not_called()
+
+
+def test_picking_an_unusable_directory_still_reports_failure():
+    """The user chose a directory, but it could not be written to — `select_output_directory` has
+    already said so, and the caller must still cancel. The answer is whether the directory became
+    usable, not whether the user picked something."""
+    plugin = _plugin(usable=[False, False])
+
+    assert plugin.ensure_output_directory("need it") is False
     plugin.select_output_directory.assert_called_once()


### PR DESCRIPTION
WorkdirService owns the filesystem half - what the configured path is, whether it can be written
to right now, and creating the Temp subdirectory under it. WorkdirView owns the two dialogs: the
file picker, and the modal that explains why a directory is needed. Neither knows about the other.

The four coordinating methods stay in mapflow.py, and that is the design rather than a shortcut.
SearchController and ProjectProcessingController both need "is there a directory, ask if not". A
WorkdirController would mean two controllers calling a third, which spec/007_architecture.md
forbids, so they keep taking ensure_output_directory as an injected callable and the composition
root supplies it. What changed is that none of the four touches a widget any more.

prompt_output_directory dissolved instead of moving. It did three things at once: show a modal,
open a file dialog, and decide whether the result was usable. Those are now the view,
select_output_directory, and the service - and ensure_output_directory reads as the sequence it
always was underneath.

That split also repaired the tests around it. The old prompt tests drove a hand-rolled
_FakeMessageBox with class-level mutable state shared between them, and asserted the outcome
through it. The replacements ask the service twice - unusable, then still unusable after the pick
- which states the rule the code actually implements: the answer is whether the directory became
usable, not whether the user picked something. Two tests were also added for is_usable itself,
including that a remembered path whose directory has since been deleted or unmounted is not
usable; the setting outlives the directory, which is the whole reason the check exists.

This is the last cluster of Phase C. mapflow.py is 1183 lines, from 2993 when the phase started.
The 105 remaining self.dlg accesses are controller construction (handing a controller its widgets),
signal wiring, and the startup block that restores saved filter values into widgets - which is
what the WAL records as the honest reading of the acceptance criterion, since a composition root
cannot build controllers without naming widgets.

## Manual test
With no working directory configured, start a processing and choose to save results locally: the
plugin explains why a directory is needed and offers to pick one; "Later" cancels the action.
Pick one and it is remembered across restarts. Point it at a directory you cannot write to (or an
unmounted external drive) - it names the reason and asks for another rather than failing silently.
Delete the configured directory outside QGIS, then try to save results: it must notice it is gone
and ask again rather than erroring. Regression surface: with a working directory configured and
present, none of these prompts should ever appear - saving results, downloading an AOI and running
a search must all proceed without asking. And the plugin must still start when the configured
directory is unavailable, rather than failing to load.
