### PR TITLE
chore: re-plan Phase C2 around what the layer rules actually allow

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -55,29 +55,76 @@ so it is **Phase C2** below rather than a footnote here.
 
 Empties the layering allowlist, which is Phase C's unmet acceptance criterion.
 
-`ProcessingService`, `ProviderService`, `ProjectService`, `DataCatalogService`,
-`AreaCalculatorService`, `ProcessingApi` and `DataCatalogApi` each take the main dialog as a
-constructor argument and reach through it — **138 `self.dlg` accesses**, measured. Each service
-needs its widget access moved to the matching view, its constructor changed, and every test that
-builds it updated. That is one MR per service; there is no shortcut that does several at once,
-because each constructor change ripples into a different set of tests.
+Five services and two api modules take the main dialog as a constructor argument and reach through
+it — **138 `self.dlg` accesses**, measured.
+
+**A service may not hold a view.** `MAY_IMPORT["service"]` is `{api, service, model, schema,
+errors}`, so "move the widget access into the matching view" is not the fix: the service could not
+call that view. Widget access leaves a service in exactly two directions —
+
+* **writes leave as signals**, which a controller connects to a view method;
+* **reads move up to a controller**, which passes plain values down; state the service needs
+  continuously is **pushed** to it (the shape `ProcessingService.set_open_template` already uses),
+  never pulled.
+
+Every step therefore has a controller part, named below. Where a controller does not exist for the
+region, that is called out — none of these need a new one.
 
 **Before Phase D**, deliberately: Phase D moves `functional/` wholesale, and five of the files it
 moves are the ones this rewrites. Doing D first means moving a file and then rewriting it.
 
-[ ] C2.1 `AreaCalculatorService` (17 accesses) — smallest, so the first MR is a complete worked
-    example: which reads become view methods, how the constructor changes, what happens to its tests.
-[ ] C2.2 `ProcessingService` (26)
-[ ] C2.3 `ProjectService` (28)
-[ ] C2.4 `DataCatalogService` (29)
-[ ] C2.5 `ProviderService` (38)
-[ ] C2.6 `ProcessingApi` and `DataCatalogApi` — last, and different in kind: they hold the dialog
-    only to hand it to the result loader, so the fix is a constructor change rather than a view.
+#### Group A — the service builds its own view (do these first)
 
