### PR TITLE
refactor: the processings table leaves ProcessingService for its controller

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,7 +105,7 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-[ ] C2.2a The processings table → `ProjectProcessingController`
+[ready-for-review] C2.2a The processings table → `ProjectProcessingController`
     `selected_processing_ids` ×4, `update_processing_table` ×2, `show_processings_pages` ×2,
     `sort_processings` ×2, `enable_processings_pages`, `set_table_loading`,
     `delete_processings_from_table`, `add_new_processing`, `update_processing_name`,

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -86,8 +86,7 @@ class ProjectProcessingController(QObject):
         self.template_service.refreshRequested.connect(self.refresh_table)
         # The in-template view holds no widget and owns no timer, so its rebuilt rows and its
         # slower poll cadence arrive here to be applied.
-        self.template_service.templateRowsChanged.connect(
-            self.processing_service.view.update_processing_table)
+        self.template_service.templateRowsChanged.connect(self.render_rows)
         self.template_service.pollIntervalChanged.connect(self._set_poll_interval)
         # `ProcessingService` turns a table selection into objects, so it needs to know which view
         # the table is showing — but it must not reach into `TemplateService` to find out. The
@@ -96,6 +95,85 @@ class ProjectProcessingController(QObject):
         self.template_service.templateClosed.connect(self._on_template_closed)
         self.template_service.visibleProcessingsChanged.connect(
             self.processing_service.set_visible_processings)
+        self._setup_processings_table_bindings()
+
+    def _setup_processings_table_bindings(self):
+        """The processings table: what the service announces for it, and the pager/sort/filter
+        controls that drive it. `ProcessingService` made these connections for itself and drew
+        the results; it now only says what belongs in the table."""
+        self.processing_service.tableLoading.connect(self.render_loading)
+        self.processing_service.rowsChanged.connect(self.render_rows)
+        self.processing_service.pagerChanged.connect(self._render_processings_pager)
+        self.processing_service.pagerEnabled.connect(
+            self.processing_view.enable_processings_pages)
+        self.processing_service.processingAdded.connect(self._render_new_processing)
+        self.processing_service.processingRenamed.connect(self._render_processing_name)
+        self.processing_service.processingsDeleted.connect(self._render_deleted_processings)
+
+        self.dlg.processingsNextPageButton.clicked.connect(
+            self.processing_service.show_processings_next_page)
+        self.dlg.processingsPreviousPageButton.clicked.connect(
+            self.processing_service.show_processings_previous_page)
+        self.dlg.filterProcessings.textEdited.connect(
+            self.processing_service.get_filtered_processings)
+        self.dlg.sortProcessingsCombo.activated.connect(self.on_combo_sort_changed)
+        # A column-click sort needs no request: the rows are already held.
+        self.processing_view.connect_header_sort(self.rerender_rows)
+
+    # ==== RENDERING WHAT THE PROCESSING SERVICE ANNOUNCES ==== #
+
+    def render_loading(self):
+        self.processing_view.set_table_loading()
+        self.push_selection()
+
+    def render_rows(self, rows):
+        self.processing_view.update_processing_table(rows)
+        self.push_selection()
+
+    def _render_processings_pager(self, enable, page_number, total_pages):
+        if enable:
+            self.processing_view.show_processings_pages(True, page_number, total_pages)
+        else:
+            self.processing_view.show_processings_pages(False)
+
+    def _render_new_processing(self, processing):
+        self.processing_view.add_new_processing(processing)
+        self.push_selection()
+
+    def _render_processing_name(self, processing_id: str, new_name: str):
+        self.processing_view.update_processing_name(processing_id=processing_id,
+                                                    new_name=new_name)
+
+    def _render_deleted_processings(self, processing_ids):
+        self.processing_view.delete_processings_from_table(processing_ids)
+        self.push_selection()
+
+    # ==== WHAT THE TABLE CURRENTLY SAYS, PUSHED TO THE SERVICES THAT NEED IT ==== #
+
+    def push_selection(self):
+        """Hand the selected row ids to `ProcessingService`, which resolves them into processings
+        and templates — and which `TemplateService` reads in turn for the open template's AOIs.
+        Neither service may read the table itself.
+
+        Called from `Mapflow.push_processings_selection` on every selection change, and again
+        after each render here: a programmatic rebuild restores the selection with the table's
+        signals blocked, so nothing else would re-sync it.
+        """
+        self.processing_service.set_selected_ids(
+            self.processing_view.selected_processing_ids())
+
+    def _push_table_query(self):
+        """The sort and filter the table is showing. Pushed before every fetch and re-render
+        rather than read by the service, which needs them again in a callback that runs long
+        after the widgets were read."""
+        sort_by, sort_order = self.processing_view.sort_processings()
+        self.processing_service.set_sort(sort_by, sort_order)
+        self.processing_service.set_filter(self.processing_view.processings_filter)
+
+    def on_combo_sort_changed(self, *args):
+        """Picking from the sort combo drops any column-click override, then re-fetches."""
+        self.processing_view.clear_header_sort()
+        self.refresh_table()
 
     def _on_template_closed(self, _closed=None):
         """`templateClosed` carries the template that was closed, so it cannot be connected to
@@ -111,6 +189,7 @@ class ProjectProcessingController(QObject):
 
     def refresh_table(self):
         """Re-fetch whatever the table is showing."""
+        self._push_table_query()
         if self.template_service.in_template_mode:
             self.template_service.refresh_template_view()
         else:
@@ -118,11 +197,12 @@ class ProjectProcessingController(QObject):
 
     def rerender_rows(self):
         """Re-render the rows already held, for a sort that needs no request."""
+        self._push_table_query()
         if self.template_service.in_template_mode:
             rows = self.template_service.combined_template_rows()
         else:
             rows = self.processing_service.combined_processing_rows()
-        self.processing_service.view.update_processing_table(rows)
+        self.render_rows(rows)
 
     def rehydrate_template(self):
         """A processing was started inside a template: re-hydrate so it binds to its AOI."""
@@ -267,7 +347,7 @@ class ProjectProcessingController(QObject):
     def exit_template(self):
         """Return from the in-template view to the project's processings list."""
         self.template_service.exit_template_view()
-        self.processing_service.setup_processings_table()
+        self.open_processings_table()
         self._set_processings_tab_text(self.tr("Processing"))
         self._update_nav_buttons()
 
