### PR TITLE
refactor: the start panel leaves ProcessingService for its controller

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,24 +105,16 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-[ready-for-review] C2.2a The processings table → `ProjectProcessingController`
-    `selected_processing_ids` ×4, `update_processing_table` ×2, `show_processings_pages` ×2,
-    `sort_processings` ×2, `enable_processings_pages`, `set_table_loading`,
-    `delete_processings_from_table`, `add_new_processing`, `update_processing_name`,
-    `connect_header_sort`, plus the pager/filter/sort connections the service makes for itself
-    (`processing_service.py:569-572`) and `filterProcessings.text()`.
-[ ] C2.2b The start panel → `ProcessingController`
+[ready-for-review] C2.2b The start panel → `ProcessingController`
     `read_processing_start_params` ×2, `disable_processing_start` ×3, `set_processing_cost`,
-    `clear_processing_name` ×2, `startProcessing` ×4, `cornfirmProcessingStart` ×3, `modelCombo`
-    ×2, `modelOptions`/`modelOptionsLayout`/`enabled_blocks` ×4, `processingName`.
-    Plus the **four cross-region reads**, which need pushed state: `metadataTable` ×3 (the search
-    selection, from `SearchController`) and `polygonCombo` ×1 (the chosen AOI layer, which only
-    picks between two error messages).
-
-Two things found while sizing this, both worth fixing as they are met rather than filed:
-`processing_service` reaches **through** its view to the dialog (`self.view.dlg` ×3), which defeats
-the view and is invisible to the `dialog-param` check because it is not `self.dlg`; and it reads a
-view's private `_header_sort_by`.
+    `clear_processing_name` ×2, `startProcessing`, `cornfirmProcessingStart`, `modelCombo`,
+    `modelOptions`/`modelOptionsLayout`/`enabled_blocks`, `processingName`, plus the four
+    cross-region reads (search selection, AOI layer) now pushed via `app_context` /
+    `set_start_panel`. `ProcessingView` moved to `mapflow.py`; `service-imports-view` cleared.
+[ ] C2.2c The last widget read: `startProcessing.isEnabled()` in `validate_context_params`.
+    Blocked until `DataCatalogView` (C2.3) and `ProviderService` (C2.4) stop writing that button —
+    only then can its state be pushed instead of read. Clears `dialog-param` / `widget-import`
+    for `processing_service` together with C2.6 (`ProcessingApi(dlg=...)`).
 [ ] C2.3 `DataCatalogService` (29 dlg, 38 view) → `DataCatalogController` + `DataCatalogView`
     **The largest item, not the mechanical one.** With 38 view calls against a 57-line controller,
     this service *is* the My Imagery controller; turning those into signals would be the wrong

--- a/mapflow/functional/app_context.py
+++ b/mapflow/functional/app_context.py
@@ -34,7 +34,6 @@ class AppContext:
     project_id: Optional[str] = None
     current_project: Optional["MapflowProject"] = None
     user_role: Optional["UserRole"] = UserRole.owner
-    selected_processing_ids: List[str] = field(default_factory=list)
 
     # === AOI State ===
     aoi: Optional[QgsGeometry] = None  # full AOI, used for search/metadata requests
@@ -84,6 +83,10 @@ class AppContext:
     metadata_layer: Optional[QgsVectorLayer] = None
     meta_layer_table_connection = None
     search_footprints: Dict[str, Any] = field(default_factory=dict)
+    # `local_index` of every selected search-result row. Pushed from the metadata table (a widget
+    # a service may not read) so `ProcessingService` can gate planned processing and look up a
+    # provider's minimum area — it is the key into `search_footprints` above, so it lives beside it.
+    selected_search_indices: List[str] = field(default_factory=list)
     search_page_offset: int = 0
     # Raw imagery-search results as returned by the API for the current view (regular search
     # or template) — a GeoJSON FeatureCollection with a per-feature ``local_index``. Retained

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -36,7 +36,8 @@ class ProcessingController(QObject):
                  provider_service=None,
                  model_combo=None,
                  model_options_changed=None,
-                 metadata_table=None):
+                 metadata_table=None,
+                 start_button=None):
         super().__init__()
         self.iface = iface
         self.aoi_service = aoi_service
@@ -61,6 +62,20 @@ class ProcessingController(QObject):
         if processing_service is not None:
             processing_service.ratingLoaded.connect(self.processing_view.set_rating_labels)
             processing_service.reviewSubmitted.connect(self._on_review_submitted)
+            # The start panel: the service says what it must show, this renders it. The service
+            # holds no view and reads no widget but the one enabled-state it still needs (C2.2c).
+            processing_service.startPanelNeeded.connect(self._provide_start_panel)
+            processing_service.startDisabled.connect(self.processing_view.disable_processing_start)
+            processing_service.startUnblocked.connect(
+                self.processing_view.clear_problem_and_enable_start)
+            processing_service.submissionInFlight.connect(self._on_submission_in_flight)
+            processing_service.costQuoted.connect(self.processing_view.set_processing_cost)
+            processing_service.processingNameCleared.connect(
+                self.processing_view.clear_processing_name)
+            processing_service.processingNameSet.connect(self.processing_view.set_processing_name)
+            processing_service.confirmationRequested.connect(self._confirm_processing_start)
+        if start_button is not None:
+            start_button.clicked.connect(self.start_processing)
         if rating_submit_button is not None:
             rating_submit_button.clicked.connect(self.submit_rating)
         if rating_combo is not None:
@@ -133,7 +148,33 @@ class ProcessingController(QObject):
         if self.app_context.billing_type == BillingType.credits:
             self.processing_service.update_processing_cost()
 
-    # ---------- the start button ----------
+    # ---------- the start panel: what the service asks for, and starting ----------
+
+    def _provide_start_panel(self) -> None:
+        """Answer `startPanelNeeded`: hand the service the panel it is about to read. Synchronous,
+        so the service has it by the time its `emit()` returns."""
+        self.processing_service.set_start_panel(
+            params=self.processing_view.read_processing_start_params(),
+            enabled_blocks=self.processing_view.enabled_blocks(),
+            has_option_widgets=self.processing_view.has_option_widgets(),
+            aoi_layer_chosen=self.processing_view.aoi_layer_chosen())
+
+    def start_processing(self, *args) -> None:
+        """The Start button. The button is the start panel's, so its click is this controller's."""
+        self.processing_service.start_processing()
+
+    def _on_submission_in_flight(self, in_flight: bool) -> None:
+        """Disable Start while a run request is out; re-enable when it returns."""
+        self.processing_view.set_start_enabled(not in_flight)
+
+    def _confirm_processing_start(self, processing_params) -> None:
+        """The user asked to confirm each start: raise the dialog, and submit on OK. The dialog is
+        the view's — a service may not build one — and the values it shows are half domain
+        (from the service) and half panel (read by the view)."""
+        self.processing_view.confirm_processing_start(
+            name=processing_params.name,
+            details=self.processing_service.confirmation_details(),
+            on_accept=lambda: self.processing_service.submit_processing(processing_params))
 
     def update_start_processing_button_state(self, *args) -> None:
         """Render start button text and enforce planned-processing image selection gate."""

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -67,8 +67,8 @@ class ProjectProcessingController(QObject):
         self.project_connection = None
     
     def _setup_processing_bindings(self):
