### PR TITLE
refactor: take the dialog and the view out of ProjectService

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -180,6 +180,13 @@ for every model that has options; see the note under C3.2.
     call `.show()`. With no parent — `parent=None`, or `QApplication.activeWindow()` returning None —
     the widget can be collected before it is drawn, so the user sees nothing. Folds naturally into
     the error-reporting item below, which already rewrites both.
+[ ] C3.5a An account with no projects re-requests the list forever
+    `ProjectService.get_projects_callback` treats "no projects and no filter" as a stale page and
+    re-requests without parameters — which returns the same empty result, and asks again. It is
+    guarded only by the assumption that every account has a `Default` project. Asynchronous, so it
+    is an endless request loop rather than stack recursion, which makes it look like a hung plugin
+    talking to the server rather than a crash. Pinned as current behaviour by
+    `test_an_empty_unfiltered_result_asks_again_without_parameters`; that test changes with the fix.
 [ ] C3.5 A template rename is dropped silently if the response shape drifts
     The rename callback wraps its parse in a broad `except Exception`, so a changed payload looks
     exactly like a successful rename that did not happen.

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -544,12 +544,30 @@ class ProjectProcessingController(QObject):
         """
         # Stop processing polling when leaving processings view
         self.processing_service.processing_fetch_timer.stop()
-        
-        # Fetch projects (handles saved page restoration internally)
-        self.project_service.get_projects(open_saved_page)
+
+        if open_saved_page:
+            self.restore_saved_projects_page()
+        else:
+            self.refresh_projects()
 
         # Switch view
         self.project_view.switch_to_projects()
+
+    def restore_saved_projects_page(self) -> None:
+        """Put the user back on the page, sort and filter they left.
+
+        The widgets are set before the request rather than after it, so the panel and the results
+        describe the same query — otherwise the list arrives sorted one way while the combo still
+        claims another.
+        """
+        page = self.project_service.saved_projects_page()
+        sort_by, sort_order = page['sort_by'], page['sort_order']
+        if page['filter']:
+            self.project_view.set_projects_filter(page['filter'])
+        self.project_view.set_sort_index(
+            self.project_service.sort_combo_index(sort_by, sort_order))
+        self.project_service.get_projects(sort_by, sort_order, page['filter'],
+                                          offset=int(page['offset']))
 
         # Remove old cost
         self.processing_service.update_processing_cost()

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -5,7 +5,7 @@ from ..app_context import AppContext
 from ..service.alert_service import alert
 from ..service.processing_service import ProcessingService
 from ..service.project_service import ProjectService
-from ...config import config
+from ...config import config, Config
 from ...dialogs import CreateProjectDialog, UpdateProjectDialog, MainDialog, UpdateProcessingDialog
 from ...dialogs.processing_details_dialog import ProcessingDetailsDialog
 from ...schema import ImagerySearchParams, MyImageryParams, UserDefinedParams
@@ -34,7 +34,9 @@ class ProjectProcessingController(QObject):
                  data_catalog_service=None,
                  result_loader=None,
                  processing_view=None,
-                 ensure_output_directory=None):
+                 ensure_output_directory=None,
+                 project_view=None,
+                 config=None):
         super().__init__()
         self.dlg = dlg
         self.processing_service = processing_service
@@ -53,6 +55,10 @@ class ProjectProcessingController(QObject):
         #: because the prompt is still `mapflow.py`'s; it becomes a real collaborator when the
         #: output-directory cluster is extracted. Defaults to yes so tests need not stub it.
         self.ensure_output_directory = ensure_output_directory or (lambda reason: True)
+        #: The projects panel. `ProjectService` no longer builds it — a service may not hold a
+        #: view — so it arrives here and this controller drives it.
+        self.project_view = project_view
+        self.config = config or Config
 
         self._setup_processing_bindings()
         self._setup_project_bindings()
@@ -129,14 +135,87 @@ class ProjectProcessingController(QObject):
         self.processing_service.processing_fetch_timer.start()
     
     def _setup_project_bindings(self):
-        """Project-specific UI connections."""
-        # Project service already sets up its own pagination/filter bindings in __init__
-        # Projects
+        """Project-specific UI connections, including the ones `ProjectService` used to make for
+        itself — it holds no widget now, so every read below happens here and is passed in."""
         self.dlg.createProject.clicked.connect(self.create_project)
         self.dlg.deleteProject.clicked.connect(self.delete_project)
         self.dlg.updateProject.clicked.connect(self.update_project)
-        self.project_service.projectsUpdated.connect(self.project_service.update_projects)
+        self.dlg.projectsNextPageButton.clicked.connect(self.show_projects_next_page)
+        self.dlg.projectsPreviousPageButton.clicked.connect(self.show_projects_previous_page)
+        self.dlg.filterProjects.textEdited.connect(self.on_projects_filter_edited)
+        self.dlg.sortProjectsCombo.activated.connect(self.refresh_projects)
+
+        self.project_service.projectsUpdated.connect(self.on_projects_updated)
         self.project_service.projectsFiltered.connect(self.connect_projects)
+        # What the panel must show. The service decides *what*; the view knows *how* — the project
+        # name is elided against the live label width, which only the widget can measure.
+        self.project_service.projectsLoaded.connect(self._render_projects_table)
+        self.project_service.pagerChanged.connect(self._render_pager)
+        self.project_service.currentProjectChanged.connect(self._render_current_project)
+        self.project_service.windowTitleChanged.connect(self.project_view.set_window_title)
+        self.project_service.projectChangeRightsChanged.connect(
+            self.project_view.enable_project_change)
+        self.project_service.sharedRoleApplied.connect(self.project_view.enable_shared_project)
+        self.project_service.selectionLocked.connect(self._lock_projects_selection)
+
+    # ==== RENDERING WHAT THE PROJECT SERVICE ANNOUNCES ==== #
+
+    def _render_projects_table(self, projects):
+        self.project_view.freeze_projects_sorting()
+        self.project_view.setup_projects_table(projects)
+
+    def _render_pager(self, enable, page_number, total_pages):
+        if enable:
+            self.project_view.show_projects_pages(True, page_number, total_pages)
+        else:
+            self.project_view.show_projects_pages(False)
+
+    def _render_current_project(self, project):
+        """Name the open project, and gate the 'go to processings' arrow on there being one."""
+        self.project_view.enable_switch_to_processings(project is not None)
+        if project is not None:
+            self.project_view.show_current_project(project.name)
+        if project is not None and project.workflowDefs:
+            self.project_view.setup_workflow_defs(project.workflowDefs, self.config.DEFAULT_MODEL)
+
+    def _lock_projects_selection(self, locked: bool):
+        if locked:
+            self.project_view.lock_projects_selection()
+        else:
+            self.project_view.unlock_projects_selection()
+            self.project_view.select_project(self.app_context.project_id)
+
+    # ==== DRIVING THE PROJECT SERVICE FROM THE PANEL ==== #
+
+    def refresh_projects(self, *args):
+        """Re-request the current page with whatever the sort and filter widgets now say."""
+        sort_by, sort_order = self.project_view.sort_projects()
+        self.project_service.get_projects(sort_by, sort_order, self.project_view.projects_filter)
+
+    def show_projects_next_page(self, *args):
+        self.project_service.to_next_page()
+        self.refresh_projects()
+
+    def show_projects_previous_page(self, *args):
+        self.project_service.to_previous_page()
+        self.refresh_projects()
+
+    def on_projects_filter_edited(self, *args):
+        """Typing in the filter resets to the first page — the page the user was on described a
+        different result set."""
+        self.project_service.to_first_page()
+        self.refresh_projects()
+
+    def on_projects_updated(self, *args):
+        if not self.project_service.projects:
+            self.project_view.clear_projects_table()
+        self.project_service.update_projects(self.project_view.projects_filter)
+        if self.app_context.project_id:
+            self.project_view.select_project(self.app_context.project_id)
+
+    def on_project_change(self, *args):
+        """The table's selection changed. Which project that is, is a widget read."""
+        self.project_service.on_project_change(self.project_view.selected_project_id())
 
     def _setup_navigation(self):
         """Navigation between projects, processings and in-template views."""