@@ -328,6 +408,11 @@ class ProjectProcessingController(QObject):
         self.project_view.switch_to_processings()
 
         # Setup processings table for the project
+        self.open_processings_table()
+
+    def open_processings_table(self):
+        """Put the project's own processings back in the table, from the first page."""
+        self._push_table_query()
         self.processing_service.setup_processings_table()
 
     # ==== WHAT THE TABLE OFFERS FOR THE CURRENT SELECTION ==== #

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -26,6 +26,8 @@ from ..api.processing_api import ProcessingApi
 from ...schema import ProcessingDTO, UpdateProcessingSchema, ProcessingStatus, BillingType, PostProcessingSchemaV2
 from ...model.processing_history import ProcessingHistory
 from ...schema.processing import (
+    ProcessingSortBy,
+    ProcessingSortOrder,
     ProcessingsRequest,
     ProcessingsResult,
 )
@@ -73,6 +75,27 @@ class ProcessingService(QObject):
     #: refreshed. The refresh itself goes through `refreshRequested` like every other.
     reviewSubmitted = pyqtSignal()
 
+    # ---------- what the processings table must show ----------
+    #
+    # The table is `ProjectProcessingController`'s to render; this service only says what belongs
+    # in it. Everything below is announced, never drawn.
+
+    #: A request is in flight — put a "Loading…" placeholder up.
+    tableLoading = pyqtSignal()
+    #: The project's rows (templates above processings), ready to render.
+    rowsChanged = pyqtSignal(object)
+    #: (show the pager, page number, total pages).
+    pagerChanged = pyqtSignal(bool, int, int)
+    #: Whether the pager arrows may be clicked. Separate from `pagerChanged` because a request in
+    #: flight disables them without changing which page is being shown.
+    pagerEnabled = pyqtSignal(bool)
+    #: A processing was just started: add its row without waiting for the next poll.
+    processingAdded = pyqtSignal(object)
+    #: (processing id, new name) after a rename round trip.
+    processingRenamed = pyqtSignal(str, str)
+    #: The ids whose rows the server confirmed gone.
+    processingsDeleted = pyqtSignal(object)
+
     # Whether the last processings poll saw only final-state processings; combined with
     # template statuses to decide if the project poll can stop (see _apply_poll_timer_state).
     _processings_all_final = True
@@ -87,6 +110,14 @@ class ProcessingService(QObject):
     #: template open" rather than raising.
     _open_template = None
     _visible_processings = None