-        """Processing-specific UI connections."""
-        self.dlg.startProcessing.clicked.connect(self.processing_service.start_processing)
+        """Processing-specific UI connections. The Start button belongs to the start panel, so its
+        click is `ProcessingController`'s — not made here."""
         self.dlg.processing_update_action.triggered.connect(self.update_processing)
         self.dlg.options_menu.aboutToShow.connect(self.update_processing_options_menu)
         self.dlg.see_details_action.triggered.connect(self.show_selected_details)

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from typing import Dict, Optional, List, Tuple
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
-from PyQt5.QtWidgets import QMessageBox, QApplication, QInputDialog
+from PyQt5.QtWidgets import QMessageBox, QApplication
 from .provider_service import (get_provider_params, 
                                setup_provider_info, 
                                validate_provider_params, 
@@ -14,14 +14,12 @@ from .provider_service import (get_provider_params,
                                
 from .. import helpers
 from ...dialogs.main_dialog import MainDialog
-from ...dialogs.confirm_processing_start_dialog import ConfirmProcessingStartDialog
 from ...errors import (BadProcessingInput,
                        ErrorMessage,
                        PluginError,
                        ImageIdRequired,
                        AoiNotIntersectsImage)
 from ...http import Http, api_message_parser
-from ..view.processing_view import ProcessingView
 from ..api.processing_api import ProcessingApi
 from ...schema import ProcessingDTO, UpdateProcessingSchema, ProcessingStatus, BillingType, PostProcessingSchemaV2
 from ...model.processing_history import ProcessingHistory
@@ -96,6 +94,35 @@ class ProcessingService(QObject):
     #: The ids whose rows the server confirmed gone.
     processingsDeleted = pyqtSignal(object)
 
+    # ---------- what the start panel must show ----------
+
+    #: (reason, clear the AOI area too) — a start is blocked and this is why.
+    startDisabled = pyqtSignal(str, bool)
+    #: Every check passed: enable Start and drop whatever reason was showing.
+    startUnblocked = pyqtSignal()
+    #: A submission is in flight (True) or has come back (False). Only the button moves — the
+    #: reason label is left alone, because nothing has been decided about it.
+    submissionInFlight = pyqtSignal(bool)
+    #: The server quoted this many credits.
+    costQuoted = pyqtSignal(int)
+    #: The run started under this name; clear the box only if it still reads it, since the user
+    #: may already have typed the next one.
+    processingNameCleared = pyqtSignal(str)
+    #: Prefill the name box (duplicating an existing processing).
+    processingNameSet = pyqtSignal(str)
+    #: Everything checks out but the user asked to confirm each start. Carries the validated
+    #: params; the dialog is the controller's to raise.
+    confirmationRequested = pyqtSignal(object)
+
+    #: "Tell me what the start panel says." Emitted immediately before this service reads its own
+    #: copy of it. Qt direct connections are synchronous, so `ProcessingController` has answered
+    #: with `set_start_panel` by the time `emit()` returns.
+    #:
+    #: This inversion earns its keep: `update_processing_cost` has six callers, two of them other
+    #: controllers and one another service, so the panel can be neither a parameter nor pushed on
+    #: a widget signal without pinning down the order three separate places wire things in.
+    startPanelNeeded = pyqtSignal()
+
     # Whether the last processings poll saw only final-state processings; combined with
     # template statuses to decide if the project poll can stop (see _apply_poll_timer_state).
     _processings_all_final = True
@@ -119,6 +146,17 @@ class ProcessingService(QObject):
     _sort_order = ProcessingSortOrder.descending.value
     _filter = ""
 
+    #: What the start panel says, refreshed via `startPanelNeeded`. `None` params means the panel
+    #: has never answered — treated as "no parameters", which is what an empty panel means anyway.
+    _start_params = None
+    _enabled_blocks = ()
+    #: Whether the option checkboxes have been built yet. A model that declares blocks is quoted
+    #: only once they exist, so "no widgets" is not the same as "no blocks ticked".
+    _has_option_widgets = False
+    #: Whether the AOI combo has a layer at all. It only picks between two error messages: a
+    #: chosen layer that yielded no AOI is corrupt, no layer is simply not chosen yet.
+    _aoi_layer_chosen = False
+
     def __init__(self,
                  http: Http,
                  dlg: MainDialog,
@@ -132,7 +170,6 @@ class ProcessingService(QObject):
         self.iface = iface
         self.result_loader = result_loader
         self.app_context = app_context
-        self.view = ProcessingView(dlg=dlg)
         self.api = ProcessingApi(http=http,
                                  dlg=dlg,
                                  iface=iface,
@@ -145,7 +182,7 @@ class ProcessingService(QObject):
         self.processings_page_limit = Config.PROCESSINGS_PAGE_LIMIT
         self.processings_page_offset = 0
         self.processings_history = None # ProcessingHistory() - local storage for active processings list
-        self.processing_fetch_timer = QTimer(dlg)
+        self.processing_fetch_timer = QTimer(self)
         self.processing_fetch_timer.setInterval(timer_interval)
         self._default_poll_interval = timer_interval
         self.processing_cost = 0
@@ -179,6 +216,27 @@ class ProcessingService(QObject):
 
     def set_filter(self, terms: str) -> None:
         self._filter = terms or ""
+
+    def set_start_panel(self, params, enabled_blocks=(), has_option_widgets: bool = False,
+                        aoi_layer_chosen: bool = False) -> None:
+        """The start panel's current reading, answering `startPanelNeeded`. `aoi_layer_chosen`
+        rides along because the only code that reads it runs inside the same validation pass that
+        asks for this — so one synchronous push carries the whole panel."""
+        self._start_params = params
+        self._enabled_blocks = tuple(enabled_blocks or ())
+        self._has_option_widgets = bool(has_option_widgets)
+        self._aoi_layer_chosen = bool(aoi_layer_chosen)
+
+    def _read_start_panel(self):
+        """Refresh `_start_params` from whoever owns the panel, then return it."""
+        self.startPanelNeeded.emit()
+        return self._start_params
+
+    @property
+    def _selected_search_indices(self):
+        """`local_index` of every selected search result. Lives on `app_context` next to
+        `search_footprints`, which it is the key into."""
+        return getattr(self.app_context, "selected_search_indices", None) or ()
 
     def load_processing_history(self):
         """
@@ -228,7 +286,7 @@ class ProcessingService(QObject):
                 alert(error)
                 disable_start = False
             if not self.app_context.aoi:
-                if self.dlg.polygonCombo.currentLayer():
+                if self._aoi_layer_chosen:
                     raise BadProcessingInput(self.tr('Processing area layer is corrupted or has invalid projection'))
                 else:
                     raise BadProcessingInput(self.tr('Please, select a valid area of interest'))
@@ -291,19 +349,16 @@ class ProcessingService(QObject):
         # provider the metadata-table selection (possibly stale) is irrelevant — bail early.
         if not isinstance(self.app_context.data_provider, ImagerySearchProvider):
             return None, None
-        selected = self.dlg.metadataTable.selectedItems()
+        selected = self._selected_search_indices
         if not selected:
             return None, None
         footprints = self.app_context.search_footprints or {}
         provider_min_areas = getattr(self.app_context, "provider_min_areas", None) or {}
         # Track the binding (largest) minimum so the reported provider name matches it.
         binding_min, binding_provider = None, None
-        for row in sorted({item.row() for item in selected}):
-            index_item = self.dlg.metadataTable.item(row, Config.LOCAL_INDEX_COLUMN)
-            if not index_item:
-                continue
+        for local_index in dict.fromkeys(selected):  # de-duplicated, order preserved
             try:
-                feature = footprints.get(int(index_item.text()))
+                feature = footprints.get(int(local_index))
             except (TypeError, ValueError):
                 feature = None
             if feature is None:
@@ -325,8 +380,11 @@ class ProcessingService(QObject):
         if planned_selection_error:
             return planned_selection_error
         if not self.app_context.aoi:
-            # Here the button must already be disabled, and the warning text set
-            if self.view.dlg.startProcessing.isEnabled():
+            # The only widget this service still reads. It exists because "the button is currently
+            # enabled" means "an earlier check already set a reason", and re-reporting "Set AOI"
+            # over that reason would hide it. The button is written from DataCatalogView and
+            # ProviderService too, so this cannot become pushed state until they stop (C2.2c).
+            if self.dlg.startProcessing.isEnabled():
                 if not self.app_context.user_role.can_start_processing:
                     error = self.tr('Not enough rights to start processing in a shared project ({})').format(self.app_context.user_role.value)
                 else:
@@ -335,8 +393,7 @@ class ProcessingService(QObject):
             error = self.tr("Error! Models are not initialized.\n"
                             "Please, make sure you have selected a project")
         elif self.app_context.billing_type != BillingType.credits:
-            self.view.dlg.startProcessing.setEnabled(True)
-            self.view.dlg.processingProblemsLabel.clear()
+            self.startUnblocked.emit()
             error = None
         return error
 
@@ -367,8 +424,7 @@ class ProcessingService(QObject):
         """Require an image selection only when a planned (template) start actually applies."""
         if not self.template_to_run():
             return None
-        selected_rows = {item.row() for item in self.dlg.metadataTable.selectedItems()}
-        if selected_rows:
+        if self._selected_search_indices:
             return None
         return self.tr("Select one or more images in search results to start planned processing")
 
@@ -380,15 +436,15 @@ class ProcessingService(QObject):
             # Keep the AOI area on screen even when the processing is blocked (e.g. area too
             # big/small): the size is known and useful. Genuinely-unknown-area cases clear the
             # label upstream (area_calculator), so never clear it on a validation error here.
-            self.dlg.disable_processing_start(error, clear_area=False)
+            self.startDisabled.emit(error, False)
             return
         elif not processing_params: # neither error nor params => return w/o disabling (empty name)
             return
-        
+
         # Check processing limits
         if not self.check_processing_limits():
             return
-        
+
         # Handle confirmation dialog or direct submission
         self.handle_processing_submission(processing_params)
 
@@ -413,50 +469,61 @@ class ProcessingService(QObject):
             return False
         return True
         
+    def confirm_before_start(self) -> bool:
+        """Whether the user asked to confirm every start.
+
+        Read from the setting rather than the checkbox that shows it: `MainDialog` initialises the
+        box from this key and writes it back on every toggle, so the two never disagree, and a
+        setting is not a widget."""
+        return str(self.app_context.settings.value("confirmProcessingStart", "true")).lower() == "true"
+
     def handle_processing_submission(self, processing_params: PostProcessingSchemaV2):
+        """Submit now, or ask for confirmation first.
+
+        The dialog itself is `ProcessingController`'s — a service may not build one — so this
+        announces that confirmation is wanted and stops. `submit_processing` is what the
+        controller calls back into once the user has agreed.
         """
-        Handle the actual processing submission, either directly or after confirmation.
-        """
-        def post_processing():
-            try:
-                self.dlg.startProcessing.setEnabled(False)
-                template = self.template_to_run()
-                if template:
-                    self.iface.messageBar().pushInfo(
-                        self.app_context.plugin_name,
-                        self.tr('Starting planned processing...')
-                    )
-                    self.api.run_template_processing(
-                        template_id=template.id,
-                        data=self._build_run_template_processing_schema(processing_params),
-                        callback=self.start_processing_callback,
-                        error_handler=self.start_processing_error_handler,
-                    )
-                else:
-                    self.iface.messageBar().pushInfo(
-                        self.app_context.plugin_name,
-                        self.tr('Starting the processing...')
-                    )
-                    self.api.create_processing(
-                        processing_params,
-                        self.start_processing_callback,
-                        self.start_processing_error_handler
-                    )
-            except Exception as e:
-                alert(self.tr("Could not launch processing! Error: {}.").format(str(e)))
-        
-        # Show confirmation dialog if enabled
-        if self.dlg.cornfirmProcessingStart.isChecked():
-            self.show_confirmation_dialog(processing_params, post_processing)
+        if self.confirm_before_start():
+            self.confirmationRequested.emit(processing_params)
         else:
-            post_processing()
+            self.submit_processing(processing_params)
+
+    def submit_processing(self, processing_params: PostProcessingSchemaV2):
+        """Send the run. Reached directly, or from the controller after the user confirmed."""
+        try:
+            self.submissionInFlight.emit(True)
+            template = self.template_to_run()
+            if template:
+                self.iface.messageBar().pushInfo(
+                    self.app_context.plugin_name,
+                    self.tr('Starting planned processing...')
+                )
+                self.api.run_template_processing(
+                    template_id=template.id,
+                    data=self._build_run_template_processing_schema(processing_params),
+                    callback=self.start_processing_callback,
+                    error_handler=self.start_processing_error_handler,
+                )
+            else:
+                self.iface.messageBar().pushInfo(
+                    self.app_context.plugin_name,
+                    self.tr('Starting the processing...')
+                )
+                self.api.create_processing(
+                    processing_params,
+                    self.start_processing_callback,
+                    self.start_processing_error_handler
+                )
+        except Exception as e:
+            alert(self.tr("Could not launch processing! Error: {}.").format(str(e)))
 
     def _build_run_template_processing_schema(
         self,
         processing_params: PostProcessingSchemaV2,
     ) -> RunTemplateProcessingSchema:
         wd_id = processing_params.wdId
-        wd_name = None if wd_id else self.dlg.modelCombo.currentText()
+        wd_name = None if wd_id else self.selected_model_name()
         return RunTemplateProcessingSchema(
             name=processing_params.name,
             description=processing_params.description,
@@ -469,52 +536,34 @@ class ProcessingService(QObject):
             updateTemplateGeometry=False,
         )
 
-    def show_confirmation_dialog(self, processing_params: PostProcessingSchemaV2, callback):
-        """
-        Show the processing confirmation dialog with current parameters.
-        """
-        dialog = ConfirmProcessingStartDialog(self.dlg)
-        
-        def set_start_confirmation():
-            if not dialog.checkBox.isChecked() != self.dlg.cornfirmProcessingStart.isChecked():
-                self.dlg.cornfirmProcessingStart.setChecked(not dialog.checkBox.isChecked())
-                self.app_context.settings.setValue(
-                    "confirmProcessingStart", 
-                    str(not dialog.checkBox.isChecked())
-                )
-        
-        dialog.checkBox.toggled.connect(set_start_confirmation)
-        dialog.accepted.connect(callback)
-        
-        # Prepare dialog parameters
-        price = self.tr("{cost} credits").format(cost=self.processing_cost) if self.app_context.billing_type == BillingType.credits else None
-        
-        ui_start_params = self.view.read_processing_start_params()
-        
-        dialog.setup(
-            name=processing_params.name,
-            price=price,
-            provider=setup_provider_info(self.app_context.data_provider),
-            zoom=str(ui_start_params.zoom),
-            area=str(round(self.app_context.aoi_size, 2)) + self.tr(" sq.km"),
-            model=self.dlg.modelCombo.currentText(),
-            blocks=[self.dlg.modelOptionsLayout.itemAt(i).widget()
-                    for i in range(self.dlg.modelOptionsLayout.count())]
-        )
-        dialog.deleteLater()
-        
+    def selected_model_name(self) -> Optional[str]:
+        """The model the start panel shows, refreshed on demand: a template run is built well
+        after the panel was last read."""
+        params = self._read_start_panel()
+        return params.wd_name if params else None
+
+    def confirmation_details(self) -> dict:
+        """What the confirmation dialog has to show, in plain values. The dialog is raised by
+        `ProcessingController`; this is the part of it that is domain, not widgets."""
+        return {
+            "price": self.tr("{cost} credits").format(cost=self.processing_cost)
+                     if self.app_context.billing_type == BillingType.credits else None,
+            "provider": setup_provider_info(self.app_context.data_provider),
+            "area": str(round(self.app_context.aoi_size, 2)) + self.tr(" sq.km"),
+        }
+
     def get_processing_schema(self, ui_start_params, provider):
-        if not provider or not self.app_context.aoi:
+        if not ui_start_params or not provider or not self.app_context.aoi:
             return None
-        
+
         wd = self.app_context.get_workflow_def(ui_start_params.wd_name)
         if not wd:
             return None
-        if len(wd.blocks) > 0 and len(self.dlg.modelOptions) == 0:
+        if len(wd.blocks) > 0 and not self._has_option_widgets:
             # Wait till options are added and this function is  re-called
             blocks = []
         else:
-            blocks = wd.get_enabled_blocks(self.dlg.enabled_blocks())
+            blocks = wd.get_enabled_blocks(list(self._enabled_blocks))
 
         provider_params, processing_meta = get_provider_params(provider=provider,
                                                                zoom=ui_start_params.zoom)
@@ -556,16 +605,16 @@ class ProcessingService(QObject):
             # ask for that rather than a plain refresh. Template run responses also may not be a
             # full ProcessingDTO, so we do not parse one here.
             if isinstance(response_data, dict) and response_data.get("name"):
-                self.view.clear_processing_name(response_data["name"])
+                self.processingNameCleared.emit(response_data["name"])
             self.templateRehydrateRequested.emit()
-            self.dlg.startProcessing.setEnabled(True)
+            self.submissionInFlight.emit(False)
             return
         new_processing = None
         # Template start responses may differ from processing-create responses.
         # Try optimistic local update only when payload looks like a Processing DTO.
         if isinstance(response_data, dict) and response_data.get("id") and response_data.get("name"):
             new_processing = ProcessingDTO.from_dict(response_data)
-            self.view.clear_processing_name(new_processing.name)
+            self.processingNameCleared.emit(new_processing.name)
         if new_processing is not None:
             # Add to history
             self.processings[new_processing.id] = new_processing
@@ -575,7 +624,7 @@ class ProcessingService(QObject):
         # Always refresh full list because template-started processings can affect
         # both processings and template status/counts in table.
         self.refreshRequested.emit()
-        self.dlg.startProcessing.setEnabled(True)
+        self.submissionInFlight.emit(False)
 
     def start_processing_error_handler(self, response: QNetworkReply) -> None:        
         """Error handler for processing creation requests.
@@ -602,7 +651,7 @@ class ProcessingService(QObject):
                                title=self.tr('Processing creation failed'),
                                email_body=email_body).show()
         if False not in self.app_context.allow_enable_processing.values():
-            self.dlg.startProcessing.setEnabled(True)
+            self.submissionInFlight.emit(False)
 
     # =============  REQUEST ================= #
     def setup_processings_table(self):
@@ -976,7 +1025,7 @@ class ProcessingService(QObject):
         if error:
             # Keep the AOI area visible even when blocked (area too big/small, provider minimum,
             # etc.) — we know the size. Unknown-area cases are cleared upstream (area_calculator).
-            self.dlg.disable_processing_start(error, clear_area=False)
+            self.startDisabled.emit(error, False)
             return
 
         # /cost itself is only meaningful when the user is billed in credits.
@@ -995,7 +1044,7 @@ class ProcessingService(QObject):
 
     def calculate_processing_cost_callback(self, response: QNetworkReply):
         self.processing_cost = int(response.readAll().data().decode())
-        self.view.set_processing_cost(self.processing_cost)
+        self.costQuoted.emit(self.processing_cost)
 
     def disable_processing_start(self, response: QNetworkReply):
         """
@@ -1022,7 +1071,7 @@ class ProcessingService(QObject):
                 reason = self.tr('Not enough rights to start processing in a shared project ({})').format(self.app_context.user_role.value)
             else:
                 reason = self.tr('Processing cost is not available:\n{message}').format(message=message)
-            self.view.disable_processing_start(reason, clear_area=False)
+            self.startDisabled.emit(reason, False)
 
     def confirm_delete_processings(self) -> None:
         """Delete one or more processings or templates from the server.
@@ -1176,9 +1225,9 @@ class ProcessingService(QObject):
         processing = self.selected_processing()
         if not processing:
             return
-        self.dlg.disable_processing_start("")
+        self.startDisabled.emit("", False)
         self.app_context.allow_enable_processing['aoi_loaded'] = False
-        self.dlg.processingName.setText(processing.name)
+        self.processingNameSet.emit(processing.name)
         duplicate_provider_and_model(processing)
         self.result_loader.download_aoi_file(pid=processing.id, callback=self.duplicate_aoi_callback)
 
@@ -1200,7 +1249,7 @@ class ProcessingService(QObject):
             return None, context_error
         
         # UI parameters validation
-        ui_start_params = self.view.read_processing_start_params()
+        ui_start_params = self._read_start_panel()
         provider = self.app_context.data_provider
         processing_params = self.get_processing_schema(ui_start_params, provider)
         params_error, disable_start = self.validate_processing_params(processing_params, allow_empty_name)

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -2,6 +2,7 @@ from typing import List, Tuple, Union
 from PyQt5.QtCore import Qt, QCoreApplication
 from PyQt5.QtWidgets import QAbstractItemView, QTableWidgetItem, QMessageBox, QCheckBox
 from ...dialogs.main_dialog import MainDialog
+from ...dialogs.confirm_processing_start_dialog import ConfirmProcessingStartDialog
 from ...dialogs import icons
 from ...dialogs import colors
 from ...schema.processing import (ProcessingDTO,
@@ -110,11 +111,60 @@ class ProcessingView:
                              self.dlg.modelOptionsLayout.itemAt(i).widget().isChecked()]
         )
 
+    def has_option_widgets(self) -> bool:
+        """Whether the model-option checkboxes have been built. A model that declares blocks is
+        quoted only once these exist, so this is not the same as 'no options ticked'."""
+        return len(self.dlg.modelOptions) > 0
+
+    def aoi_layer_chosen(self) -> bool:
+        """Whether the AOI combo names a layer at all — the choice between the two
+        no-AOI error messages."""
+        return self.dlg.polygonCombo.currentLayer() is not None
+
     def clear_processing_name(self, name):
         # If the name is expected, we clear it after the processsing is launched;
         # Otherwise it means that the user has altered the text already and it should be preserved
         if self.dlg.processingName.text() == name:
             self.dlg.processingName.clear()
+
+    def set_processing_name(self, name: str) -> None:
+        self.dlg.processingName.setText(name)
+
+    def set_start_enabled(self, enabled: bool) -> None:
+        self.dlg.startProcessing.setEnabled(enabled)
+
+    def clear_problem_and_enable_start(self) -> None:
+        """AREA/NONE billing: nothing blocks a start, so drop any leftover reason and enable it."""
+        self.dlg.startProcessing.setEnabled(True)
+        self.dlg.processingProblemsLabel.clear()
+
+    def confirm_processing_start(self, name: str, details: dict, on_accept) -> None:
+        """Raise the start-confirmation dialog. The domain values (price, provider, area) come
+        from the service in `details`; the panel-derived ones (zoom, model, options) are read
+        here, because a service may not touch a widget and this is where they live."""
+        dialog = ConfirmProcessingStartDialog(self.dlg)
+
+        def sync_dont_ask_again():
+            # "Don't ask again" is the inverse of the Settings-tab checkbox. Setting that box
+            # persists the choice through its own toggled handler, so nothing writes settings here.
+            dont_ask = dialog.checkBox.isChecked()
+            if self.dlg.cornfirmProcessingStart.isChecked() != (not dont_ask):
+                self.dlg.cornfirmProcessingStart.setChecked(not dont_ask)
+
+        dialog.checkBox.toggled.connect(sync_dont_ask_again)
+        dialog.accepted.connect(on_accept)
+        ui_start_params = self.read_processing_start_params()
+        dialog.setup(
+            name=name,
+            price=details.get("price"),
+            provider=details.get("provider"),
+            zoom=str(ui_start_params.zoom),
+            area=details.get("area"),
+            model=self.dlg.modelCombo.currentText(),
+            blocks=[self.dlg.modelOptionsLayout.itemAt(i).widget()
+                    for i in range(self.dlg.modelOptionsLayout.count())],
+        )
+        dialog.deleteLater()
 
     def disable_processing_start(self, reason: str, clear_area: bool):
         self.dlg.disable_processing_start(reason=reason, clear_area=clear_area)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -36,6 +36,7 @@ from .functional.service.preview_service import PreviewService
 from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
 from .functional.view.search_view import SearchView
+from .functional.view.processing_view import ProcessingView
 from .functional.service import (DataCatalogService,
                                  ProcessingService,
                                  ProjectService,
@@ -230,7 +231,10 @@ class Mapflow(QObject):
                                                     result_loader=self.result_loader,
                                                     app_context=self.app_context,
                                                     timer_interval=self.config.PROCESSING_TABLE_REFRESH_INTERVAL * 1000)
-        
+        # The start panel's view. Built here, not by the service — a service holds no view
+        # (spec/007 § Services) — and handed to the controllers that render through it.
+        self.processing_view = ProcessingView(dlg=self.dlg)
+
         # ========== 8. LOAD PROVIDERS FROM SETTINGS ==========
         # load providers from settings before initializing area calculator service
         errors = []
@@ -321,6 +325,10 @@ class Mapflow(QObject):
         # than reading the table. So the push has to run before any of their handlers, and Qt
         # calls slots in connection order: this connect must stay above them.
         self.dlg.processingsTable.itemSelectionChanged.connect(self.push_processings_selection)
+        # Same reason for the search table: the start-button gate reads the selected images through
+        # the service, which is told them rather than reading the metadata table. Pushed before the
+        # controllers whose handlers read them back.
+        self.dlg.metadataTable.itemSelectionChanged.connect(self.push_search_selection)
         self.processing_controller = ProcessingController(
             iface=self.iface,
             aoi_service=self.aoi_service,
@@ -328,7 +336,7 @@ class Mapflow(QObject):
             add_layer_action=self.add_layer_action,
             remove_layer_action=self.remove_layer_action,
             processing_service=self.processing_service,
-            processing_view=self.processing_service.view,
+            processing_view=self.processing_view,
             app_context=self.app_context,
             review_dialog=self.review_dialog,
             rating_submit_button=self.dlg.ratingSubmitButton,
@@ -339,7 +347,8 @@ class Mapflow(QObject):
             provider_service=self.provider_service,
             model_combo=self.dlg.modelCombo,
             model_options_changed=self.dlg.modelOptionsChanged,
-            metadata_table=self.dlg.metadataTable)
+            metadata_table=self.dlg.metadataTable,
+            start_button=self.dlg.startProcessing)
 
         # Templates (MR-1): create / update-search-params / exclude-from-search.
         self.template_service = TemplateService(app_context=self.app_context,
@@ -369,7 +378,7 @@ class Mapflow(QObject):
             processings_table=self.dlg.processingsTable,
             see_processings_action=self.dlg.see_processings_action,
             see_search_results_action=self.dlg.see_search_results_action,
-            processing_view=self.processing_service.view,
+            processing_view=self.processing_view,
             rename_action=self.dlg.template_rename_action,
             pause_action=self.dlg.template_pause_action,
             resume_action=self.dlg.template_resume_action,
@@ -386,7 +395,7 @@ class Mapflow(QObject):
             aoi_service=self.aoi_service,
             data_catalog_service=self.data_catalog_service,
             result_loader=self.result_loader,
-            processing_view=self.processing_service.view,
+            processing_view=self.processing_view,
             ensure_output_directory=self.ensure_output_directory,
             project_view=self.project_view,
             config=self.config)
@@ -568,6 +577,14 @@ class Mapflow(QObject):
         click a row.
         """
         self.project_processing_controller.push_selection()
+
+    def push_search_selection(self):
+        """Deliver the search table's selected image indices to `app_context`, where they sit
+        beside `search_footprints` — the dict they are the key into. `ProcessingService` reads
+        them from there for the planned-processing gate and the provider-minimum-area check,
+        rather than touching the metadata table.
+        """
+        self.app_context.selected_search_indices = self.search_view.selected_local_indices()
 
     def setup_add_layer_menu(self):
         self.add_layer_menu.addAction(self.draw_aoi)

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -83,7 +83,6 @@ ALLOWED = {
     ("service-imports-dialogs", "mapflow.functional.service.data_catalog"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
     ("service-imports-view", "mapflow.functional.service.data_catalog"),
-    ("service-imports-view", "mapflow.functional.service.processing_service"),
     ("view-imports-service", "mapflow.functional.view.processing_view"),
 }
 

--- a/tests/qgis/test_imagery_search_multi.py
+++ b/tests/qgis/test_imagery_search_multi.py
@@ -377,10 +377,11 @@ class TestSetupProviderInfoMultiImage:
 class TestUpdateProcessingCostSkipsNonCredits:
     def _service(self, billing_type):
         from mapflow.functional.service.processing_service import ProcessingService
+        from PyQt5.QtCore import QObject
         service = ProcessingService.__new__(ProcessingService)
+        QObject.__init__(service)  # a disabled start is announced as a signal
         service.app_context = SimpleNamespace(billing_type=billing_type)
         service.api = MagicMock()
-        service.dlg = MagicMock()
         # Tag validate_all_processing_params so we can detect whether we got past the billing gate.
         service.validate_all_processing_params = MagicMock(return_value=(MagicMock(), None))
         return service
@@ -409,8 +410,10 @@ class TestUpdateProcessingCostSkipsNonCredits:
         service = self._service(BillingType.area)
         service.validate_all_processing_params = MagicMock(
             return_value=(None, "Models are not initialized"))
+        disabled = []
+        service.startDisabled.connect(lambda *a: disabled.append(a))
         service.update_processing_cost()
-        service.dlg.disable_processing_start.assert_called_once()
+        assert len(disabled) == 1
         service.api.get_cost.assert_not_called()
 
     def test_runs_when_billing_is_credits(self):

--- a/tests/qgis/test_processing_aoi_geometry.py
+++ b/tests/qgis/test_processing_aoi_geometry.py
@@ -24,9 +24,8 @@ def _as_geojson(geometry: QgsGeometry) -> dict:
 
 def _service(processing_aoi):
     service = ProcessingService.__new__(ProcessingService)
-    service.dlg = MagicMock()
-    service.dlg.modelOptions = []
-    service.dlg.enabled_blocks.return_value = []
+    # The option checkboxes and their ticked state are pushed in, not read off a widget.
+    service.set_start_panel(params=None, enabled_blocks=[], has_option_widgets=False)
     workflow_def = SimpleNamespace(id="wd-1", blocks=[], get_enabled_blocks=lambda enabled: [])
     service.app_context = SimpleNamespace(
         project_id="project-1",

--- a/tests/qgis/test_processing_cost.py
+++ b/tests/qgis/test_processing_cost.py
@@ -8,8 +8,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from qgis.core import QgsGeometry, QgsProject
+from PyQt5.QtCore import QObject
 
-from mapflow.config import Config
 from mapflow.model.provider.default import ImagerySearchProvider, MyImageryProvider
 from mapflow.functional.service.processing_service import ProcessingService
 from mapflow.mapflow import Mapflow
@@ -31,14 +31,6 @@ def _footprint(provider=None):
     return feature
 
 
-def _selection(rows):
-    return [SimpleNamespace(row=lambda r=r: r) for r in rows]
-
-
-def _index_side_effect(index_cells):
-    return lambda row, col: index_cells.get(row) if col == Config.LOCAL_INDEX_COLUMN else None
-
-
 def test_register_provider_min_areas_maps_name_and_display_name():
     plugin = Mapflow.__new__(Mapflow)
     plugin.app_context = SimpleNamespace(provider_min_areas={})
@@ -58,7 +50,6 @@ def test_register_provider_min_areas_maps_name_and_display_name():
 
 def test_selected_search_min_area_returns_most_restrictive_and_provider():
     service = ProcessingService.__new__(ProcessingService)
-    service.dlg = MagicMock()
     service.app_context = SimpleNamespace(
         data_provider=_search_provider(),
         search_footprints={
@@ -66,12 +57,8 @@ def test_selected_search_min_area_returns_most_restrictive_and_provider():
             2: _footprint(provider="arcgis_world_imagery"),
         },
         provider_min_areas={"orbview": 3.0, "arcgis_world_imagery": 5.0},
+        selected_search_indices=["0", "2"],
     )
-    service.dlg.metadataTable.selectedItems.return_value = _selection([0, 2])
-    service.dlg.metadataTable.item.side_effect = _index_side_effect({
-        0: MagicMock(text=MagicMock(return_value="0")),
-        2: MagicMock(text=MagicMock(return_value="2")),
-    })
 
     min_area, provider = service._selected_search_min_area()
 
@@ -82,15 +69,11 @@ def test_selected_search_min_area_returns_most_restrictive_and_provider():
 
 def test_selected_search_min_area_lookup_is_case_insensitive():
     service = ProcessingService.__new__(ProcessingService)
-    service.dlg = MagicMock()
     service.app_context = SimpleNamespace(
         data_provider=_search_provider(),
         search_footprints={0: _footprint(provider="ArcGIS_World_Imagery")},
         provider_min_areas={"arcgis_world_imagery": 5.0},
-    )
-    service.dlg.metadataTable.selectedItems.return_value = _selection([0])
-    service.dlg.metadataTable.item.side_effect = _index_side_effect(
-        {0: MagicMock(text=MagicMock(return_value="0"))}
+        selected_search_indices=["0"],
     )
 
     assert service._selected_search_min_area() == (5.0, "ArcGIS_World_Imagery")
@@ -98,21 +81,21 @@ def test_selected_search_min_area_lookup_is_case_insensitive():
 
 def test_selected_search_min_area_is_none_without_selection():
     service = ProcessingService.__new__(ProcessingService)
-    service.dlg = MagicMock()
-    service.app_context = SimpleNamespace(data_provider=_search_provider())
-    service.dlg.metadataTable.selectedItems.return_value = []
+    service.app_context = SimpleNamespace(data_provider=_search_provider(),
+                                          selected_search_indices=[])
 
     assert service._selected_search_min_area() == (None, None)
 
 
 def test_selected_search_min_area_skips_non_search_provider():
     service = ProcessingService.__new__(ProcessingService)
-    service.dlg = MagicMock()
-    service.app_context = SimpleNamespace(data_provider=MyImageryProvider())
+    # Even with a (stale) selection present, a non-search provider short-circuits to (None, None).
+    service.app_context = SimpleNamespace(data_provider=MyImageryProvider(),
+                                          selected_search_indices=["0"],
+                                          search_footprints={0: _footprint(provider="orbview")},
+                                          provider_min_areas={"orbview": 3.0})
 
-    # Even with a (stale) selection present, a non-search provider short-circuits.
     assert service._selected_search_min_area() == (None, None)
-    service.dlg.metadataTable.selectedItems.assert_not_called()
 
 
 def test_validate_processing_params_blocks_below_provider_min_area():
@@ -147,23 +130,23 @@ def test_validate_processing_params_passes_when_area_meets_provider_min():
 
 def test_update_processing_cost_skips_request_when_below_provider_min_area():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the disable is announced as a signal
     service.tr = lambda text: text
-    service.dlg = MagicMock()
     service.api = MagicMock()
     # Reach validate_processing_params with a too-small AOI∩image area.
     service.validate_context_params = MagicMock(return_value=None)
-    service.view = MagicMock()
-    service.view.read_processing_start_params.return_value = SimpleNamespace()
+    service.set_start_panel(SimpleNamespace())
     service.app_context = SimpleNamespace(
         aoi=_small_aoi(), processing_aoi=_small_aoi(), project=QgsProject.instance(),
         aoi_size=0.1, aoi_area_limit=1000.0, data_provider=object(),
     )
     service.get_processing_schema = MagicMock(return_value=SimpleNamespace(name="Run 1"))
     service._selected_search_min_area = MagicMock(return_value=(5.0, "orbview"))
+    disabled = []
+    service.startDisabled.connect(lambda *a: disabled.append(a))
 
     service.update_processing_cost()
 
     service.api.get_cost.assert_not_called()
-    service.dlg.disable_processing_start.assert_called_once()
     # The AOI size is known, so a blocking validation error must NOT clear the area label.
-    assert service.dlg.disable_processing_start.call_args.kwargs.get("clear_area") is False
+    assert len(disabled) == 1 and disabled[0][1] is False

--- a/tests/qgis/test_processing_start_panel.py
+++ b/tests/qgis/test_processing_start_panel.py
@@ -1,0 +1,201 @@
+"""QGIS-tier tests for the start panel after it left ProcessingService.
+
+The service used to read the model combo, the option checkboxes, the AOI combo and the search
+selection, and drive the Start button and the confirmation dialog directly. A service may do none
+of that (`spec/007_architecture.md` § Services). It now *announces* what the panel must show and
+is *told* what the panel says, and `ProcessingController` is the only thing that touches widgets.
+
+The wiring is built in the real `ProcessingController.__init__`, and these run it — not a
+hand-rolled set of connections. A test that makes the connection it checks cannot fail when the
+production code stops making it (the bug that survived 866 tests in C2.2a).
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from mapflow.functional.controller.processing_controller import ProcessingController
+from mapflow.functional.service import processing_service as processing_service_module
+from mapflow.functional.service.processing_service import ProcessingService
+
+
+class _AoiServiceStub(QObject):
+    """The three AOI signals `ProcessingController.__init__` connects unconditionally."""
+    aoiLayerRegistered = pyqtSignal(object)
+    aoiLayersChanged = pyqtSignal()
+    currentAoiLayerChanged = pyqtSignal(object)
+
+
+class _Button(QObject):
+    clicked = pyqtSignal()
+
+
+def _service():
+    service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # it is the panel's signals we are testing
+    service.tr = lambda text: text
+    return service
+
+
+def _controller(service, start_button=None):
+    """A real `ProcessingController`, wired by its own `__init__` against a real service."""
+    return ProcessingController(
+        iface=MagicMock(),
+        aoi_service=_AoiServiceStub(),
+        aoi_view=MagicMock(),
+        add_layer_action=MagicMock(),
+        remove_layer_action=MagicMock(),
+        processing_service=service,
+        processing_view=MagicMock(),
+        app_context=MagicMock(),
+        start_button=start_button)
+
+
+# ---------- the service announces, the controller renders ----------
+
+def test_a_blocked_start_reaches_the_view():
+    service = _service()
+    controller = _controller(service)
+
+    service.startDisabled.emit("too big", True)
+
+    controller.processing_view.disable_processing_start.assert_called_once_with("too big", True)
+
+
+def test_an_unblocked_start_clears_the_problem_and_enables():
+    service = _service()
+    controller = _controller(service)
+
+    service.startUnblocked.emit()
+
+    controller.processing_view.clear_problem_and_enable_start.assert_called_once()
+
+
+def test_a_submission_in_flight_disables_the_button_and_returning_re_enables():
+    service = _service()
+    controller = _controller(service)
+
+    service.submissionInFlight.emit(True)
+    controller.processing_view.set_start_enabled.assert_called_with(False)
+
+    service.submissionInFlight.emit(False)
+    controller.processing_view.set_start_enabled.assert_called_with(True)
+
+
+def test_a_quoted_cost_reaches_the_view():
+    service = _service()
+    controller = _controller(service)
+
+    service.costQuoted.emit(42)
+
+    controller.processing_view.set_processing_cost.assert_called_once_with(42)
+
+
+def test_the_name_box_is_cleared_and_prefilled_on_request():
+    service = _service()
+    controller = _controller(service)
+
+    service.processingNameCleared.emit("Run 1")
+    controller.processing_view.clear_processing_name.assert_called_once_with("Run 1")
+
+    service.processingNameSet.emit("Copy of Run 1")
+    controller.processing_view.set_processing_name.assert_called_once_with("Copy of Run 1")
+
+
+# ---------- the synchronous panel round trip ----------
+
+def test_reading_the_panel_fills_it_before_returning():
+    """`startPanelNeeded` is emitted and answered synchronously: by the time the service's own
+    `_read_start_panel` returns, the controller has already pushed the panel back. This is the
+    whole reason the inversion works instead of a stored copy going stale."""
+    service = _service()
+    controller = _controller(service)
+    params = SimpleNamespace(wd_name="Buildings")
+    controller.processing_view.read_processing_start_params.return_value = params
+    controller.processing_view.enabled_blocks.return_value = [True, False]
+    controller.processing_view.has_option_widgets.return_value = True
+    controller.processing_view.aoi_layer_chosen.return_value = True
+
+    returned = service._read_start_panel()
+
+    assert returned is params
+    assert service._start_params is params
+    assert service._enabled_blocks == (True, False)
+    assert service._has_option_widgets is True
+    assert service._aoi_layer_chosen is True
+
+
+def test_with_no_controller_listening_the_panel_reads_empty():
+    """Tests and early startup have no controller yet; the service must answer "no parameters"
+    rather than raise, so the ordinary "specify parameters" path handles it."""
+    service = _service()
+
+    assert service._read_start_panel() is None
+
+
+# ---------- starting, and confirmation ----------
+
+def test_the_start_button_starts_a_processing():
+    service = _service()
+    service.start_processing = MagicMock()
+    button = _Button()
+    # Keep the controller referenced: if it is collected, Qt drops the connection and the click
+    # reaches nothing.
+    controller = _controller(service, start_button=button)
+    assert controller is not None
+
+    button.clicked.emit()
+
+    service.start_processing.assert_called_once()
+
+
+def test_confirmation_is_asked_for_only_when_the_setting_says_so():
+    service = _service()
+    service.app_context = SimpleNamespace(settings=MagicMock())
+    service.submit_processing = MagicMock()
+    asked = []
+    service.confirmationRequested.connect(asked.append)
+    params = SimpleNamespace(name="Run 1")
+
+    service.app_context.settings.value.return_value = "false"
+    service.handle_processing_submission(params)
+    assert asked == [] and service.submit_processing.call_count == 1
+
+    service.app_context.settings.value.return_value = "true"
+    service.handle_processing_submission(params)
+    assert asked == [params] and service.submit_processing.call_count == 1  # not submitted again
+
+
+def test_confirmation_raises_the_dialog_and_submits_on_accept():
+    service = _service()
+    service.submit_processing = MagicMock()
+    service.confirmation_details = MagicMock(return_value={"price": None})
+    controller = _controller(service)
+    params = SimpleNamespace(name="Run 1")
+
+    service.confirmationRequested.emit(params)
+
+    call = controller.processing_view.confirm_processing_start.call_args
+    assert call.kwargs["name"] == "Run 1"
+    # The dialog is handed an on_accept that submits the very params it is confirming.
+    call.kwargs["on_accept"]()
+    service.submit_processing.assert_called_once_with(params)
+
+
+def test_submit_sends_the_run_and_marks_it_in_flight():
+    service = _service()
+    service.iface = MagicMock()
+    service.api = MagicMock()
+    service.app_context = SimpleNamespace(plugin_name="Mapflow")
+    service.template_to_run = MagicMock(return_value=None)
+    service.start_processing_callback = MagicMock()
+    service.start_processing_error_handler = MagicMock()
+    in_flight = []
+    service.submissionInFlight.connect(in_flight.append)
+    params = SimpleNamespace(name="Run 1")
+
+    with patch.object(processing_service_module, "alert"):
+        service.submit_processing(params)
+
+    service.api.create_processing.assert_called_once()
+    assert in_flight == [True]  # re-enable is the callback's job, not this method's

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -16,6 +16,14 @@ from mapflow.schema.processing import PostProcessingSchemaV2
 from mapflow.schema.template import RunTemplateProcessingSchema
 
 
+def _settings(confirm="true"):
+    """A settings stub whose `confirmProcessingStart` reads back as `confirm`."""
+    settings = MagicMock()
+    settings.value.side_effect = lambda key, default=None: (
+        confirm if key == "confirmProcessingStart" else default)
+    return settings
+
+
 def _processing_payload():
     return PostProcessingSchemaV2(
         name="Run 1",
@@ -31,13 +39,13 @@ def _processing_payload():
 
 def test_handle_processing_submission_uses_template_run_when_template_selected():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)
     service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.dlg.cornfirmProcessingStart.isChecked.return_value = False
-    service.dlg.modelCombo.currentText.return_value = "Buildings"
     service.iface = MagicMock()
-    service.app_context = SimpleNamespace(plugin_name="Mapflow")
+    service.app_context = SimpleNamespace(plugin_name="Mapflow",
+                                          settings=_settings(confirm="false"))
     service.api = MagicMock()
+    service.set_start_panel(SimpleNamespace(wd_name="Buildings"))
     service.start_processing_callback = MagicMock()
     service.start_processing_error_handler = MagicMock()
     # A template run happens iff template_to_run() resolves (template + imagery-search source + open results).
@@ -57,11 +65,11 @@ def test_handle_processing_submission_uses_template_run_when_template_selected()
 
 def test_handle_processing_submission_uses_regular_processing_when_no_template_selected():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)
     service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.dlg.cornfirmProcessingStart.isChecked.return_value = False
     service.iface = MagicMock()
-    service.app_context = SimpleNamespace(plugin_name="Mapflow")
+    service.app_context = SimpleNamespace(plugin_name="Mapflow",
+                                          settings=_settings(confirm="false"))
     service.api = MagicMock()
     service.start_processing_callback = MagicMock()
     service.start_processing_error_handler = MagicMock()
@@ -81,18 +89,15 @@ def test_handle_processing_submission_uses_regular_processing_when_no_template_s
 def test_planned_processing_selection_error_requires_selected_metadata_rows():
     service = ProcessingService.__new__(ProcessingService)
     service.tr = lambda text: text
-    service.dlg = MagicMock()
     # Planned image gate applies only when a planned start applies (template_to_run resolves).
     service.template_to_run = MagicMock(return_value=SimpleNamespace(id="template-1"))
 
-    service.dlg.metadataTable.selectedItems.return_value = []
+    service.app_context = SimpleNamespace(selected_search_indices=[])
     assert service.planned_processing_selection_error() == (
         "Select one or more images in search results to start planned processing"
     )
 
-    selected_item = MagicMock()
-    selected_item.row.return_value = 0
-    service.dlg.metadataTable.selectedItems.return_value = [selected_item]
+    service.app_context.selected_search_indices = ["0"]
     assert service.planned_processing_selection_error() is None
 
 
@@ -417,15 +422,14 @@ def test_on_metadata_table_cell_clicked_does_not_mark_seen():
 def test_start_processing_callback_refreshes_processings_for_regular_response():
     service = ProcessingService.__new__(ProcessingService)
     service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.view = MagicMock()
     service.processing_fetch_timer = MagicMock()
     service.processings = {}
     service.processings_history = MagicMock()
     QObject.__init__(service)  # the refresh request is a signal now
-    asked, added = [], []
+    asked, added, in_flight = [], [], []
     service.refreshRequested.connect(lambda: asked.append(True))
     service.processingAdded.connect(added.append)
+    service.submissionInFlight.connect(in_flight.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"id": "proc-1", "name": "Run 1"}'
@@ -437,21 +441,20 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
 
     assert asked == [True]
     assert added == [mock_processing]
-    service.dlg.startProcessing.setEnabled.assert_called_with(True)
+    assert in_flight[-1] is False  # the button is re-enabled once the run has been sent
 
 
 def test_start_processing_callback_refreshes_processings_for_template_response_shape():
     service = ProcessingService.__new__(ProcessingService)
     service.tr = lambda text: text
-    service.dlg = MagicMock()
-    service.view = MagicMock()
     service.processing_fetch_timer = MagicMock()
     service.processings = {}
     service.processings_history = MagicMock()
     QObject.__init__(service)  # the refresh request is a signal now
-    asked, added = [], []
+    asked, added, in_flight = [], [], []
     service.refreshRequested.connect(lambda: asked.append(True))
     service.processingAdded.connect(added.append)
+    service.submissionInFlight.connect(in_flight.append)
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"template": {"id": "tpl-1"}, "searchResults": []}'
@@ -461,16 +464,18 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
 
     assert asked == [True]
     assert added == []
-    service.dlg.startProcessing.setEnabled.assert_called_with(True)
+    assert in_flight[-1] is False
 
 
 def test_disable_processing_start_uses_fallback_when_api_message_is_none():
     service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)  # the disable is announced as a signal
     service.tr = lambda text: text
-    service.view = MagicMock()
     service.app_context = SimpleNamespace(
         user_role=SimpleNamespace(can_start_processing=True, value="owner")
     )
+    disabled = []
+    service.startDisabled.connect(lambda *a: disabled.append(a))
 
     response = MagicMock()
     response.readAll.return_value.data.return_value = b"{}"
@@ -479,10 +484,7 @@ def test_disable_processing_start_uses_fallback_when_api_message_is_none():
     with patch.object(processing_service_module, "api_message_parser", return_value=None):
         service.disable_processing_start(response)
 
-    service.view.disable_processing_start.assert_called_once_with(
-        "Processing cost is not available:\nUnknown server error",
-        clear_area=False,
-    )
+    assert disabled == [("Processing cost is not available:\nUnknown server error", False)]
 
 
 def _rename_service(name="Old template"):

--- a/tests/qgis/test_template_start_processing_refresh.py
+++ b/tests/qgis/test_template_start_processing_refresh.py
@@ -29,14 +29,19 @@ def _service(in_template_mode):
     service = ProcessingService.__new__(ProcessingService)
     QObject.__init__(service)  # the refresh requests are signals now
     service.tr = lambda text: text
-    service.dlg = MagicMock()
     service.api = MagicMock()
-    service.view = MagicMock()
     service.processing_fetch_timer = MagicMock()
     service.set_open_template(SimpleNamespace(id="tpl-1") if in_template_mode else None)
     service.processings = {}
     service.processings_history = MagicMock()
     return service
+
+
+def _in_flight(service):
+    """The submission-in-flight signals, in order (True on send, False when it returns)."""
+    seen = []
+    service.submissionInFlight.connect(seen.append)
+    return seen
 
 
 def _template_service(active_template=SimpleNamespace(id="tpl-1")):
@@ -69,6 +74,7 @@ def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     service = _service(in_template_mode=True)
     asked = _requests(service)
     added = _added(service)
+    in_flight = _in_flight(service)
 
     with patch.object(processing_service_module, "alert"):
         service.start_processing_callback(_response(_PROCESSING))
@@ -77,7 +83,7 @@ def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     assert asked == ["rehydrate"]
     # No flat optimistic add in template mode.
     assert added == []
-    service.dlg.startProcessing.setEnabled.assert_called_once_with(True)
+    assert in_flight[-1] is False  # the button is re-enabled once the run has been sent
 
 
 def test_regular_start_does_flat_add_and_asks_for_a_plain_refresh():


### PR DESCRIPTION
The service read the model combo, the option checkboxes, the AOI combo and the search selection,
drove the Start button, and built the confirmation dialog. A service may touch none of that
(spec/007 § Services). It now announces what the panel must show — startDisabled, startUnblocked,
submissionInFlight, costQuoted, processingName{Cleared,Set}, confirmationRequested — and is told
what the panel says, through set_start_panel / set_sort / set_filter. ProcessingController renders,
and ProcessingView builds the confirmation dialog.

The panel is pushed on demand rather than passed as an argument, because update_processing_cost has
six callers — mapflow.py, three controllers and AreaCalculatorService — two of them controller to
controller and one service to service, so the method can neither move to a controller nor take the
panel as a parameter. The service emits startPanelNeeded immediately before it reads its copy; a Qt
direct connection is synchronous, so ProcessingController has answered with set_start_panel by the
time emit() returns. With nobody connected (tests, early startup) the service keeps its empty panel
and the ordinary "specify parameters" path handles it.

The search-image selection goes on app_context beside search_footprints — it is the key into that
dict — and is pushed there from mapflow.py on the metadata table's selection, before the
controllers whose handlers read it back. Same ordering rule as the processings-table selection in
C2.2a: Qt calls slots in connection order, so a push that several regions read must be connected
above them, which is the composition root's job.

ProcessingView moved out of the service to mapflow.py: once every call was a signal, a service
holding a view it never calls is the smell this phase removes. That clears service-imports-view for
processing_service. self.dlg stays for the single startProcessing.isEnabled() read — that button is
also written by DataCatalogView and ProviderService, so it cannot become pushed state until they
stop (C2.2c) — and for ProcessingApi(dlg=...) (C2.6); so dialog-param, service-imports-dialogs and
widget-import remain until those. The poll timer is reparented from the dialog to the service, and
app_context.selected_processing_ids (dead since before this phase) is deleted.

confirm_before_start reads the confirmProcessingStart setting, not the checkbox that mirrors it:
MainDialog initialises the box from the setting and writes it back on every toggle, so the setting
is always current and is not a widget.

## Manual test
Pick a model: its options and price update, and a credits account sees a cost. Tick/untick options:
the cost re-quotes. Start a processing with "confirm before start" on (Settings tab): the
confirmation dialog shows the right name, price, provider, zoom, area and options, and OK starts the
run; toggling "don't ask again" flips the Settings-tab checkbox. Start with it off: the run starts
immediately. Start button disables during the request and re-enables when it returns. Duplicate a
processing from the table: the name box is prefilled and Start is disabled until an AOI loads.

Regression surface, all silent if the push is mis-ordered: the "Start planned processing" gate — a
planned start stays blocked with "Select one or more images" until images are selected in the
search table; the provider-minimum-area check — a too-small AOI∩image is refused before the cost
request; and the AREA/NONE billing path, where Start is enabled without a cost being quoted.