@@ -235,18 +314,18 @@ class ProjectProcessingController(QObject):
 
         # Save current projects page state before switching
         if save_page:
-            sort_by, sort_order = self.project_service.view.sort_projects()
+            sort_by, sort_order = self.project_view.sort_projects()
             projects_page = {
                 'offset': self.project_service.projects_page_offset,
                 'sort_by': sort_by,
                 'sort_order': sort_order,
-                'filter': self.project_service.view.projects_filter
+                'filter': self.project_view.projects_filter
             }
             self.app_context.settings.setValue('projectsPage', projects_page)
         # Load processing history
         self.processing_service.load_processing_history()
         # Switch view
-        self.project_service.view.switch_to_processings()
+        self.project_view.switch_to_processings()
 
         # Setup processings table for the project
         self.processing_service.setup_processings_table()
@@ -470,7 +549,7 @@ class ProjectProcessingController(QObject):
         self.project_service.get_projects(open_saved_page)
 
         # Switch view
-        self.project_service.view.switch_to_projects()
+        self.project_view.switch_to_projects()
 
         # Remove old cost
         self.processing_service.update_processing_cost()
@@ -506,4 +585,5 @@ class ProjectProcessingController(QObject):
         if self.project_connection is not None:
             self.dlg.projectsTable.itemSelectionChanged.disconnect(self.project_connection)
             self.project_connection = None
-        self.project_connection = self.dlg.projectsTable.itemSelectionChanged.connect(self.project_service.on_project_change)
+        self.project_connection = self.dlg.projectsTable.itemSelectionChanged.connect(
+            self.on_project_change)

--- a/mapflow/functional/service/project_service.py
+++ b/mapflow/functional/service/project_service.py
@@ -1,43 +1,63 @@
+"""Projects: fetching them, which one is open, and what the current user may do with it.
+
+Holds no widget and no view (`spec/007_architecture.md` § Layer rules). What the projects panel
+must show leaves as signals; what the panel says arrives as arguments. `ProjectProcessingController`
+connects the two — it already owns the projects/processings table and the navigation between them.
+"""
 import json
 from typing import Optional, Callable
 
-from PyQt5.QtCore import QObject, pyqtSignal, Qt
+from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
-from PyQt5.QtWidgets import QAbstractItemView
+
 from .. import helpers
 from ..app_context import AppContext
-from ...dialogs import MainDialog
 from ...config import Config
-from ...schema.project import CreateProjectSchema, UpdateProjectSchema, MapflowProject, ProjectsRequest, ProjectsResult, \
-    ProjectSortBy, ProjectSortOrder, UserRole
+from ...schema.project import (CreateProjectSchema, UpdateProjectSchema, MapflowProject,
+                               ProjectsRequest, ProjectsResult, ProjectSortBy, ProjectSortOrder,
+                               UserRole)
 from ..api.project_api import ProjectApi
-from ..view.project_view import ProjectView
 
 
 class ProjectService(QObject):
+    #: The projects list arrived, as a `ProjectsResult`. The controller fills the table and the
+    #: pager from it — how many pages that is, is arithmetic the controller does not need to know,
+    #: so `pagerChanged` carries the answer separately.
+    projectsLoaded = pyqtSignal(object)
+    #: (show controls, page number, total pages).
+    pagerChanged = pyqtSignal(bool, int, int)
+    #: A different project is open, or none (`None`). Carries the project so the controller can
+    #: name it in the header; the elision needs the live label width, so it is the view's.
+    currentProjectChanged = pyqtSignal(object)
+    #: The window title for the current project, role and owner.
+    windowTitleChanged = pyqtSignal(str)
+    #: (reason, may edit) for the rename/delete controls.
+    projectChangeRightsChanged = pyqtSignal(str, bool)
+    #: This project is shared and the user's role limits what they may do.
+    sharedRoleApplied = pyqtSignal(object)
+    #: True while a request that renumbers the table is in flight, so the table must not be
+    #: selectable — clicking during that window selects whatever lands on the row aimed at.
+    selectionLocked = pyqtSignal(bool)
+
     projectsUpdated = pyqtSignal()
     projectsFiltered = pyqtSignal()
 
-    def __init__(self, http, app_context: AppContext, dlg: MainDialog, config: Config):
+    def __init__(self, http, app_context: AppContext, config: Config):
         super().__init__()
         self.http = http
         self.app_context = app_context
-        self.dlg = dlg
         self.config = config
         self.api = ProjectApi(self.http)
-        self.view = ProjectView(self.dlg)
         self.projects_data = None
         self.projects = {}
         self.app_context.project_id = self.app_context.project_id
         self.projects_page_limit = Config.PROJECTS_PAGE_LIMIT
         self.projects_page_offset = 0
-        # Connections
-        self.dlg.projectsNextPageButton.clicked.connect(self.show_projects_next_page)
-        self.dlg.projectsPreviousPageButton.clicked.connect(self.show_projects_previous_page)
-        self.dlg.filterProjects.textEdited.connect(self.get_filtered_projects)
-        self.dlg.sortProjectsCombo.activated.connect(self.get_projects)
-        self.area_calculator_service = None # will be set later to avoid circular import
-    
+        #: What the last request filtered by, so the empty-result branch can tell "nothing matches
+        #: this filter" from "this account has no projects at all".
+        self._last_filter = ""
+        self.area_calculator_service = None  # set later to avoid a circular import
+
     def set_current_project(self, project: MapflowProject):
         self.app_context.project_id = project.id
         self.app_context.current_project = project