-Each MR deletes its own entries from `tests/functional/test_layering.py`'s `ALLOWED`.
-`test_the_allowlist_has_no_stale_entries` fails if an exemption outlives its violation, so the list
-cannot silently drift — but note it only shrinks when someone removes the entry, so removing it is
-part of the MR, not a follow-up.
+`ProjectService`, `DataCatalogService` and `ProcessingService` each construct a view in their
+`__init__` (`self.view = ProjectView(self.dlg)`) and drive it directly. They hold **two** allowlist
+entries each — `dialog-param` and `service-imports-view` — and one change clears both.
+
+Recipe: the composition root builds the view and hands it to the controller; the service's
+`self.view.x` calls become signals; the controller connects them; `dlg` leaves the constructor.
+No new pushed state is needed, because these services only touch widgets in their own region.
+
+[ ] C2.1 `ProjectService` (28) → `ProjectController` + `ProjectView`
+    The most self-contained: every widget is in the projects panel (`currentProjectLabel` ×7,
+    `projectsTable` ×6, `filterProjects` ×4, the sort combo and pager). Both the controller and the
+    view exist. This is the worked example the rest follow.
+[ ] C2.2 `DataCatalogService` (29) → `DataCatalogController` + `DataCatalogView`
+    Dominated by one widget (`mosaicTable` ×18, `imageTable` ×4), so mostly mechanical once C2.1
+    sets the pattern. `selected_mosaic_cell` / `selected_image_cell` ×4 are the dedup guard — they
+    are widget state the service consults, so they become pushed state or move to the controller.
+[ ] C2.3 `ProcessingService` (26) → `ProcessingController` + `ProcessingView`
+    Mostly its own region, but **four accesses reach other regions**: `metadataTable` ×3
+    (`SearchView`) and `polygonCombo` ×1 (`AoiView`). Those become pushed state, so this one needs
+    a small amount of Group B work; do it after C2.1–C2.2 have settled the easy pattern.
+
+#### Group B — the service reaches into other regions' widgets
+
+No view of its own, and the widgets belong to two or three other regions. These need pushed state,
+which is why they are last.
+
+[ ] C2.4 `ProviderService` (38) → `ProviderController`, with reads pushed from `SearchController`
+    Spans three views: `metadataTable` ×11 (`SearchView`), `sourceCombo`/`zoomCombo`/`providerCombo`
+    ×8 (`ProviderView`), `modelCombo`/`modelOptions` ×5 (`ProcessingView`), plus `tabWidget` ×4 and
+    `startProcessing` ×2. The largest of the six and the one most likely to want splitting into two
+    MRs — decide once C2.3 has shown how much pushed state costs.
+[ ] C2.5 `AreaCalculatorService` (17, plus the `use_imagery_extent` checkbox it is handed directly)
+    → `ProcessingController` (`spec/007_architecture.md` assigns it "AOI and provider selection,
+    cost")
+    Fewest accesses but not the easiest: nine are writes that become signals
+    (`disable_processing_start` ×3, `labelAoiArea`, the checkbox ×5), three are `providerIndex()`
+    which `app_context.data_provider` already answers, and the remaining ten are pulled widget
+    state — the AOI polygon layer ×4, the search-image selection ×2, the catalog dedup guard ×4 —
+    each needing its own push. It is also called *by another service* (`ProjectService`), so
+    "let the caller read the widget" does not work here.
+
+#### Then the api modules
+
+[ ] C2.6 `ProcessingApi` and `DataCatalogApi` — different in kind: they hold the dialog only to
+    pass it to the result loader, so this is a constructor change, not a view extraction. Last
+    because the result loader's own home is decided in Phase D.
+
+Each MR deletes its own entries from `tests/functional/test_layering.py`'s `ALLOWED` — removing
+them is part of the MR, not a follow-up. `test_the_allowlist_has_no_stale_entries` then fails if an
+exemption outlives its violation, so the list cannot silently drift.
 
 Acceptance: `ALLOWED` is empty, and `MAY_IMPORT` holds with no exemptions.
 


### PR DESCRIPTION
The phase said each service's widget access "moves to the matching view". A service may not hold a
view - MAY_IMPORT["service"] is {api, service, model, schema, errors} - so that fix is not
available, and swapping a dialog-param exemption for a service-imports-view one would clear nothing
anyway. The plan was written without checking it against the rule the phase exists to enforce.

Widget access leaves a service in exactly two directions, and the entry now says so: writes leave
as signals a controller connects to a view, and reads move up to a controller, with anything the
service needs continuously pushed to it rather than pulled. That is the shape
ProcessingService.set_open_template already uses.

Every step now names its controller, because "which controller connects this" is the part that
decides whether a step is an afternoon or a week, and it was missing from all six.

The ordering was wrong for the same reason. It ran smallest-first by access count, which made
AreaCalculatorService the opener at 17 accesses. Counting is a poor proxy: three services build
their own view and drive it directly, so they hold two allowlist entries each and one change clears
both, with no new state needed because they only touch their own region's widgets. The other two
have no view and reach into two or three other regions, so every read needs a push designed for it.
That is the real split, and it now orders the phase - ProjectService opens, AreaCalculatorService
is second to last.

Sizing that honestly also changed what the phase is. These are not mechanical constructor edits;
each is a Phase-C-shaped restructure, and C2.4 (ProviderService, 38 accesses across three views)
may well want splitting once C2.3 shows what pushed state costs.

Numbers here are measured, not estimated: per-service access counts, which widget each touches, and
which of them already construct a view.

## Manual test
none - tracker only, no code changes.