+
+    #: The table's current selection, its sort and its filter text. All three are read at times
+    #: this service is not on the stack — a fetch callback sorts rows minutes after the request —
+    #: so they are held here and pushed in, rather than fetched from a widget on demand.
+    _selected_ids = ()
+    _sort_by = ProcessingSortBy.created.value
+    _sort_order = ProcessingSortOrder.descending.value
+    _filter = ""
 
     def __init__(self,
                  http: Http,
@@ -130,6 +161,24 @@ class ProcessingService(QObject):
         """The pool a table row id resolves against: an open template's, or None for this
         service's own `processings`."""
         self._visible_processings = processings
+
+    def set_selected_ids(self, ids) -> None:
+        """The ids of the currently selected table rows, in table order."""
+        self._selected_ids = tuple(ids or ())
+
+    def selected_ids(self, limit=None) -> List[str]:
+        """The selection, at most `limit` rows. `TemplateService` reads this too — it resolves the
+        same rows into AOIs, and a service may not reach for the table itself."""
+        return list(self._selected_ids[:limit])
+
+    def set_sort(self, sort_by: str, sort_order: str) -> None:
+        """The sort the table is showing. Applied to the *next* request and to the rows it
+        returns, so a reply that lands after the user re-sorts is still ordered as requested."""
+        self._sort_by = sort_by
+        self._sort_order = sort_order
+
+    def set_filter(self, terms: str) -> None:
+        self._filter = terms or ""
 
     def load_processing_history(self):
         """
@@ -522,7 +571,7 @@ class ProcessingService(QObject):
             self.processings[new_processing.id] = new_processing
             self.processings_history.add(new_processing.id, new_processing.status)
             # display
-            self.view.add_new_processing(new_processing)
+            self.processingAdded.emit(new_processing)
         # Always refresh full list because template-started processings can affect
         # both processings and template status/counts in table.
         self.refreshRequested.emit()
@@ -560,27 +609,9 @@ class ProcessingService(QObject):
         if not self.app_context.current_project:
             return
         self.processings_page_offset = 0
-        self.view.set_table_loading()
+        self.tableLoading.emit()
         self.get_processings()
         self.processing_fetch_timer.start()
-
-    def connect_processings_pagination(self):
-        """Connect pagination, sorting and filtering signals. Called once during plugin init."""
-        self.dlg.processingsNextPageButton.clicked.connect(self.show_processings_next_page)
-        self.dlg.processingsPreviousPageButton.clicked.connect(self.show_processings_previous_page)
-        self.dlg.filterProcessings.textEdited.connect(self.get_filtered_processings)
-        self.dlg.sortProcessingsCombo.activated.connect(self._on_combo_sort_changed)
-        self.view.connect_header_sort(self._on_header_sort_changed)
-
-    def _on_combo_sort_changed(self):
-        """Combo sort resets any header-click override and re-fetches."""
-        self.view._header_sort_by = None
-        self.refreshRequested.emit()
-
-    def _on_header_sort_changed(self):
-        """Re-render the table with current data using the header sort. Both views sort, so this
-        asks for a re-render rather than rendering the project rows itself."""
-        self.rerenderRequested.emit()
 
     def get_processings(self):
         """Fetch the *project's* processings. Not the entry point for "refresh the table" — that
@@ -594,21 +625,19 @@ class ProcessingService(QObject):
                 self.processings_page_offset = 0
         except (AttributeError, TypeError):
             pass
-        sort_by, sort_order = self.view.sort_processings()
-        terms = self.dlg.filterProcessings.text() or None
         request_body = ProcessingsRequest(
             limit=self.processings_page_limit,
             offset=self.processings_page_offset,
-            terms=terms,
-            sortBy=sort_by,
-            sortOrder=sort_order,
+            terms=self._filter or None,
+            sortBy=self._sort_by,
+            sortOrder=self._sort_order,
         )
         self.api.get_processings(
             project_id=self.app_context.current_project.id,
             request_body=request_body,
             callback=self.get_processings_callback,
         )
-        self.view.enable_processings_pages(False)
+        self.pagerEnabled.emit(False)
 
     def get_processings_callback(self, response: QNetworkReply):
         """Update the processing table and user limit.
@@ -628,9 +657,9 @@ class ProcessingService(QObject):
             quotient, remainder = divmod(self.processings_data.total, self.processings_page_limit)
             total_pages = quotient + (remainder > 0)
             page_number = int(self.processings_page_offset / self.processings_page_limit) + 1
-            self.view.show_processings_pages(True, page_number, total_pages)
+            self.pagerChanged.emit(True, page_number, total_pages)
         else:
-            self.view.show_processings_pages(False)
+            self.pagerChanged.emit(False, 1, 1)
         self.update_local_processings(processings)
         current_project_id = getattr(self.app_context.current_project, "id", None)
         if current_project_id:
@@ -640,7 +669,7 @@ class ProcessingService(QObject):
             )
         else:
             self.templates = {}
-            self.view.update_processing_table(self.combined_processing_rows())
+            self.rowsChanged.emit(self.combined_processing_rows())
             self._apply_poll_timer_state()
 
     def get_templates_callback(self, response: QNetworkReply):
@@ -676,7 +705,7 @@ class ProcessingService(QObject):
             templates.append(template)
 
         self.templates = {template.id: template for template in templates}
-        self.view.update_processing_table(self.combined_processing_rows())
+        self.rowsChanged.emit(self.combined_processing_rows())
         self._apply_poll_timer_state()
 
     def _apply_poll_timer_state(self):
@@ -737,8 +766,7 @@ class ProcessingService(QObject):
     def combined_processing_rows(self):
         """The *project* rows: its templates above its processings. The in-template rows are
         `combined_template_rows`; which of the two the table wants is the controller's call."""
-        sort_by, sort_order = self.view.sort_processings()
-        reverse = sort_order == "DESC"
+        sort_by, reverse = self._sort_by, self._sort_order == "DESC"
         templates = sorted(self.templates.values(), key=lambda t: self._sort_key(t, sort_by), reverse=reverse)
         processings = sorted(self.processings.values(), key=lambda p: self._sort_key(p, sort_by), reverse=reverse)
         return list(templates) + list(processings)
@@ -832,7 +860,7 @@ class ProcessingService(QObject):
         response_data = json.loads(response.readAll().data())
         processing = ProcessingDTO.from_dict(response_data)
         self.save_processing(processing)
-        self.view.update_processing_name(processing_id=processing.id, new_name=processing.name)
+        self.processingRenamed.emit(str(processing.id), processing.name)
         self.processings[processing.id] = processing
 
     # ============ REVIEW AND RATING ============ #
@@ -1004,7 +1032,7 @@ class ProcessingService(QObject):
         """
         # Pause refreshing processings table to avoid conflicts
         self.processing_fetch_timer.stop()
-        selected_ids = self.view.selected_processing_ids()
+        selected_ids = self.selected_ids()
         # Filter to only items that exist (templates or processings)
         valid_ids = [pid for pid in selected_ids if pid in self.processings or pid in self.templates]
         # Ask for confirmation if there are selected rows
@@ -1020,7 +1048,7 @@ class ProcessingService(QObject):
                            failed: List):
         # todo: save and report error responses?
         if len(items) == 0:
-            self.view.delete_processings_from_table(deleted)
+            self.processingsDeleted.emit(deleted)
             if len(failed) > 0:
                 failed_ids = ', <br>'.join(str(f) for f in failed)
                 alert(self.tr(f"Failed to remove items with following ids: <center> {failed_ids}"))
@@ -1081,7 +1109,7 @@ class ProcessingService(QObject):
         self.processing_fetch_timer.deleteLater()
 
     def selected_processings(self, limit=None) -> List[ProcessingDTO]:
-        pids = self.view.selected_processing_ids(limit=limit)
+        pids = self.selected_ids(limit=limit)
         # In template view the table holds the template's processings, not the project's.
         pool = self.processings if self._visible_processings is None else self._visible_processings
         # limit None will give full selection
@@ -1096,7 +1124,7 @@ class ProcessingService(QObject):
     
     def selected_templates(self, limit=None) -> List[ProcessingTemplateDTO]:
         """Get selected templates from the table."""
-        pids = self.view.selected_processing_ids(limit=limit)
+        pids = self.selected_ids(limit=limit)
         # Filter to get only templates (not processings)
         selected_templates = [self.templates[pid] for pid in filter(lambda pid: pid in self.templates, pids)]
         return selected_templates
@@ -1120,7 +1148,7 @@ class ProcessingService(QObject):
 
     def is_only_templates_selected(self) -> bool:
         """True only when current table selection contains templates and no processings."""
-        pids = self.view.selected_processing_ids()
+        pids = self.selected_ids()
         if not pids:
             return False
         return all(pid in self.templates for pid in pids)

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -905,7 +905,10 @@ class TemplateService(QObject):
     # ---------- what the table selection means for templates ----------
 
     def _selected_ids(self, limit=None):
-        return self.processing_service.view.selected_processing_ids(limit=limit)
+        """The same table selection `ProcessingService` resolves into processings, resolved here
+        into AOIs. It is held there because it is pushed in from the controller that owns the
+        table — reaching for the widget, or for that service's view, is not a service's to do."""
+        return self.processing_service.selected_ids(limit=limit)
 
     def selected_aois(self, limit=None) -> list:
         """Selected AOI rows (only meaningful inside the in-template view)."""

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -62,6 +62,10 @@ class ProcessingView:
             lambda col: self._on_header_clicked(col, on_sort_changed)
         )
 
+    def clear_header_sort(self) -> None:
+        """Drop the column-click override so `sort_processings` reads the combo again."""
+        self._header_sort_by = None
+
     def _on_header_clicked(self, column: int, on_sort_changed):
         sort_by = self._COLUMN_SORT_MAP.get(column)
         if sort_by is None:
@@ -79,6 +83,10 @@ class ProcessingView:
     def tr(self, message: str) -> str:
         """Translate message using QCoreApplication."""
         return QCoreApplication.translate('ProcessingView', message)
+
+    @property
+    def processings_filter(self) -> str:
+        return self.dlg.filterProcessings.text()
 
     @property
     def processing_name(self):
@@ -443,8 +451,10 @@ class ProcessingView:
                        blocking=False)
 
     def selected_processing_ids(self, limit=None):
-        # add unique selected rows
-        selected_rows = list(set(index.row() for index in self.dlg.processingsTable.selectionModel().selectedIndexes()))
+        # Unique selected rows, in table order: `limit` slices this list, so an unordered set
+        # would make `limit=1` pick an arbitrary row of a multi-selection.
+        selected_rows = sorted({index.row()
+                                for index in self.dlg.processingsTable.selectionModel().selectedIndexes()})
         if not selected_rows:
             return []
         pids = [self.dlg.processingsTable.item(row,

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -316,6 +316,11 @@ class Mapflow(QObject):
         self.aoi_service.editSessionEnded.connect(self.aoi_view.leave_edit_session)
         self.aoi_view.saveRequested.connect(self.aoi_service.save_session)
         self.aoi_view.cancelRequested.connect(self.aoi_service.cancel_session)
+        # Three controllers below react to a processings-table selection, and all three resolve
+        # that selection into objects through ProcessingService — which is told the ids rather
+        # than reading the table. So the push has to run before any of their handlers, and Qt
+        # calls slots in connection order: this connect must stay above them.
+        self.dlg.processingsTable.itemSelectionChanged.connect(self.push_processings_selection)
         self.processing_controller = ProcessingController(
             iface=self.iface,
             aoi_service=self.aoi_service,
@@ -448,7 +453,6 @@ class Mapflow(QObject):
         self.dlg.processingsTable.cellDoubleClicked.connect(
             self.project_processing_controller.load_results)
         self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
-        self.processing_service.connect_processings_pagination()
         # Entering and leaving a template is TemplateController's entirely — it owns the layers,
         # the search results and the view state they drive. What the processings-table selection
         # enables is split between the two controllers that own those widgets: the Start button is
@@ -553,6 +557,17 @@ class Mapflow(QObject):
         else:
             self.project_processing_controller.show_projects()
             self.project_service.setup_project_change_rights()
+
+    def push_processings_selection(self):
+        """Deliver the processings table's selection to the services that resolve it.
+
+        The work is `ProjectProcessingController`'s — it owns what the table's selection means —
+        but the connection has to be made here, before the controllers that react to the same
+        signal are built, because two of them read the resolved selection. Resolving the
+        attribute at call time keeps that possible: the controller exists long before a user can
+        click a row.
+        """
+        self.project_processing_controller.push_selection()
 
     def setup_add_layer_menu(self):
         self.add_layer_menu.addAction(self.draw_aoi)
@@ -1066,7 +1081,7 @@ class Mapflow(QObject):
             self.app_context.project_id = Config.PROJECT_ID
             self.project_view.setup_workflow_defs(default_project.workflowDefs, 
                                                           self.config.DEFAULT_MODEL)
-            self.processing_service.setup_processings_table()
+            self.project_processing_controller.open_processings_table()
         else:
             if self.app_context.project_id:
                 self.app_context.current_project = self.project_service.get_project(

--- a/tests/qgis/behavioral/test_projects_and_processings.py
+++ b/tests/qgis/behavioral/test_projects_and_processings.py
@@ -48,6 +48,29 @@ def test_the_processings_of_the_opened_project_are_listed(logged_in, network):
         "the loading placeholder is still there — the results never rendered")
 
 
+def test_selecting_a_processing_offers_the_actions_that_need_one(logged_in, network):
+    """Rating is disabled until a finished processing is picked, so this is the shortest
+    user-visible proof that the table's selection reaches everything that acts on it.
+
+    It is worth having as a journey rather than only as a unit: the selection travels from the
+    widget through several listeners, and the one this asserts on runs *first*. A change that
+    delivered the selection late would leave this button reflecting the previous click.
+    """
+    open_first_project(logged_in, network)
+    table = logged_in.dlg.processingsTable
+    assert not logged_in.dlg.ratingComboBox.isEnabled(), (
+        "nothing is selected yet, so there is nothing to rate")
+
+    name = fixture("processings_page")["results"][0]["name"]
+    row = next(r for r in range(table.rowCount())
+               for c in range(table.columnCount())
+               if table.item(r, c) and table.item(r, c).text() == name)
+    table.selectRow(row)
+
+    assert logged_in.dlg.ratingComboBox.isEnabled(), (
+        f"selecting '{name}' left the rating controls disabled")
+
+
 def test_opening_a_project_populates_the_model_list(logged_in, network):
     """Models arrive with the project, not with the account — see the startup journey."""
     open_first_project(logged_in, network)

--- a/tests/qgis/test_contributor_delete_templates.py
+++ b/tests/qgis/test_contributor_delete_templates.py
@@ -21,8 +21,7 @@ OTHER = "user-2"
 
 def _service(user_role, user_id, selected_ids, templates):
     service = ProcessingService.__new__(ProcessingService)
-    service.view = MagicMock()
-    service.view.selected_processing_ids.return_value = list(selected_ids)
+    service.set_selected_ids(selected_ids)
     service.templates = templates
     ctx = AppContext()
     ctx.user_role = user_role

--- a/tests/qgis/test_processing_poll_render.py
+++ b/tests/qgis/test_processing_poll_render.py
@@ -8,32 +8,43 @@ table flash. The poll must render the table once, with the combined rows.
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from PyQt5.QtCore import QObject
+
 from mapflow.functional.service.processing_service import ProcessingService
+
+
+def _rendered(service):
+    """The row sets the service asked the controller to draw."""
+    rendered = []
+    service.rowsChanged.connect(rendered.append)
+    return rendered
 
 
 def test_update_local_processings_does_not_render_table():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the rows are announced as a signal
     service.tr = lambda text: text
-    service.view = MagicMock()
     service.iface = MagicMock()
     service.app_context = SimpleNamespace(settings=MagicMock())
     history = MagicMock()
     history.update.return_value = {}
     service.processings_history = history
+    rendered = _rendered(service)
 
     service.update_local_processings([SimpleNamespace(id="proc-1", name="Run 1")])
 
     # History is still updated, but rendering is deferred to the combined render.
     history.update.assert_called_once()
-    service.view.update_processing_table.assert_not_called()
+    assert rendered == []
 
 
 def test_update_local_processings_noop_without_history():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)
     service.tr = lambda text: text
-    service.view = MagicMock()
     service.processings_history = None
+    rendered = _rendered(service)
 
     service.update_local_processings([SimpleNamespace(id="proc-1", name="Run 1")])
 
-    service.view.update_processing_table.assert_not_called()
+    assert rendered == []

--- a/tests/qgis/test_processings_table_actions.py
+++ b/tests/qgis/test_processings_table_actions.py
@@ -128,7 +128,6 @@ def _processing_service(processings):
     # silently never fires, and every assertion below would then pass for the wrong reason.
     QObject.__init__(service)
     service.processings = processings
-    service.view = MagicMock()
     return service
 
 
@@ -146,14 +145,14 @@ def _push(template_service, processing_service):
 
 def test_without_a_template_the_selection_resolves_against_the_projects_processings():
     service = _processing_service({"p-1": "project processing"})
-    service.view.selected_processing_ids.return_value = ["p-1"]
+    service.set_selected_ids(["p-1"])
 
     assert service.selected_processings() == ["project processing"]
 
 
 def test_an_open_template_switches_the_pool_the_selection_resolves_against():
     processing_service = _processing_service({"p-1": "project processing"})
-    processing_service.view.selected_processing_ids.return_value = ["p-2"]
+    processing_service.set_selected_ids(["p-2"])
     template_service = _template_service()
     _push(template_service, processing_service)
 
@@ -173,7 +172,7 @@ def test_leaving_the_template_puts_the_pool_back():
     template_service.in_template_mode = False
     template_service.template_processings = {}
 
-    processing_service.view.selected_processing_ids.return_value = ["p-1"]
+    processing_service.set_selected_ids(["p-1"])
     assert processing_service.selected_processings() == ["project processing"]
 
 
@@ -187,7 +186,7 @@ def test_processings_arriving_after_the_template_was_left_do_not_come_back_as_th
     template_service.in_template_mode = False  # already left
     template_service.template_processings = {"p-2": "late arrival"}
 
-    processing_service.view.selected_processing_ids.return_value = ["p-1"]
+    processing_service.set_selected_ids(["p-1"])
     assert processing_service.selected_processings() == ["project processing"]
 
 

--- a/tests/qgis/test_processings_table_refresh.py
+++ b/tests/qgis/test_processings_table_refresh.py
@@ -34,6 +34,8 @@ def controller():
     controller.processing_service = MagicMock()
     controller.template_service = MagicMock()
     controller.template_service.in_template_mode = False
+    controller.processing_view = MagicMock()
+    controller.processing_view.sort_processings.return_value = ("CREATED", "DESC")
     return controller
 
 

--- a/tests/qgis/test_processings_table_render.py
+++ b/tests/qgis/test_processings_table_render.py
@@ -1,0 +1,349 @@
+"""QGIS-tier tests for the split between what fills the processings table and what draws it.
+
+`ProcessingService` held the table: it read the sort combo, the filter box and the selected
+rows, and called a view to render. A service may not do any of that (`spec/007_architecture.md`
+§ Services), and the cost was concrete — `TemplateService` had to reach through
+`ProcessingService.view` to learn what was selected, because that was the only place the
+answer existed.
+
+Now the service announces (`rowsChanged`, `pagerChanged`, …) and is *told* the three things it
+used to read (`set_sort`, `set_filter`, `set_selected_ids`). These pin both halves: that the
+service emits rather than draws, and that `ProjectProcessingController` draws what it hears.
+"""
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from mapflow.functional.controller.project_processing_controller import ProjectProcessingController
+from mapflow.functional.service import processing_service as processing_service_module
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.functional.service.template_service import TemplateService
+
+
+def _service():
+    service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # everything the table shows leaves as a signal
+    service.tr = lambda text: text
+    service.api = MagicMock()
+    service.view = MagicMock()
+    service.iface = MagicMock()
+    service.app_context = SimpleNamespace(current_project=SimpleNamespace(id="proj-1"),
+                                          settings=MagicMock())
+    service.processings = {}
+    service.templates = {}
+    service.processings_data = None
+    service.processings_page_limit = 10
+    service.processings_page_offset = 0
+    service.processings_history = None
+    service.processing_fetch_timer = MagicMock()
+    service._delete_state = {}
+    return service
+
+
+def _response(payload):
+    reply = MagicMock()
+    reply.readAll.return_value.data.return_value = json.dumps(payload).encode()
+    return reply
+
+
+def _controller():
+    controller = ProjectProcessingController.__new__(ProjectProcessingController)
+    QObject.__init__(controller)
+    controller.tr = lambda text: text
+    controller.dlg = MagicMock()
+    controller.processing_service = MagicMock()
+    controller.template_service = MagicMock()
+    controller.template_service.in_template_mode = False
+    controller.processing_view = MagicMock()
+    controller.processing_view.sort_processings.return_value = ("CREATED", "DESC")
+    controller.processing_view.processings_filter = ""
+    controller.processing_view.selected_processing_ids.return_value = []
+    return controller
+
+
+# ---------- the service announces the table, it does not draw it ----------
+
+def test_opening_the_table_asks_for_a_loading_placeholder():
+    service = _service()
+    loading = []
+    service.tableLoading.connect(lambda: loading.append(True))
+
+    service.setup_processings_table()
+
+    assert loading == [True]
+    assert service.processings_page_offset == 0
+
+
+def test_a_request_carries_the_pushed_sort_and_filter():
+    """The widgets are read by the controller and handed over; nothing here reaches for them."""
+    service = _service()
+    service.set_sort("NAME", "ASC")
+    service.set_filter("roads")
+
+    service.get_processings()
+
+    request = service.api.get_processings.call_args.kwargs["request_body"]
+    assert (request.sortBy, request.sortOrder) == ("NAME", "ASC")
+    assert request.terms == "roads"
+
+
+def test_an_empty_filter_is_sent_as_no_filter():
+    """`terms=""` would ask the server to match the empty string; the field must be omitted."""
+    service = _service()
+    service.set_filter("")
+
+    service.get_processings()
+
+    assert service.api.get_processings.call_args.kwargs["request_body"].terms is None
+
+
+def test_a_request_in_flight_disables_the_pager():
+    """Paging a list that is about to be replaced pages the wrong list."""
+    service = _service()
+    enabled = []
+    service.pagerEnabled.connect(enabled.append)
+
+    service.get_processings()
+
+    assert enabled == [False]
+
+
+def test_the_pager_is_announced_when_the_results_span_pages():
+    service = _service()
+    service.processings_page_offset = 20  # third page of ten
+    pager = []
+    service.pagerChanged.connect(lambda *a: pager.append(a))
+
+    service.get_processings_callback(_response({"results": [], "total": 95, "count": 0}))
+
+    assert pager == [(True, 3, 10)]
+
+
+def test_the_pager_is_hidden_for_a_single_page():
+    service = _service()
+    pager = []
+    service.pagerChanged.connect(lambda *a: pager.append(a))
+
+    service.get_processings_callback(_response({"results": [], "total": 4, "count": 0}))
+
+    assert pager == [(False, 1, 1)]
+
+
+def test_the_rows_are_announced_once_the_templates_resolve():
+    service = _service()
+    service.app_context.current_project = None  # no template fetch: render immediately
+    rendered = []
+    service.rowsChanged.connect(rendered.append)
+
+    service.get_processings_callback(_response({"results": [], "total": 0, "count": 0}))
+
+    assert rendered == [[]]
+
+
+def test_a_rename_is_announced_with_the_id_and_the_new_name():
+    service = _service()
+    service.save_processing = MagicMock()
+    renamed = []
+    service.processingRenamed.connect(lambda *a: renamed.append(a))
+    renamed_dto = SimpleNamespace(id="p-1", name="Renamed")
+
+    with patch.object(processing_service_module.ProcessingDTO, "from_dict",
+                      return_value=renamed_dto):
+        service.update_processing_callback(_response({"id": "p-1", "name": "Renamed"}))
+
+    assert renamed == [("p-1", "Renamed")]
+    assert service.processings["p-1"] is renamed_dto
+
+
+def test_the_ids_that_were_deleted_are_announced_when_the_run_finishes():
+    service = _service()
+    deleted = []
+    service.processingsDeleted.connect(deleted.append)
+
+    service.delete_processings(response=None, items=[], deleted=["p-1", "p-2"], failed=[])
+
+    assert deleted == [["p-1", "p-2"]]
+
+
+# ---------- the sort is remembered, not re-read ----------
+
+def test_the_rows_are_sorted_by_the_sort_the_request_used():
+    """The reason sort is pushed rather than passed: `combined_processing_rows` runs in a
+    callback, long after the controller read the combo. Re-reading the widget there would sort
+    a reply by a sort the user picked while it was in flight."""
+    service = _service()
+    service.set_sort("NAME", "ASC")
+    service.processings = {
+        "p-1": SimpleNamespace(id="p-1", name="Beta", created=2),
+        "p-2": SimpleNamespace(id="p-2", name="Alpha", created=1),
+    }
+
+    assert [p.name for p in service.combined_processing_rows()] == ["Alpha", "Beta"]
+
+    service.set_sort("NAME", "DESC")
+    assert [p.name for p in service.combined_processing_rows()] == ["Beta", "Alpha"]
+
+
+def test_templates_are_listed_above_processings_whatever_the_sort():
+    """A planned processing is the parent of the runs under it, so it heads the list."""
+    service = _service()
+    service.set_sort("NAME", "ASC")
+    service.processings = {"p-1": SimpleNamespace(id="p-1", name="Alpha", created=1)}
+    service.templates = {"t-1": SimpleNamespace(id="t-1", name="Zulu", createdAt=2)}
+
+    assert [row.name for row in service.combined_processing_rows()] == ["Zulu", "Alpha"]
+
+
+# ---------- the selection is pushed, and two services read it ----------
+
+def test_the_selection_is_held_and_sliced_in_table_order():
+    service = _service()
+    service.set_selected_ids(["p-1", "p-2", "p-3"])
+
+    assert service.selected_ids() == ["p-1", "p-2", "p-3"]
+    assert service.selected_ids(limit=1) == ["p-1"]
+
+
+def test_no_selection_reads_as_empty_before_anything_is_pushed():
+    """Every `selected_*` call runs through this, including on a service the plugin has only
+    just built."""
+    assert ProcessingService.__new__(ProcessingService).selected_ids() == []
+
+
+def test_the_template_service_resolves_the_same_selection():
+    """It used to reach through `ProcessingService.view` for this — a service holding another
+    service's view. The ids live on the service now, so it asks the service."""
+    processing_service = _service()
+    processing_service.set_selected_ids(["aoi-1"])
+    template_service = TemplateService(app_context=MagicMock(),
+                                       processing_service=processing_service)
+    template_service.template_aois = {"aoi-1": "the AOI", "aoi-2": "another"}
+
+    assert template_service.selected_aois() == ["the AOI"]
+
+
+# ---------- the controller draws what it hears ----------
+
+def test_the_controller_renders_the_rows_it_is_given():
+    controller = _controller()
+    rows = ["row"]
+
+    controller.render_rows(rows)
+
+    controller.processing_view.update_processing_table.assert_called_once_with(rows)
+
+
+def test_every_render_re_syncs_the_selection():
+    """A rebuild restores the selection with the table's signals blocked, so no selection
+    signal fires — nothing else would notice that a selected row is gone."""
+    controller = _controller()
+    controller.processing_view.selected_processing_ids.return_value = ["p-1"]
+
+    controller.render_rows([])
+
+    controller.processing_service.set_selected_ids.assert_called_with(["p-1"])
+
+
+def test_the_loading_placeholder_also_re_syncs_the_selection():
+    controller = _controller()
+
+    controller.render_loading()
+
+    controller.processing_view.set_table_loading.assert_called_once()
+    controller.processing_service.set_selected_ids.assert_called_with([])
+
+
+def test_the_pager_is_shown_or_hidden_as_announced():
+    controller = _controller()
+
+    controller._render_processings_pager(True, 3, 10)
+    controller.processing_view.show_processings_pages.assert_called_once_with(True, 3, 10)
+
+    controller.processing_view.reset_mock()
+    controller._render_processings_pager(False, 1, 1)
+    controller.processing_view.show_processings_pages.assert_called_once_with(False)
+
+
+def test_a_fetch_hands_over_the_sort_and_filter_first():
+    controller = _controller()
+    controller.processing_view.sort_processings.return_value = ("STATUS", "ASC")
+    controller.processing_view.processings_filter = "roads"
+
+    controller.refresh_table()
+
+    controller.processing_service.set_sort.assert_called_once_with("STATUS", "ASC")
+    controller.processing_service.set_filter.assert_called_once_with("roads")
+    controller.processing_service.get_processings.assert_called_once()
+
+
+def test_choosing_from_the_sort_combo_drops_the_column_override_and_refetches():
+    """A column click overrides the combo; picking from the combo has to take the wheel back,
+    or the list keeps arriving in the column's order."""
+    controller = _controller()
+
+    controller.on_combo_sort_changed(2)
+
+    controller.processing_view.clear_header_sort.assert_called_once()
+    controller.processing_service.get_processings.assert_called_once()
+
+
+def test_a_column_sort_re_renders_without_a_request():
+    """The rows are already held; asking the server again would only cost a round trip."""
+    controller = _controller()
+    controller.processing_service.combined_processing_rows.return_value = ["row"]
+
+    controller.rerender_rows()
+
+    controller.processing_service.get_processings.assert_not_called()
+    controller.processing_view.update_processing_table.assert_called_once_with(["row"])
+
+
+class _TemplateStub(QObject):
+    """`TemplateService`, reduced to the signals the controller subscribes to."""
+    refreshRequested = pyqtSignal()
+    templateRowsChanged = pyqtSignal(object)
+    pollIntervalChanged = pyqtSignal(int)
+    templateOpened = pyqtSignal(object)
+    templateClosed = pyqtSignal(object)
+    visibleProcessingsChanged = pyqtSignal(object)
+
+    in_template_mode = False
+
+
+def test_setting_up_the_bindings_subscribes_to_all_of_them():
+    """Asserted against a controller that really ran its wiring, not one whose connections the
+    test made for it. A connection that silently stopped being made is invisible otherwise: the
+    services still work in isolation, and every test that wires its own passes."""
+    controller = _controller()
+    template_service = _TemplateStub()
+    controller.template_service = template_service
+
+    controller._setup_processing_bindings()
+
+    template = SimpleNamespace(id="t-1")
+    template_service.templateOpened.emit(template)
+    controller.processing_service.set_open_template.assert_called_once_with(template)
+
+    template_service.visibleProcessingsChanged.emit({"p-1": "one"})
+    controller.processing_service.set_visible_processings.assert_called_once_with({"p-1": "one"})
+
+    template_service.templateClosed.emit(template)
+    assert controller.processing_service.set_open_template.call_args.args == (None,)
+
+    template_service.templateRowsChanged.emit(["row"])
+    controller.processing_view.update_processing_table.assert_called_once_with(["row"])
+
+
+def test_opening_the_table_hands_over_the_query_before_the_first_page():
+    """`setup_processings_table` fetches immediately, so a push afterwards would arrive too
+    late and the first page would come back under the previous project's sort."""
+    controller = _controller()
+    controller.processing_view.sort_processings.return_value = ("NAME", "ASC")
+
+    controller.open_processings_table()
+
+    called = [call[0] for call in controller.processing_service.mock_calls]
+    assert called.index("set_sort") < called.index("setup_processings_table")
+    controller.processing_service.set_sort.assert_called_once_with("NAME", "ASC")

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -423,8 +423,9 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
     service.processings = {}
     service.processings_history = MagicMock()
     QObject.__init__(service)  # the refresh request is a signal now
-    asked = []
+    asked, added = [], []
     service.refreshRequested.connect(lambda: asked.append(True))
+    service.processingAdded.connect(added.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"id": "proc-1", "name": "Run 1"}'
@@ -435,7 +436,7 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
         service.start_processing_callback(response)
 
     assert asked == [True]
-    service.view.add_new_processing.assert_called_once()
+    assert added == [mock_processing]
     service.dlg.startProcessing.setEnabled.assert_called_with(True)
 
 
@@ -448,8 +449,9 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
     service.processings = {}
     service.processings_history = MagicMock()
     QObject.__init__(service)  # the refresh request is a signal now
-    asked = []
+    asked, added = [], []
     service.refreshRequested.connect(lambda: asked.append(True))
+    service.processingAdded.connect(added.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"template": {"id": "tpl-1"}, "searchResults": []}'
@@ -458,7 +460,7 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
         service.start_processing_callback(response)
 
     assert asked == [True]
-    service.view.add_new_processing.assert_not_called()
+    assert added == []
     service.dlg.startProcessing.setEnabled.assert_called_with(True)
 
 
@@ -740,7 +742,7 @@ def test_confirm_delete_processings_deletes_templates():
     service.processings = {}
     service.api = MagicMock()
     service.view = MagicMock()
-    service.view.selected_processing_ids.return_value = ["tpl-1"]
+    service.set_selected_ids(["tpl-1"])
     service._delete_state = {}
 
     with patch.object(processing_service_module, "alert", return_value=True):
@@ -823,6 +825,7 @@ def test_delete_processings_callback_continues_with_remaining_items():
 
 def test_get_processings_callback_requests_templates_for_current_project_only():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the rows are announced as a signal
     service.tr = lambda text: text
     service.app_context = SimpleNamespace(current_project=SimpleNamespace(id="project-1"))
     service.api = MagicMock()
@@ -833,6 +836,8 @@ def test_get_processings_callback_requests_templates_for_current_project_only():
     service.processings_page_offset = 0
     service.processings_history = None
     service.update_local_processings = MagicMock()
+    rendered = []
+    service.rowsChanged.connect(rendered.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"results": [], "total": 0}'
@@ -847,18 +852,21 @@ def test_get_processings_callback_requests_templates_for_current_project_only():
     service.api.get_templates.assert_not_called()
     # The table render is deferred to the combined render after templates resolve,
     # so the poll never flashes through a processings-only state.
-    service.view.update_processing_table.assert_not_called()
+    assert rendered == []
 
 
 def test_get_templates_callback_filters_templates_to_current_project():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the rows are announced as a signal
     service.tr = lambda text: text
     service.app_context = SimpleNamespace(current_project=SimpleNamespace(id="3fa85f64-5717-4562-b3fc-2c963f66afa6"))
     service.view = MagicMock()
-    service.view.sort_processings.return_value = ("CREATED", "DESC")
+    service.set_sort("CREATED", "DESC")
     service.processings = {}
     service.in_template_mode = False
     service.processing_fetch_timer = MagicMock()
+    rendered = []
+    service.rowsChanged.connect(rendered.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = (
@@ -873,20 +881,23 @@ def test_get_templates_callback_filters_templates_to_current_project():
     assert len(service.templates) == 1
     template = list(service.templates.values())[0]
     assert str(template.projectId) == "3fa85f64-5717-4562-b3fc-2c963f66afa6"
-    service.view.update_processing_table.assert_called_once()
+    assert len(rendered) == 1
 
 
 def test_get_templates_callback_builds_templates_without_hydration_request():
     """Project list omits searchParams; the poll must NOT fall back to the full list."""
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the rows are announced as a signal
     service.tr = lambda text: text
     service.app_context = SimpleNamespace(current_project=SimpleNamespace(id="3fa85f64-5717-4562-b3fc-2c963f66afa6"))
     service.api = MagicMock()
     service.view = MagicMock()
-    service.view.sort_processings.return_value = ("CREATED", "DESC")
+    service.set_sort("CREATED", "DESC")
     service.processings = {}
     service.in_template_mode = False
     service.processing_fetch_timer = MagicMock()
+    rendered = []
+    service.rowsChanged.connect(rendered.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = (
@@ -900,5 +911,5 @@ def test_get_templates_callback_builds_templates_without_hydration_request():
     # No second request, and the template is still built and rendered once.
     service.api.get_templates.assert_not_called()
     assert len(service.templates) == 1
-    service.view.update_processing_table.assert_called_once()
+    assert len(rendered) == 1
 

--- a/tests/qgis/test_template_start_processing_refresh.py
+++ b/tests/qgis/test_template_start_processing_refresh.py
@@ -55,12 +55,20 @@ def _requests(service):
     return asked
 
 
+def _added(service):
+    """The rows the service asked to have inserted optimistically."""
+    added = []
+    service.processingAdded.connect(added.append)
+    return added
+
+
 _PROCESSING = {"id": "p-1", "name": "Run 1", "status": "IN_PROGRESS"}
 
 
 def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     service = _service(in_template_mode=True)
     asked = _requests(service)
+    added = _added(service)
 
     with patch.object(processing_service_module, "alert"):
         service.start_processing_callback(_response(_PROCESSING))
@@ -68,20 +76,21 @@ def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     # A plain refresh would refetch the rows without rebinding the new processing to its AOI.
     assert asked == ["rehydrate"]
     # No flat optimistic add in template mode.
-    service.view.add_new_processing.assert_not_called()
+    assert added == []
     service.dlg.startProcessing.setEnabled.assert_called_once_with(True)
 
 
 def test_regular_start_does_flat_add_and_asks_for_a_plain_refresh():
     service = _service(in_template_mode=False)
     asked = _requests(service)
+    added = _added(service)
     fake_dto = SimpleNamespace(id="p-1", name="Run 1", status="IN_PROGRESS")
 
     with patch.object(processing_service_module, "alert"), \
             patch.object(processing_service_module.ProcessingDTO, "from_dict", return_value=fake_dto):
         service.start_processing_callback(_response(_PROCESSING))
 
-    service.view.add_new_processing.assert_called_once_with(fake_dto)
+    assert added == [fake_dto]
     assert asked == ["refresh"]
     service.api.get_template.assert_not_called()
 


### PR DESCRIPTION
The service read the sort combo, the filter box and the selected rows, and called a view to
draw the results. A service may not touch a widget (spec/007 § Services), and the cost was not
theoretical: TemplateService had to reach through ProcessingService.view to learn what was
selected, because that was the only place the answer existed. Two services sharing one view is
worse than either reading the table directly, and it was invisible to the layering check, which
looks for imports and `dlg` parameters.

The service now announces (tableLoading, rowsChanged, pagerChanged, pagerEnabled,
processingAdded, processingRenamed, processingsDeleted) and is told the three things it used to
read. ProjectProcessingController renders, and makes the pager/sort/filter connections the
service used to make for itself.

Sort and filter are *pushed* rather than passed as call arguments because the callbacks need
them again: get_processings_callback sorts rows through combined_processing_rows long after the
controller returned, and those rows must be ordered by the sort the request used — not by
whatever the combo says when the reply lands.

The selection push is connected in mapflow.py rather than in the controller, and that placement
is load-bearing. Three controllers subscribe to processingsTable.itemSelectionChanged, all three
resolve the selection into objects through ProcessingService, and ProcessingController is
constructed first. A push made inside ProjectProcessingController would therefore run after two
consumers had already read the previous selection. Qt calls slots in connection order, so the
push is connected before any controller exists — the composition root deciding between regions,
which is what spec/007 § The composition root describes. The controller also re-pushes after
every render: a programmatic rebuild restores the selection with the table's signals blocked, so
nothing else would notice a selected row that no longer exists.

Two defects the plan filed against this step, fixed on the way: the service wrote a view's
private _header_sort_by (now clear_header_sort()), and reached through its own view to the
dialog for the filter text (now the view's processings_filter).

selected_processing_ids now sorts the selected rows. It built list(set(rows)) and sliced
[:limit], so selected_processing() picked an arbitrary row of a multi-selection; table order is
deterministic and is what the caller means by "the first one".

ProcessingService keeps self.dlg and self.view for the start panel, so its allowlist entries
stay until C2.2b. Its table-facing surface is gone: 26 view calls down to 7, all of them the
start panel's.

The behavioural journey added here is the smallest user-visible proof the push is wired and
ordered: rating is disabled until a finished processing is picked, and the listener it asserts
on is the one that runs first. A unit test would not have caught a late delivery.

## Manual test
Open a project. Page, sort (both the combo and a column header) and filter the processings
table; each must still re-request and re-render, and a column sort must re-order without a
network call. Start a processing: its row appears immediately. Rename one from the context menu:
the name changes in place. Delete one: its row goes.

Regression surface, all of it selection-driven and all of it fails silently if the push is
wrong: with a processing selected, the rating/review controls must enable and the context menu
must offer the processing actions; with a single template row selected, the "enter template"
arrow must enable and (as a contributor, on your own template) so must Delete. Inside a
template, selecting an AOI row must still offer the AOI rename/delete/edit actions and filter
the search results to that AOI. Leaving a template must put the project's own list back under
the sort the combo shows.