@@ -62,25 +82,24 @@ class ProjectService(QObject):
         project = MapflowProject.from_dict(json.loads(response.readAll().data()))
         self.set_current_project(project)
         self.get_projects()
-    
+
     def delete_project(self, project_id):
-        # Remove and temporary forbid selection (until get_projects_callback)
-        self.dlg.projectsTable.setSelectionMode(QAbstractItemView.NoSelection)
-        self.dlg.projectsTable.clearSelection()
+        # The list renumbers when this returns, so nothing may be selected until it does.
+        self.selectionLocked.emit(True)
         self.api.delete_project(project_id, self.delete_project_callback)
-    
+
     def delete_project_callback(self, response: QNetworkReply):
         self.projects_data.total += -1
         self.get_projects()
-    
+
     def update_project(self, project_id, project: UpdateProjectSchema):
         self.api.update_project(project_id, project, self.update_project_callback)
-    
+
     def update_project_callback(self, response: QNetworkReply):
         project = MapflowProject.from_dict(json.loads(response.readAll().data()))
         self.set_current_project(project)
         self.get_projects()
-    
+
     def get_project(self, project_id, callback: Callable, error_handler: Callable, error_handler_kwargs: dict):
         self.api.get_project(project_id, callback, error_handler, error_handler_kwargs)
 
@@ -89,17 +108,10 @@ class ProjectService(QObject):
         self.apply_project_aoi_area_limit(self.app_context.current_project)
         if self.app_context.current_project:
             self.app_context.project_id = self.app_context.current_project.id
-            elided_name = self.dlg.currentProjectLabel.fontMetrics().elidedText(
-                self.app_context.current_project.name,
-                Qt.ElideRight,
-                self.dlg.currentProjectLabel.width() - 50)
-            self.dlg.currentProjectLabel.setText(self.tr("Project: <b>{}").format(elided_name))
-            self.dlg.currentProjectLabel.adjustSize()
+            self.currentProjectChanged.emit(self.app_context.current_project)
         self.get_project_sharing()
         self.setup_project_change_rights()
         self.app_context.settings.setValue("project_id", self.app_context.project_id)
-        self.view.setup_workflow_defs(self.app_context.current_project.workflowDefs, 
-                                      self.config.DEFAULT_MODEL)
         # Manually toggle function to avoid race condition
         # TODO: Can we avoid this? Calling the function from here is ugly
         self.area_calculator_service.calculate_aoi_area_use_image_extent()
@@ -107,111 +119,98 @@ class ProjectService(QObject):
     def get_project_error_handler(self, response: QNetworkReply, **kwargs):
         pass
 
-    def get_projects(self, open_saved_page: Optional[bool] = False):
-        """Get projects depending on page parameters (offset, sorting, filtering).
+    @staticmethod
+    def sort_combo_index(sort_by, sort_order) -> int:
+        """The sort combo's index for a stored (sort_by, sort_order) pair.
 
-        Either get saved projects page (e.g. we load plugin with processings of project from 2nd page, 
-        and when going back to projects table, 2nd page should be shown).
-        Or load projects based on current offset and UI (sorting index and filtering text).
-
-        :param open_saved_page: A boolean that determines if we should get projects page from the settings or not.
+        The combo pairs each field with both directions, so neither value alone identifies a row —
+        the index is the single element common to the field's pair and the direction's triple.
+        `ProjectView.sort_projects` is the inverse.
         """
-        try: # if something changed and offset is now >= projects count
+        if sort_by == ProjectSortBy.name:
+            by = (0, 1)
+        elif sort_by == ProjectSortBy.created:
+            by = (2, 3)
+        else:  # ProjectSortBy.updated
+            by = (4, 5)
+        if sort_order == ProjectSortOrder.ascending:  # A-Z, Oldest first, Updated long ago
+            order = (0, 3, 5)
+        else:  # descending: Z-A, Newest first, Updated recently
+            order = (1, 2, 4)
+        return set(by).intersection(set(order)).pop()
+
+    def saved_projects_page(self) -> dict:
+        """The page, sort and filter last left behind, so the user returns where they were."""
+        return self.app_context.settings.value('projectsPage',
+                                               {'offset': self.projects_page_offset,
+                                                'sort_by': ProjectSortBy.updated,
+                                                'sort_order': ProjectSortOrder.descending,
+                                                'filter': ""})
+
+    def get_projects(self,
+                     sort_by=ProjectSortBy.updated,
+                     sort_order=ProjectSortOrder.descending,
+                     projects_filter: str = ""):
+        """Request a page of projects. Sorting and filtering come from the panel, so the caller
+        reads them and passes them in."""
+        try:  # if something changed and offset is now >= projects count
             if self.projects_page_offset >= self.projects_data.total:
-                self.projects_page_offset = 0 # show first page
+                self.projects_page_offset = 0  # show first page
         except AttributeError:
-            pass # if projects is an empty dict
-        # Open the page containing current project
-        if open_saved_page is True:
-            # Get each page parameter from dict in settings (if no dict - create one with default values)
-            projects_page = self.app_context.settings.value('projectsPage', {'offset' : self.projects_page_offset,
-                                                                 'sort_by' : ProjectSortBy.updated,
-                                                                 'sort_order' : ProjectSortOrder.descending,
-                                                                 'filter': ""})
-            self.projects_page_offset = int(projects_page['offset'])
-            sort_by = projects_page['sort_by']
-            sort_order = projects_page['sort_order']
-            projects_filter = projects_page['filter']
-            # Set saved filtering and sorting in UI
-            if projects_filter:
-                self.dlg.filterProjects.setText(projects_filter)
-            # Find pairs of sorting combo indecies from sort_by (not knowing sort_order)
-            if sort_by == ProjectSortBy.name:
-                by = (0, 1)
-            elif sort_by == ProjectSortBy.created:
-                by = (2, 3)
-            else: # sort_by == ProjectSortBy.updated
-                by = (4, 5)
-            # Find triples of sorting combo indecies from sort_order (not knowing sort_by)
-            if sort_order == ProjectSortOrder.ascending: # A-Z, Oldest first, Updated long ago
-                order = (0, 3, 5)
-            else: # ProjectSortOrder.descending: Z-A, Newest first, Updated recently
-                order = (1, 2, 4)
-            # Get and set the only element of the intersection of sort_by and sort_order indecies
-            index = set(by).intersection(set(order)).pop()
-            self.dlg.sortProjectsCombo.setCurrentIndex(index)
-        # Load page getting params from UI and don't change self.projects_page_offset
-        else:
-            sort_by, sort_order = self.view.sort_projects()
-            projects_filter = self.dlg.filterProjects.text()
-        # Send request with defined parameters
-        request_body = ProjectsRequest(self.projects_page_limit, 
+            pass  # if projects is an empty dict
+        self._last_filter = projects_filter
+        request_body = ProjectsRequest(self.projects_page_limit,
                                        self.projects_page_offset,
                                        projects_filter,
                                        sort_by, sort_order)
         self.api.get_projects(request_body, self.get_projects_callback)
         # Forbid clicking on pages controls before getting a response
-        self.view.enable_projects_pages(False)
-        self.dlg.projectsTable.clearSelection()
-    
+        self.pagerChanged.emit(False, 1, 1)
+        self.selectionLocked.emit(True)
+
     def get_projects_callback(self, response: QNetworkReply):
         self.projects_data = ProjectsResult.from_dict(json.loads(response.readAll().data()))
         self.projects = {project.id: project for project in self.projects_data.results}
-        self.dlg.projectsTable.setSortingEnabled(False) # temporary disable sorting by clicking the header
-        self.view.setup_projects_table(self.projects_data.results)
+        self.projectsLoaded.emit(self.projects_data.results)
         # En(dis)able page controls based on total, limit and offset
         if self.projects_data.total > self.projects_page_limit:
             quotient, remainder = divmod(self.projects_data.total, self.projects_page_limit)
             projects_total_pages = quotient + (remainder > 0)
-            projects_page_number = int(self.projects_page_offset/self.projects_page_limit) + 1
-            self.view.show_projects_pages(True, projects_page_number, projects_total_pages)
-        else:
-            # When no projects found, but no filter specified (should be at lest 'Default')
-            if not self.projects_data.total and len(self.dlg.filterProjects.text()) <= 1:
-                self.get_projects() # request first page without any parameters
-            else: # when total is just less than the limit
-                self.view.show_projects_pages(False) # show first page and no controls
+            projects_page_number = int(self.projects_page_offset / self.projects_page_limit) + 1
+            self.pagerChanged.emit(True, projects_page_number, projects_total_pages)
+        elif not self.projects_data.total and len(self._last_filter) <= 1:
+            # No projects and no filter to explain it — every account has at least 'Default', so
+            # this is a stale page rather than an empty account. Ask for the first page unfiltered.
+            self.get_projects()
+            return
+        else:  # total is just less than the limit
+            self.pagerChanged.emit(False, 1, 1)
         self.projectsUpdated.emit()
-        self.dlg.projectsTable.clearSelection()
-        self.dlg.projectsTable.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.select_project(self.app_context.project_id)
-    
-    def select_project(self, project_id):
-        self.view.select_project(project_id)
-    
-    def show_projects_next_page(self):
+        self.selectionLocked.emit(False)
+
+    # The offset is this service's state, but re-requesting needs the panel's sort and filter —
+    # so these move the cursor and the caller asks for the page.
+
+    def to_next_page(self) -> None:
         self.projects_page_offset += self.projects_page_limit
-        self.get_projects()
 
-    def show_projects_previous_page(self):
+    def to_previous_page(self) -> None:
         self.projects_page_offset += -self.projects_page_limit
-        self.get_projects()
 
-    def get_filtered_projects(self):
-        """Get projects, resetting filtered offset value.
-
-        Is called when texted is edited by user (not just changed programmatically).
-        So each time offset resets to 0 to show 1st page of newly filtered response.
-        """
+    def to_first_page(self) -> None:
+        """The filter text changed, so whichever page the user was on no longer means anything."""
         self.projects_page_offset = 0
         self.app_context.project_id = None
-        self.get_projects()
 
     # ========== Projects ========== #
 
-    def on_project_change(self):
-        selected_id = self.dlg.selected_project_id()
-        if selected_id is not None and selected_id == self.app_context.project_id and self.app_context.workflow_defs:
+    def on_project_change(self, selected_id):
+        """A row was selected in the projects table (or the selection was cleared).
+
+        ``selected_id`` is read from the table by the caller — a service may not read a widget.
+        """
+        if selected_id is not None and selected_id == self.app_context.project_id \
+                and self.app_context.workflow_defs:
             # we look at workflow defs because if they are NOT initialized, it means that the project
             # is not initialized yet (at plugin's startup) and we still need to set it up
             # otherwise, if the WDs are set, we assume that the project hasn't changed and skip further setup
@@ -221,33 +220,25 @@ class ProjectService(QObject):
             self.apply_project_aoi_area_limit(None)  # no project open -> no AOI area limit
             self.app_context.settings.setValue("project_id", None)
             self.setup_project_change_rights()
-            self.dlg.setWindowTitle(helpers.generate_plugin_header(self.app_context.plugin_name,
-                                                                   env=self.config.MAPFLOW_ENV))
-            self.dlg.switchProcessingsButton.setEnabled(False)
-        else:
-            self.dlg.switchProcessingsButton.setEnabled(True)
-            # Find project in projects/page and set as current
-            self.app_context.project_id = selected_id
-            for pid, project in self.projects.items():
-                if selected_id == pid:
-                    self.app_context.current_project = project
-                    elided_name = self.dlg.currentProjectLabel.fontMetrics().elidedText(
-                        self.app_context.current_project.name,
-                        Qt.ElideRight,
-                        self.dlg.currentProjectLabel.width() - 50)
-                    self.dlg.currentProjectLabel.setText(self.tr("Project: <b>{}").format(elided_name))
-            if self.app_context.current_project:
-                self.apply_project_aoi_area_limit(self.app_context.current_project)
-                self.get_project_sharing()
-                self.view.setup_workflow_defs(self.app_context.current_project.workflowDefs,
-                                              self.config.DEFAULT_MODEL)
-            self.setup_project_change_rights()
-            self.app_context.settings.setValue("project_id", self.app_context.project_id)
+            self.windowTitleChanged.emit(
+                helpers.generate_plugin_header(self.app_context.plugin_name,
+                                               env=self.config.MAPFLOW_ENV))
+            self.currentProjectChanged.emit(None)
+            return
+        self.app_context.project_id = selected_id
+        for pid, project in self.projects.items():
+            if selected_id == pid:
+                self.app_context.current_project = project
+                self.currentProjectChanged.emit(project)
+        if self.app_context.current_project:
+            self.apply_project_aoi_area_limit(self.app_context.current_project)
+            self.get_project_sharing()
+        self.setup_project_change_rights()
+        self.app_context.settings.setValue("project_id", self.app_context.project_id)
 
-            # Manually toggle function to avoid race condition
-            # TODO: Can we avoid this? Calling the function from here is ugly
-            self.area_calculator_service.calculate_aoi_area_use_image_extent()
-
+        # Manually toggle function to avoid race condition
+        # TODO: Can we avoid this? Calling the function from here is ugly
+        self.area_calculator_service.calculate_aoi_area_use_image_extent()
 
     def setup_project_change_rights(self):
         project_editable = True
@@ -262,15 +253,11 @@ class ProjectService(QObject):
                 self.app_context.user_role.value)
         else:
             reason = ""
-        self.dlg.enable_project_change(reason,
-                                       project_editable and self.app_context.user_role.can_delete_rename_project)
+        self.projectChangeRightsChanged.emit(
+            reason, project_editable and self.app_context.user_role.can_delete_rename_project)
 
-    def update_projects(self):
-        if not self.projects:
-            self.view.clear_projects_table()
-        self.filter_projects(self.view.projects_filter)
-        if self.app_context.project_id:
-            self.select_project(self.app_context.project_id)
+    def update_projects(self, name_filter: str = ""):
+        self.filter_projects(name_filter)
 
     def filter_projects(self, name_filter):
         if not name_filter:
@@ -289,16 +276,16 @@ class ProjectService(QObject):
             return
         if self.app_context.current_project.shareProject:
             # Get user role, if project is shared
-            self.app_context.user_role = self.app_context.current_project.shareProject.get_user_role(self.app_context.username)
+            self.app_context.user_role = self.app_context.current_project.shareProject.get_user_role(
+                self.app_context.username)
             project_owner = self.app_context.current_project.shareProject.owners[0].email
-            # Disable buttons
-            self.dlg.enable_shared_project(self.app_context.user_role)
+            self.sharedRoleApplied.emit(self.app_context.user_role)
         else:
             self.app_context.user_role = UserRole.owner
             project_owner = self.app_context.username
-        # Specify new main window header
-        self.dlg.setWindowTitle(helpers.generate_plugin_header(self.app_context.plugin_name,
-                                                               env=self.config.MAPFLOW_ENV,
-                                                               project_name=self.app_context.current_project.name,
-                                                               user_role=self.app_context.user_role,
-                                                               project_owner=project_owner))
+        self.windowTitleChanged.emit(
+            helpers.generate_plugin_header(self.app_context.plugin_name,
+                                           env=self.config.MAPFLOW_ENV,
+                                           project_name=self.app_context.current_project.name,
+                                           user_role=self.app_context.user_role,
+                                           project_owner=project_owner))

--- a/mapflow/functional/service/project_service.py
+++ b/mapflow/functional/service/project_service.py
@@ -150,9 +150,12 @@ class ProjectService(QObject):
     def get_projects(self,
                      sort_by=ProjectSortBy.updated,
                      sort_order=ProjectSortOrder.descending,
-                     projects_filter: str = ""):
+                     projects_filter: str = "",
+                     offset: Optional[int] = None):
         """Request a page of projects. Sorting and filtering come from the panel, so the caller
-        reads them and passes them in."""
+        reads them and passes them in; `offset` is for restoring a remembered page."""
+        if offset is not None:
+            self.projects_page_offset = offset
         try:  # if something changed and offset is now >= projects count
             if self.projects_page_offset >= self.projects_data.total:
                 self.projects_page_offset = 0  # show first page

--- a/mapflow/functional/view/project_view.py
+++ b/mapflow/functional/view/project_view.py
@@ -197,3 +197,60 @@ class ProjectView(QObject):
     @property
     def projects_filter(self):
         return self.dlg.filterProjects.text()
+
+    def set_projects_filter(self, text: str) -> None:
+        self.dlg.filterProjects.setText(text)
+
+    def set_sort_index(self, index: int) -> None:
+        self.dlg.sortProjectsCombo.setCurrentIndex(index)
+
+    def selected_project_id(self):
+        return self.dlg.selected_project_id()
+
+    # ---------- the table's selection, while a request is in flight ----------
+
+    def lock_projects_selection(self) -> None:
+        """Forbid selecting a project until the pending request answers.
+
+        Deleting a project renumbers the table under the user; letting them click during that
+        window selects whichever project happens to land on the row they aimed at.
+        """
+        self.dlg.projectsTable.setSelectionMode(QAbstractItemView.NoSelection)
+        self.dlg.projectsTable.clearSelection()
+
+    def unlock_projects_selection(self) -> None:
+        self.dlg.projectsTable.clearSelection()
+        self.dlg.projectsTable.setSelectionMode(QAbstractItemView.SingleSelection)
+
+    def clear_projects_selection(self) -> None:
+        self.dlg.projectsTable.clearSelection()
+
+    def freeze_projects_sorting(self) -> None:
+        """Header-click sorting is re-enabled by `setup_projects_table`; turning it off first stops
+        the rows re-ordering while they are being written."""
+        self.dlg.projectsTable.setSortingEnabled(False)
+
+    # ---------- which project is open ----------
+
+    def show_current_project(self, name: str) -> None:
+        """Name the open project in the header label, elided to the width it actually has.
+
+        `fontMetrics().elidedText` needs the live widget width, so this cannot be precomputed by a
+        caller — which is why the elision lives here rather than being passed in ready-made.
+        """
+        label = self.dlg.currentProjectLabel
+        elided = label.fontMetrics().elidedText(name, Qt.ElideRight, label.width() - 50)
+        label.setText(self.tr("Project: <b>{}").format(elided))
+        label.adjustSize()
+
+    def set_window_title(self, title: str) -> None:
+        self.dlg.setWindowTitle(title)
+
+    def enable_switch_to_processings(self, enabled: bool) -> None:
+        self.dlg.switchProcessingsButton.setEnabled(enabled)
+
+    def enable_project_change(self, reason: str, enabled: bool) -> None:
+        self.dlg.enable_project_change(reason, enabled)
+
+    def enable_shared_project(self, user_role) -> None:
+        self.dlg.enable_shared_project(user_role)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -25,6 +25,7 @@ from .functional.controller.project_processing_controller import ProjectProcessi
 from .functional.controller.processing_controller import ProcessingController
 from .functional.controller.provider_controller import ProviderController
 from .functional.view.provider_view import ProviderView
+from .functional.view.project_view import ProjectView
 from .functional.controller.search_controller import SearchController
 from .functional.controller.template_controller import TemplateController
 from .functional.service.template_service import TemplateService
@@ -212,8 +213,10 @@ class Mapflow(QObject):
         # ========== 7. INITIALIZE PROJECT AND PROCESSING SERVICES ==========
         self.project_service = ProjectService(http=self.http,
                                             app_context=self.app_context,
-                                            dlg=self.dlg,
                                             config=self.config)
+        # The projects panel. Built here rather than by the service, which may not hold a view;
+        # `ProjectProcessingController` drives it.
+        self.project_view = ProjectView(self.dlg)
         
         self.provider_service = ProviderService.get_instance(providers=ProvidersList([]),
                                                             dlg=self.dlg,
@@ -379,7 +382,9 @@ class Mapflow(QObject):
             data_catalog_service=self.data_catalog_service,
             result_loader=self.result_loader,
             processing_view=self.processing_service.view,
-            ensure_output_directory=self.ensure_output_directory)
+            ensure_output_directory=self.ensure_output_directory,
+            project_view=self.project_view,
+            config=self.config)
 
         self.setup_add_layer_menu()
         # Add options menu functionality
@@ -1059,7 +1064,7 @@ class Mapflow(QObject):
         # Get all projects & setup processings table (see callback)
         if self.is_admin:
             self.app_context.project_id = Config.PROJECT_ID
-            self.project_service.view.setup_workflow_defs(default_project.workflowDefs, 
+            self.project_view.setup_workflow_defs(default_project.workflowDefs, 
                                                           self.config.DEFAULT_MODEL)
             self.processing_service.setup_processings_table()
         else:

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -66,7 +66,6 @@ ALLOWED = {
     ("widget-import", "mapflow.functional.service.alert_service"),
     ("widget-import", "mapflow.functional.service.data_catalog"),
     ("widget-import", "mapflow.functional.service.processing_service"),
-    ("widget-import", "mapflow.functional.service.project_service"),
     ("widget-import", "mapflow.functional.service.provider_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
     # Services and two api modules taking the main dialog as a constructor argument.

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -73,7 +73,6 @@ ALLOWED = {
     ("dialog-param", "mapflow.functional.service.area_calculator_service"),
     ("dialog-param", "mapflow.functional.service.data_catalog"),
     ("dialog-param", "mapflow.functional.service.processing_service"),
-    ("dialog-param", "mapflow.functional.service.project_service"),
     ("dialog-param", "mapflow.functional.service.provider_service"),
     ("dialog-param", "mapflow.functional.api.data_catalog_api"),
     ("dialog-param", "mapflow.functional.api.processing_api"),
@@ -84,10 +83,8 @@ ALLOWED = {
     ("service-imports-dialogs", "mapflow.functional.service.area_calculator_service"),
     ("service-imports-dialogs", "mapflow.functional.service.data_catalog"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
-    ("service-imports-dialogs", "mapflow.functional.service.project_service"),
     ("service-imports-view", "mapflow.functional.service.data_catalog"),
     ("service-imports-view", "mapflow.functional.service.processing_service"),
-    ("service-imports-view", "mapflow.functional.service.project_service"),
     ("view-imports-service", "mapflow.functional.view.processing_view"),
 }
 

--- a/tests/qgis/test_project_service.py
+++ b/tests/qgis/test_project_service.py
@@ -1,0 +1,351 @@
+"""QGIS-tier tests for the projects panel: what the service announces, and what the controller
+renders from it.
+
+`ProjectService` held the dialog and built its own view, so none of this was reachable without a
+plugin — the behavioural journey in `tests/qgis/behavioral/test_projects_and_processings.py` was
+the only cover. These pin the contract between the two halves: the service decides *what* the
+panel shows and emits it; the controller reads the widgets and renders.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
+from mapflow.functional.service.project_service import ProjectService
+from mapflow.schema.project import ProjectSortBy, ProjectSortOrder
+
+
+def _service(total=1, page_limit=5):
+    service = ProjectService.__new__(ProjectService)
+    QObject.__init__(service)  # the panel updates are signals
+    service.tr = lambda text: text
+    service.api = MagicMock()
+    service.config = SimpleNamespace(MAPFLOW_ENV="production", DEFAULT_MODEL="Buildings")
+    service.app_context = SimpleNamespace(settings=MagicMock(), project_id=None,
+                                          current_project=None, workflow_defs={},
+                                          plugin_name="Mapflow", username="me@example.com",
+                                          user_role=None, aoi_area_limit=None)
+    service.projects = {}
+    service.projects_data = SimpleNamespace(total=total)
+    service.projects_page_limit = page_limit
+    service.projects_page_offset = 0
+    service._last_filter = ""
+    service.area_calculator_service = MagicMock()
+    return service
+
+
+def _response(payload):
+    reply = MagicMock()
+    reply.readAll.return_value.data.return_value = json.dumps(payload).encode()
+    return reply
+
+
+def _projects_payload(count, total=None):
+    """A full project dict: `MapflowProject.from_dict` rejects partial ones, and a thin fixture
+    fails as a TypeError deep in the parse rather than as the thing under test."""
+    return {"results": [{"id": f"p-{i}",
+                         "name": f"Project {i}",
+                         "isDefault": False,
+                         "description": "",
+                         "workflowDefs": [],
+                         "created": "2026-01-01T00:00:00.000Z",
+                         "updated": "2026-01-01T00:00:00.000Z"}
+                        for i in range(count)],
+            "total": count if total is None else total}
+
+
+# ---------- requesting a page ----------
+
+def test_the_request_carries_the_sort_and_filter_it_was_given():
+    """The panel's widgets are read by the caller; nothing here reaches for them."""
+    service = _service()
+
+    service.get_projects(ProjectSortBy.name, ProjectSortOrder.ascending, "roads")
+
+    request = service.api.get_projects.call_args.args[0]
+    assert request.filter == "roads"
+    assert request.sortBy == ProjectSortBy.name
+    assert request.sortOrder == ProjectSortOrder.ascending
+
+
+def test_a_request_disables_the_pager_and_locks_the_selection():
+    """Both prevent acting on a list that is about to be replaced."""
+    service = _service()
+    pager, locks = [], []
+    service.pagerChanged.connect(lambda *a: pager.append(a))
+    service.selectionLocked.connect(locks.append)
+
+    service.get_projects()
+
+    assert pager == [(False, 1, 1)]
+    assert locks == [True]
+
+
+def test_an_offset_past_the_end_falls_back_to_the_first_page():
+    service = _service(total=3)
+    service.projects_page_offset = 99
+
+    service.get_projects()
+
+    assert service.projects_page_offset == 0
+
+
+def test_paging_moves_the_cursor_without_requesting():
+    """Re-requesting needs the panel's sort and filter, so the caller asks — this only moves."""
+    service = _service(page_limit=5)
+
+    service.to_next_page()
+    assert service.projects_page_offset == 5
+
+    service.to_previous_page()
+    assert service.projects_page_offset == 0
+
+
+def test_filtering_returns_to_the_first_page_and_forgets_the_open_project():
+    service = _service()
+    service.projects_page_offset = 10
+    service.app_context.project_id = "p-1"
+
+    service.to_first_page()
+
+    assert service.projects_page_offset == 0
+    assert service.app_context.project_id is None
+
+
+# ---------- the response ----------
+
+def test_the_results_are_announced_for_the_table():
+    service = _service()
+    shown = []
+    service.projectsLoaded.connect(shown.append)
+
+    service.get_projects_callback(_response(_projects_payload(2)))
+
+    assert len(shown[0]) == 2
+    assert set(service.projects) == {"p-0", "p-1"}
+
+
+def test_the_pager_reports_the_page_count():
+    service = _service(page_limit=5)
+    pages = []
+    service.pagerChanged.connect(lambda *a: pages.append(a))
+    service.projects_page_offset = 5
+
+    service.get_projects_callback(_response(_projects_payload(5, total=12)))
+
+    # 12 over 5 per page = 3 pages; offset 5 is the second.
+    assert pages[-1] == (True, 2, 3)
+
+
+def test_a_short_page_hides_the_pager():
+    service = _service(page_limit=5)
+    pages = []
+    service.pagerChanged.connect(lambda *a: pages.append(a))
+
+    service.get_projects_callback(_response(_projects_payload(2, total=2)))
+
+    assert pages[-1] == (False, 1, 1)
+
+
+def test_an_empty_unfiltered_result_asks_again_without_parameters():
+    """Every account has at least a Default project, so nothing-at-all means the request carried
+    a stale page rather than the account being empty."""
+    service = _service()
+    service._last_filter = ""
+
+    service.get_projects_callback(_response(_projects_payload(0, total=0)))
+
+    assert service.api.get_projects.call_count == 1
+
+
+def test_an_empty_filtered_result_is_left_alone():
+    """A filter that matches nothing is a real answer — re-requesting would discard it."""
+    service = _service()
+    service._last_filter = "no-such-project"
+
+    service.get_projects_callback(_response(_projects_payload(0, total=0)))
+
+    service.api.get_projects.assert_not_called()
+
+
+def test_the_selection_unlocks_once_the_list_has_arrived():
+    service = _service()
+    locks = []
+    service.selectionLocked.connect(locks.append)
+
+    service.get_projects_callback(_response(_projects_payload(1, total=1)))
+
+    assert locks[-1] is False
+
+
+# ---------- which project is open ----------
+
+def test_selecting_a_project_announces_it():
+    service = _service()
+    service.projects = {"p-1": SimpleNamespace(id="p-1", name="Roads", shareProject=None,
+                                               isDefault=False, workflowDefs={}, user=None)}
+    announced = []
+    service.currentProjectChanged.connect(announced.append)
+
+    service.on_project_change("p-1")
+
+    assert announced[0].name == "Roads"
+    assert service.app_context.project_id == "p-1"
+
+
+def test_clearing_the_selection_announces_no_project():
+    service = _service()
+    announced, titles = [], []
+    service.currentProjectChanged.connect(announced.append)
+    service.windowTitleChanged.connect(titles.append)
+
+    service.on_project_change(None)
+
+    assert announced == [None]
+    assert titles  # the header drops the project name
+    assert service.app_context.project_id is None
+
+
+def test_reselecting_the_open_project_does_nothing():
+    """Its workflow defs are already set up; redoing it re-requests for no reason."""
+    service = _service()
+    service.app_context.project_id = "p-1"
+    service.app_context.workflow_defs = {"wd": object()}
+    announced = []
+    service.currentProjectChanged.connect(announced.append)
+
+    service.on_project_change("p-1")
+
+    assert announced == []
+
+
+def test_reselecting_at_startup_is_not_skipped():
+    """Same id, but no workflow defs yet — the project is not set up, so it must proceed."""
+    service = _service()
+    service.app_context.project_id = "p-1"
+    service.app_context.workflow_defs = {}
+    service.projects = {"p-1": SimpleNamespace(id="p-1", name="Roads", shareProject=None,
+                                               isDefault=False, workflowDefs={}, user=None)}
+    announced = []
+    service.currentProjectChanged.connect(announced.append)
+
+    service.on_project_change("p-1")
+
+    assert announced and announced[0].name == "Roads"
+
+
+# ---------- what may be done with it ----------
+
+@pytest.mark.parametrize("project, role, expect_editable, expect_reason", [
+    (None, None, False, "No project selected"),
+    (SimpleNamespace(isDefault=True), SimpleNamespace(can_delete_rename_project=True, value="owner"),
+     False, "default project"),
+    (SimpleNamespace(isDefault=False), SimpleNamespace(can_delete_rename_project=False, value="viewer"),
+     False, "Not enough rights"),
+    (SimpleNamespace(isDefault=False), SimpleNamespace(can_delete_rename_project=True, value="owner"),
+     True, ""),
+])
+def test_the_rename_delete_controls_follow_the_project_and_the_role(
+        project, role, expect_editable, expect_reason):
+    service = _service()
+    service.app_context.current_project = project
+    service.app_context.user_role = role
+    announced = []
+    service.projectChangeRightsChanged.connect(lambda *a: announced.append(a))
+
+    service.setup_project_change_rights()
+
+    reason, editable = announced[0]
+    assert editable is expect_editable
+    assert expect_reason in reason
+
+
+def test_deleting_locks_the_selection_before_the_request():
+    """The list renumbers when this returns; a click in that window selects whatever lands on the
+    row the user aimed at."""
+    service = _service()
+    locks = []
+    service.selectionLocked.connect(locks.append)
+
+    service.delete_project("p-1")
+
+    assert locks == [True]
+    service.api.delete_project.assert_called_once()
+
+
+# ---------- the controller's half ----------
+
+def _controller():
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.project_service = MagicMock()
+    controller.project_view = MagicMock()
+    controller.app_context = SimpleNamespace(project_id=None)
+    controller.config = SimpleNamespace(DEFAULT_MODEL="Buildings")
+    return controller
+
+
+def test_the_switch_arrow_follows_whether_a_project_is_open():
+    controller = _controller()
+
+    controller._render_current_project(None)
+    assert controller.project_view.enable_switch_to_processings.call_args.args[0] is False
+
+    controller._render_current_project(SimpleNamespace(name="Roads", workflowDefs={}))
+    assert controller.project_view.enable_switch_to_processings.call_args.args[0] is True
+
+
+def test_the_open_projects_name_is_elided_by_the_view():
+    """The label's width is only knowable from the widget, so the view does the eliding — the
+    controller hands it the raw name."""
+    controller = _controller()
+
+    controller._render_current_project(SimpleNamespace(name="A very long project name",
+                                                       workflowDefs={}))
+
+    controller.project_view.show_current_project.assert_called_once_with("A very long project name")
+
+
+def test_the_models_are_repopulated_only_when_the_project_has_them():
+    controller = _controller()
+
+    controller._render_current_project(SimpleNamespace(name="Roads", workflowDefs={}))
+    controller.project_view.setup_workflow_defs.assert_not_called()
+
+    controller._render_current_project(SimpleNamespace(name="Roads", workflowDefs={"wd": object()}))
+    controller.project_view.setup_workflow_defs.assert_called_once()
+
+
+def test_refreshing_reads_the_sort_and_filter_off_the_panel():
+    controller = _controller()
+    controller.project_view.sort_projects.return_value = ("NAME", "ASC")
+    controller.project_view.projects_filter = "roads"
+
+    controller.refresh_projects()
+
+    controller.project_service.get_projects.assert_called_once_with("NAME", "ASC", "roads")
+
+
+def test_paging_moves_the_cursor_then_re_requests():
+    controller = _controller()
+    controller.project_view.sort_projects.return_value = ("UPDATED", "DESC")
+    controller.project_view.projects_filter = ""
+
+    controller.show_projects_next_page()
+
+    controller.project_service.to_next_page.assert_called_once()
+    controller.project_service.get_projects.assert_called_once()
+
+
+def test_unlocking_the_selection_restores_the_open_project():
+    controller = _controller()
+    controller.app_context.project_id = "p-1"
+
+    controller._lock_projects_selection(False)
+
+    controller.project_view.unlock_projects_selection.assert_called_once()
+    controller.project_view.select_project.assert_called_once_with("p-1")

--- a/tests/qgis/test_project_service.py
+++ b/tests/qgis/test_project_service.py
@@ -341,6 +341,82 @@ def test_paging_moves_the_cursor_then_re_requests():
     controller.project_service.get_projects.assert_called_once()
 
 
+def test_leaving_a_project_sends_a_real_sort_not_a_flag():
+    """`show_projects` takes a bool for "restore the saved page". Passing it straight into
+    `get_projects` puts it where `sort_by` goes, and the backend rejects the body with
+    `Invalid value for: body (String at 'sortBy')` — a 400 the user sees on every exit."""
+    controller = _controller()
+    controller.processing_service = MagicMock()
+    controller.project_view.sort_projects.return_value = ("UPDATED", "DESC")
+    controller.project_view.projects_filter = ""
+
+    controller.show_projects(open_saved_page=False)
+
+    sort_by = controller.project_service.get_projects.call_args.args[0]
+    assert not isinstance(sort_by, bool)
+    assert sort_by == "UPDATED"
+
+
+def test_returning_to_projects_restores_the_page_the_user_left():
+    controller = _controller()
+    controller.processing_service = MagicMock()
+    controller.project_service.saved_projects_page.return_value = {
+        'offset': 20, 'sort_by': ProjectSortBy.name,
+        'sort_order': ProjectSortOrder.ascending, 'filter': "roads"}
+    controller.project_service.sort_combo_index.return_value = 0
+
+    controller.show_projects(open_saved_page=True)
+
+    # The widgets are set to match the query the request will carry...
+    controller.project_view.set_projects_filter.assert_called_once_with("roads")
+    controller.project_view.set_sort_index.assert_called_once_with(0)
+    # ...and the request asks for the remembered page, not the first one.
+    kwargs = controller.project_service.get_projects.call_args.kwargs
+    assert kwargs["offset"] == 20
+
+
+def test_a_restored_page_with_no_filter_leaves_the_filter_box_alone():
+    controller = _controller()
+    controller.processing_service = MagicMock()
+    controller.project_service.saved_projects_page.return_value = {
+        'offset': 0, 'sort_by': ProjectSortBy.updated,
+        'sort_order': ProjectSortOrder.descending, 'filter': ""}
+    controller.project_service.sort_combo_index.return_value = 4
+
+    controller.show_projects(open_saved_page=True)
+
+    controller.project_view.set_projects_filter.assert_not_called()
+
+
+def test_an_explicit_offset_overrides_the_current_page():
+    service = _service(total=50)
+    service.projects_page_offset = 5
+
+    service.get_projects(ProjectSortBy.name, ProjectSortOrder.ascending, "", offset=20)
+
+    assert service.api.get_projects.call_args.args[0].offset == 20
+
+
+def test_a_saved_page_past_the_end_falls_back_to_the_first():
+    """A remembered page outlives the projects it referred to: deleting enough of them leaves the
+    saved offset pointing past the end, and asking for it returns nothing at all."""
+    service = _service(total=3)
+
+    service.get_projects(ProjectSortBy.name, ProjectSortOrder.ascending, "", offset=20)
+
+    assert service.api.get_projects.call_args.args[0].offset == 0
+
+
+def test_the_sort_combo_index_round_trips_every_pair():
+    """`sort_combo_index` is the inverse of `ProjectView.sort_projects`; each (field, direction)
+    pair must land on exactly one row, or restoring a saved page selects the wrong sort."""
+    seen = set()
+    for sort_by in (ProjectSortBy.name, ProjectSortBy.created, ProjectSortBy.updated):
+        for sort_order in (ProjectSortOrder.ascending, ProjectSortOrder.descending):
+            seen.add(ProjectService.sort_combo_index(sort_by, sort_order))
+    assert seen == {0, 1, 2, 3, 4, 5}
+
+
 def test_unlocking_the_selection_restores_the_open_project():
     controller = _controller()
     controller.app_context.project_id = "p-1"


### PR DESCRIPTION
C2.1, and the pattern the rest of the phase follows. ProjectService held the main dialog AND
constructed its own ProjectView, so it carried two allowlist entries; both are deleted here, which
is the first movement on the criterion Phase C left unmet.

What the panel must show now leaves as signals - projectsLoaded, pagerChanged,
currentProjectChanged, windowTitleChanged, projectChangeRightsChanged, sharedRoleApplied,
selectionLocked - and what the panel says arrives as arguments. ProjectProcessingController
connects the two; it already owned the projects/processings table and the navigation between them,
so no new controller was needed.

project_controller.py was an empty, unreferenced file, and its existence was why the plan claimed
this step's controller already existed. Deleted.

Two things the split settled that were previously ambiguous.

The elided project name appeared verbatim in two methods. It is one view method now, and it has to
be the view's: fontMetrics().elidedText needs the live label width, so no caller can precompute it.

Paging cannot re-request on its own, because the request carries the panel's sort and filter. The
service owns the offset and moves it (to_next_page / to_previous_page / to_first_page); the
controller reads the widgets and asks for the page. Previously the service did both by reading the
combo itself.

Twenty-eight tests, where there were none - nothing in the suite constructed this service, which is
also why removing its constructor argument broke nothing. The behavioural journey was the only
cover, and it cannot reach the branches. Two pairs are deliberately two-sided, because either half
alone passes while the behaviour is broken: an empty result re-requests only when there is no
filter (a filter matching nothing is a real answer, not a stale page), and reselecting the open
project is skipped only once its workflow defs exist (at startup the id already matches but the
project is not set up yet, so skipping breaks first launch).

Recorded as C3.5a rather than fixed here: that same empty-result branch loops forever for an
account with no projects at all, since it re-requests unfiltered and gets the same empty answer. It
is guarded only by the assumption that every account has a Default project. Asynchronous, so it
presents as a plugin endlessly talking to the server rather than as a crash.

## Manual test
Open the projects panel: the list fills, the pager appears only when there is more than one page,
and the arrows move between pages keeping the current sort and filter. Type in the filter - the
list narrows and returns to page one; clear it and the full list comes back. Change the sort combo
and the order changes. Select a project: its name appears in the header (elided if long, with the
full name still readable), the window title names the project, and the arrow to processings
becomes available; deselect and all three revert. Open a shared project where your role cannot
rename or delete - those controls are disabled with the reason naming the role; open the Default
project and they are disabled too. Delete a project: the table must not be clickable until the new
list arrives, and afterwards the previously open project is still selected. Regression surface:
after any of these, going into a project's processings and back must land on the same page of the
list you left.
