### PR TITLE
refactor: the My Imagery panel leaves DataCatalogService for its controller

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -115,13 +115,11 @@ service without finishing it, which is the price of a reviewable diff.
     Blocked until `DataCatalogView` (C2.3) and `ProviderService` (C2.4) stop writing that button —
     only then can its state be pushed instead of read. Clears `dialog-param` / `widget-import`
     for `processing_service` together with C2.6 (`ProcessingApi(dlg=...)`).
-[ ] C2.3 `DataCatalogService` (29 dlg, 38 view) → `DataCatalogController` + `DataCatalogView`
-    **The largest item, not the mechanical one.** With 38 view calls against a 57-line controller,
-    this service *is* the My Imagery controller; turning those into signals would be the wrong
-    shape (nobody wants a service with 38 signals). The work is moving the view orchestration into
-    `DataCatalogController` and leaving the service with its requests and its state — so the
-    controller grows by roughly what the service loses. Consider splitting it: mosaics first,
-    then images.
+[ready-for-review] C2.3 `DataCatalogService` → `DataCatalogController` + `DataCatalogView`
+    Service now announces (signals) and is told the selection (`set_selected_*`); the controller
+    owns every dialog and renders. `ProcessingView`-style: `DataCatalogView` built in `mapflow.py`.
+    `service-imports-view` + `widget-import` cleared for data_catalog; `dialog-param` +
+    `service-imports-dialogs` stay until C2.6 (`DataCatalogApi(dlg=…)` + the `MainDialog` hint).
 
 #### Group B — the service reaches into other regions' widgets
 

--- a/mapflow/functional/controller/data_catalog_controller.py
+++ b/mapflow/functional/controller/data_catalog_controller.py
@@ -1,52 +1,80 @@
-from PyQt5.QtCore import QObject
+from pathlib import Path
+
+from PyQt5.QtCore import QObject, Qt
+from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog
+
 from ..service.data_catalog import DataCatalogService
 from ..service.preview_service import PreviewService
+from ..service.alert_service import alert
+from ..view.data_catalog_view import DataCatalogView
 from ...dialogs.main_dialog import MainDialog
+from ...dialogs.mosaic_dialog import CreateMosaicDialog, UpdateMosaicDialog
+from ...dialogs.image_dialog import RenameImageDialog
+from ...dialogs.upload_raster_layer_dialog import UploadRasterLayersDialog
+from ...dialogs.error_message_widget import ErrorMessageWidget
+from ...functional.app_context import AppContext
+from ...model.provider import MyImageryProvider
 
 
 class DataCatalogController(QObject):
+    """The My Imagery panel. `DataCatalogService` does the requests and holds the mosaics/images;
+    this controller owns every dialog, reads the table selections and pushes them to the service,
+    and renders what the service announces. A service touches no widget
+    (`spec/007_architecture.md` § Services)."""
+
     def __init__(self,
                  dlg: MainDialog,
                  data_catalog_service: DataCatalogService,
-                 preview_service: PreviewService):
+                 preview_service: PreviewService,
+                 view: DataCatalogView,
+                 app_context: AppContext):
+        super().__init__()
         self.dlg = dlg
         self.service = data_catalog_service
         # Which mosaic/image is selected is the catalog's; putting the raster on the map is
         # PreviewService's, so the two preview buttons wire across.
         self.preview_service = preview_service
-        self.view = self.service.view
+        self.view = view
+        self.app_context = app_context
 
         # At first, when mosaic and image are not selected, make buttons unavailable or hidden
         self.dlg.deleteCatalogButton.setEnabled(False)
         self.dlg.seeMosaicsButton.setEnabled(False)
         self.dlg.seeImagesButton.setEnabled(False)
 
+        self._connect_buttons()
+        self._connect_service_signals()
+
+    # ---------- wiring ----------
+
+    def _connect_buttons(self):
         # Mosaic
-        self.dlg.editMosaicButton.clicked.connect(self.service.update_mosaic)
-        self.dlg.previewMosaicButton.clicked.connect(
-            self.preview_service.preview_my_imagery_mosaic)
-        self.dlg.mosaicTable.selectionModel().selectionChanged.connect(self.service.check_mosaic_selection)
-        self.dlg.showImagesButton.clicked.connect(self.view.show_images_table)
-        self.dlg.seeImagesButton.clicked.connect(self.view.show_images_table)
-        self.dlg.mosaicTable.cellDoubleClicked.connect(self.view.show_images_table)
+        self.dlg.editMosaicButton.clicked.connect(self.update_mosaic)
+        self.dlg.previewMosaicButton.clicked.connect(self.preview_service.preview_my_imagery_mosaic)
+        # itemSelectionChanged (not selectionModel().selectionChanged), so this runs in the same
+        # signal whose first slot — connected in mapflow.py above every reader — pushes the
+        # selected ids to the service. The dedup/resolve below then reads fresh pushed state.
+        self.dlg.mosaicTable.itemSelectionChanged.connect(self.check_mosaic_selection)
+        self.dlg.showImagesButton.clicked.connect(self.show_images_table)
+        self.dlg.seeImagesButton.clicked.connect(self.show_images_table)
+        self.dlg.mosaicTable.cellDoubleClicked.connect(self.show_images_table)
         self.dlg.nextImageButton.clicked.connect(self.service.get_next_preview)
         self.dlg.previousImageButton.clicked.connect(self.service.get_previous_preview)
 
         # Image
         self.dlg.addImageButton.setMenu(self.view.upload_image_menu)
-        self.view.upload_from_file.triggered.connect(self.service.upload_images_to_mosaic)
-        self.view.choose_raster_layer.triggered.connect(self.service.choose_raster_layers)
-        self.dlg.imageInfoButton.clicked.connect(self.service.image_info)
-        self.dlg.renameImageButton.clicked.connect(self.service.show_rename_image_dialog)
-        self.dlg.previewImageButton.clicked.connect(
-            self.preview_service.preview_my_imagery_image)
+        self.view.upload_from_file.triggered.connect(self.upload_images_to_mosaic)
+        self.view.choose_raster_layer.triggered.connect(self.choose_raster_layers)
+        self.dlg.imageInfoButton.clicked.connect(self.image_info)
+        self.dlg.renameImageButton.clicked.connect(self.show_rename_image_dialog)
+        self.dlg.previewImageButton.clicked.connect(self.preview_service.preview_my_imagery_image)
         self.dlg.downloadImageButton.clicked.connect(self.service.download_image)
-        self.dlg.imageTable.selectionModel().selectionChanged.connect(self.service.check_image_selection)
-        self.dlg.seeMosaicsButton.clicked.connect(self.service.switch_to_mosaics_table)
+        self.dlg.imageTable.itemSelectionChanged.connect(self.check_image_selection)
+        self.dlg.seeMosaicsButton.clicked.connect(self.switch_to_mosaics_table)
 
         # Mosaic or image (depending on selection)
-        self.dlg.addCatalogButton.clicked.connect(self.service.add_mosaic_or_image)
-        self.dlg.deleteCatalogButton.clicked.connect(self.service.delete_mosaic_or_image)
+        self.dlg.addCatalogButton.clicked.connect(self.add_mosaic_or_image)
+        self.dlg.deleteCatalogButton.clicked.connect(self.delete_mosaic_or_image)
         self.dlg.sortCatalogCombo.activated.connect(self.view.sort_catalog)
         self.dlg.refreshCatalogButton.clicked.connect(self.service.refresh_catalog)
         self.dlg.filterCatalog.textChanged.connect(self.view.filter_catalog_table)
@@ -55,3 +83,251 @@ class DataCatalogController(QObject):
         self.service.mosaicsUpdated.connect(self.service.get_user_limit)
 
         self.dlg.myImageryDocsButton.clicked.connect(self.service.open_imagery_docs)
+
+    def _connect_service_signals(self):
+        """What the service announces, rendered here."""
+        s = self.service
+        s.mosaicsChanged.connect(self._render_mosaics)
+        s.mosaicReselected.connect(self.view.display_mosaics_and_reselect)
+        s.imagesChanged.connect(self.view.display_images)
+        s.mosaicInfoChanged.connect(self.view.display_mosaic_info)
+        s.previewChanged.connect(self.view.show_preview_s)
+        s.previewNavChanged.connect(self.view.enable_mosaic_images_preview)
+        s.imageNumberChanged.connect(self.view.display_image_number)
+        s.imageRenamedInTable.connect(self.view.rename_image_in_table)
+        s.storageChanged.connect(self.view.show_storage)
+        s.mosaicSelectionCleared.connect(self.view.clear_mosaic_selection)
+        s.imageSelectionCleared.connect(self.view.clear_image_selection)
+        s.sourceMosaicSelected.connect(self.view.select_mosaic_cell)
+        s.sourceImageReady.connect(self._render_source_image)
+        s.mySourceShown.connect(self.view.show_my_imagery_source)
+        s.catalogResetToMosaics.connect(self.view.reset_to_mosaics_table)
+        s.imageSourceError.connect(self._show_source_error)
+        s.downloadUrlReady.connect(self._prompt_save_download)
+        s.dialogShouldRaise.connect(self.view.raise_dialog)
+        s.switchToMyImageryRequested.connect(self._switch_to_my_imagery)
+
+    def _render_mosaics(self, mosaics):
+        self.view.display_mosaics(mosaics)
+        self.view.clear_mosaic_selection()
+
+    def _render_source_image(self, image):
+        self.view.select_mosaic_cell(image.mosaic_id)
+        self.view.bind_source_image(image.id)
+
+    def _show_source_error(self, summary: str):
+        ErrorMessageWidget(parent=QApplication.activeWindow(), text=summary).show()
+
+    def _switch_to_my_imagery(self, providers):
+        """Point the data-source combo at My Imagery if it is not there already."""
+        current = providers[self.dlg.providerIndex()]
+        if isinstance(current, MyImageryProvider):
+            return
+        for index, provider in enumerate(providers):
+            if isinstance(provider, MyImageryProvider):
+                self.dlg.sourceCombo.setCurrentIndex(index)
+                return
+
+    # ---------- which catalog table is showing ----------
+
+    def show_images_table(self, *args):
+        self.view.show_images_table()
+        self.service.set_mosaic_table_visible(False)
+
+    def switch_to_mosaics_table(self, *args):
+        mosaic = self.service.selected_mosaic()
+        self.service.set_mosaic_table_visible(True)
+        self.view.show_mosaics_table(mosaic.name if mosaic else None)
+        if mosaic:
+            self.view.display_mosaic_info(mosaic, self.service.images)
+            self.service.get_mosaic_images(mosaic.id)
+
+    # ---------- selection ----------
+
+    def check_mosaic_selection(self, *args):
+        mosaic = self.service.selected_mosaic()
+        if mosaic:
+            self.on_mosaic_selection(mosaic)
+        else:
+            self.view.clear_mosaic_info()
+
+    def on_mosaic_selection(self, mosaic):
+        # Clear previous images details
+        self.view.clear_image_table()
+        # Selecting a mosaic clears the image selection, so drop the cached image too — otherwise
+        # a stale selected_image would still feed imageIds into the next processing (a mosaic run
+        # would wrongly reuse the previously processed image).
+        self.app_context.selected_image = None
+        # Don't send GET requests if the first selected mosaic didn't change
+        selected = self.dlg.mosaicTable.selectedIndexes()
+        if len(selected) > 1 and self.dlg.selected_mosaic_cell == selected[0]:
+            pass
+        else:
+            self.dlg.selected_mosaic_cell = self.dlg.mosaicTable.selectedIndexes()[0]
+            self.service.get_mosaic_images(mosaic.id)
+        self.view.add_mosaic_cell_buttons()
+        self.view.show_mosaic_info(mosaic.name)
+
+    def check_image_selection(self, *args):
+        image = self.service.selected_image()
+        if image:
+            self.on_image_selection(image)
+        else:
+            # Keep the cached image in sync with the table: deselecting must not leave a stale
+            # selected_image that would be picked up when building processing params.
+            self.app_context.selected_image = None
+            self.view.clear_image_info()
+
+    def on_image_selection(self, image):
+        selected_images = self.dlg.imageTable.selectedIndexes()
+        selected_mosaics = self.dlg.mosaicTable.selectedIndexes()
+        if not selected_mosaics or (len(selected_images) > 1 and self.dlg.selected_image_cell == selected_images[0]):
+            pass
+        else:
+            self.dlg.selected_mosaic_cell = self.dlg.mosaicTable.selectedIndexes()[0]
+            self.service.get_image_preview_s(image)
+        self.view.show_image_info(image)
+        self.view.add_image_cell_buttons()
+        self.app_context.selected_image = image
+
+    # ---------- add / delete dispatch ----------
+
+    def add_mosaic_or_image(self, *args):
+        if self.view.mosaic_table_visible:
+            self.create_mosaic()
+        else:
+            self.upload_images_to_mosaic()
+
+    def delete_mosaic_or_image(self, *args):
+        if self.service.selected_image():
+            self.confirm_image_deletion()
+        elif self.service.selected_mosaic():
+            self.confirm_mosaic_deletion()
+
+    # ---------- mosaic dialogs ----------
+
+    def create_mosaic(self, *args):
+        dialog = CreateMosaicDialog(self.dlg)
+        dialog.accepted.connect(lambda: self._create_mosaic_from_options(dialog))
+        dialog.setup()
+        dialog.deleteLater()
+
+    def _create_mosaic_from_options(self, mosaic_dialog: CreateMosaicDialog):
+        mosaic = mosaic_dialog.mosaic()
+        if mosaic_dialog.createMosaicCombo.currentIndex() == 0:  # empty mosaic
+            self.service.create_mosaic(mosaic)
+            return
+        if mosaic_dialog.createMosaicCombo.currentIndex() == 1:  # mosaic from files
+            image_paths = QFileDialog.getOpenFileNames(QApplication.activeWindow(),
+                                                       self.tr("Choose image to upload"),
+                                                       filter='TIF files (*.tif *.tiff)')[0]
+        else:  # mosaic from layers
+            image_paths = self._choose_raster_layer_paths()
+        if image_paths:
+            self.service.create_mosaic_from_images(mosaic, image_paths)
+
+    def update_mosaic(self, *args):
+        mosaic = self.service.selected_mosaic()
+        if not mosaic:
+            return
+        dialog = UpdateMosaicDialog(self.dlg)
+        dialog.accepted.connect(
+            lambda: self.service.update_mosaic(mosaic.id, dialog.mosaic()))
+        dialog.setup(mosaic)
+        dialog.deleteLater()
+
+    def confirm_mosaic_deletion(self):
+        mosaics = self.service.selected_mosaics()
+        if not mosaics:
+            return
+        names = [mosaic.name for mosaic in mosaics]
+        if len(names) == 1:
+            message = self.tr("<center>Delete imagery collection <b>'{name}'</b>?").format(name=names[0])
+        elif len(names) <= 3:
+            message = self.tr("<center>Delete following imagery collections:<br><b>'{names}'</b>?"
+                              ).format(names="', <br>'".join(names))
+        else:
+            message = self.tr("<center>Delete <b>{len}</b> imagery collections?").format(len=len(names))
+        if self._confirm(message):
+            self.service.delete_mosaics(response=None, mosaics=mosaics, deleted=[], failed=[])
+
+    # ---------- image dialogs ----------
+
+    def upload_images_to_mosaic(self, *args):
+        if not self.service.selected_mosaic():
+            alert(self.tr("Please, select existing imagery collection"))
+            return
+        image_paths = QFileDialog.getOpenFileNames(QApplication.activeWindow(),
+                                                   self.tr("Choose images to upload"),
+                                                   filter='TIF files (*.tif *.tiff)')[0]
+        if image_paths:
+            self.service.upload_images_to_mosaic(image_paths)
+
+    def choose_raster_layers(self, *args):
+        paths = self._choose_raster_layer_paths()
+        if paths:
+            self.service.upload_raster_layers_to_mosaic(paths)
+
+    def _choose_raster_layer_paths(self):
+        """Open the raster-layer picker and return the chosen files' paths (empty if cancelled)."""
+        dialog = UploadRasterLayersDialog(self.dlg)
+        paths = []
+
+        def collect():
+            for item in dialog.listWidget.selectedItems():
+                paths.append(item.data(Qt.UserRole))
+
+        dialog.accepted.connect(collect)
+        layers = [layer for layer in self.app_context.project.mapLayers().values()
+                  if Path(layer.source()).suffix.lower() in ['.tif', '.tiff']]
+        dialog.setup(layers)
+        dialog.deleteLater()
+        return paths
+
+    def show_rename_image_dialog(self, *args):
+        image = self.service.selected_image()
+        if not image:
+            return
+        dialog = RenameImageDialog(self.dlg)
+        dialog.accepted.connect(lambda: self.service.rename_image(image.id, dialog.image()))
+        dialog.setup(image)
+        dialog.deleteLater()
+
+    def confirm_image_deletion(self):
+        mosaic = self.service.selected_mosaic()
+        images = self.service.selected_images()
+        if not images:
+            return
+        names = [image.filename for image in images]
+        if len(names) == 1:
+            message = self.tr("<center>Delete image <b>'{name}'</b> from '{mosaic}' imagery collection?"
+                              ).format(name=names[0], mosaic=mosaic.name)
+        elif len(names) <= 3:
+            message = self.tr("<center>Delete following images from '{mosaic}' imagery collection:<br><b>'{names}'</b>?"
+                              ).format(names="', <br>'".join(names), mosaic=mosaic.name)
+        else:
+            message = self.tr("<center>Delete <b>{len}</b> images from '{mosaic}' imagery collection?"
+                              ).format(len=len(names), mosaic=mosaic.name)
+        if self._confirm(message):
+            self.service.delete_selected_images()
+
+    def image_info(self, *args):
+        image = self.service.selected_image()
+        if image:
+            self.view.full_image_info(image=image)
+
+    # ---------- download save prompt ----------
+
+    def _prompt_save_download(self, url: str, suggested_filename: str):
+        save_path, _ = QFileDialog.getSaveFileName(
+            QApplication.activeWindow(),
+            self.tr("Save image as"),
+            suggested_filename,
+            "TIF files (*.tif *.tiff);;All files (*)")
+        if save_path:
+            self.service.save_downloaded(url, save_path)
+
+    def _confirm(self, message: str) -> bool:
+        box = QMessageBox(QMessageBox.Question, "Mapflow", message, parent=QApplication.activeWindow())
+        box.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
+        return box.exec() == QMessageBox.Ok

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -3,38 +3,78 @@ from pathlib import Path
 from uuid import UUID
 import json
 
-from PyQt5.QtCore import QObject, QUrl, pyqtSignal, Qt
+from PyQt5.QtCore import QObject, QUrl, pyqtSignal
 from PyQt5.QtGui import QImage
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
-from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog, QAbstractItemView
 from qgis.core import QgsRasterLayer
 
 from ...dialogs.main_dialog import MainDialog
-from ...dialogs.mosaic_dialog import CreateMosaicDialog, UpdateMosaicDialog
-from ...dialogs.image_dialog import RenameImageDialog
-from ...dialogs.upload_raster_layer_dialog import UploadRasterLayersDialog
-from ...dialogs.error_message_widget import ErrorMessageWidget
 from ...schema.data_catalog import PreviewSize, MosaicReturnSchema, ImageReturnSchema, UserLimitSchema
 from ...schema import MyImageryParams
 from ..api.data_catalog_api import DataCatalogApi
-from ..view.data_catalog_view import DataCatalogView
+from ..service.alert_service import alert
 from ...http import Http
 from ...functional import helpers
 from ...functional.app_context import AppContext
 from ...config import Config
-from ...model.provider import MyImageryProvider
 
 
 class DataCatalogService(QObject):
     """
-    A service for querying mapflow data catalog.
-    It depends on DataCatalogApi to send requests, and implements the loginc behind the data catalog use.
-    Where possible, the service specifies api error handlers/callbacks.
+    A service for querying mapflow data catalog: requests, response parsing and the mosaic/image
+    state. It holds no widget — the My Imagery panel is `DataCatalogView`, driven by
+    `DataCatalogController`, which this service *tells* what changed (the signals below) and is
+    *told* the current selection (`set_selected_*`). See `spec/007_architecture.md` § Services.
 
-    It also stores the mosaic in memory as a dict with mosaic_id as the key for access from other places.
-    todo: maybe move storage to some repo/localstorage layer?
+    It stores the mosaics as a dict keyed by id for access from other places.
     """
     mosaicsUpdated = pyqtSignal()
+
+    # ---------- what the My Imagery panel must show (announced, never drawn) ----------
+    #: The mosaic list changed: render it and clear the selection.
+    mosaicsChanged = pyqtSignal(object)
+    #: A single mosaic was (re)fetched: render the list and reselect its cell.
+    mosaicReselected = pyqtSignal(object, object)
+    #: The open mosaic's images changed.
+    imagesChanged = pyqtSignal(object)
+    #: (mosaic, images) for the info panel.
+    mosaicInfoChanged = pyqtSignal(object, object)
+    #: A preview image (QImage) arrived.
+    previewChanged = pyqtSignal(object)
+    #: (images count, current index) for the ‹ › preview controls.
+    previewNavChanged = pyqtSignal(int, int)
+    #: (index, count) for the "n/total" preview label.
+    imageNumberChanged = pyqtSignal(int, int)
+    #: A rename round trip finished: update the row for this image.
+    imageRenamedInTable = pyqtSignal(object)
+    #: (used bytes, free bytes) for the storage label. `object`, not `int`: byte counts run into
+    #: the billions and PyQt's `int` is 32-bit, which would wrap a multi-GB quota to a negative.
+    storageChanged = pyqtSignal(object, object)
+    #: Standalone selection clears (no reload).
+    mosaicSelectionCleared = pyqtSignal()
+    imageSelectionCleared = pyqtSignal()
+    #: Reopening a processing's My Imagery source: select the mosaic cell / bind the image row.
+    sourceMosaicSelected = pyqtSignal(object)
+    sourceImageReady = pyqtSignal(object)
+    #: 'Go to source' asked to focus the My Imagery tab for these params.
+    mySourceShown = pyqtSignal(object)
+    #: An error handler wants the panel back on the mosaics table.
+    catalogResetToMosaics = pyqtSignal()
+    #: A source image/mosaic was not found (summary text for the error widget).
+    imageSourceError = pyqtSignal(str)
+    #: A download URL and its suggested filename are ready for a save-as prompt.
+    downloadUrlReady = pyqtSignal(str, str)
+    #: An upload finished — bring the plugin window back to the front.
+    dialogShouldRaise = pyqtSignal()
+    #: A catalog action needs the data source switched to My Imagery (carries the provider list).
+    switchToMyImageryRequested = pyqtSignal(object)
+
+    #: The current table selections, pushed from the controller (a service reads no table).
+    _selected_mosaic_ids = ()
+    _selected_image_ids = ()
+    #: Which catalog table is showing (mosaics vs images), pushed from the controller — the
+    #: service branches on it in poll/refresh paths but may not read the stacked layout.
+    _mosaic_table_visible = True
 
     def __init__(self,
                  http: Http,
@@ -45,13 +85,14 @@ class DataCatalogService(QObject):
                  plugin_version,
                  app_context: AppContext):
         super().__init__()
+        #: Held only to build `DataCatalogApi(dlg=…)`; the service itself touches no widget. The
+        #: dlg parameter and the api's own use of it are removed in C2.6.
         self.dlg = dlg
         self.iface = iface
         self.app_context = app_context
         self.result_loader = result_loader
         self.plugin_version = plugin_version
         self.api = DataCatalogApi(http=http, server=server, dlg=dlg, iface=iface, result_loader=self.result_loader, plugin_version=self.plugin_version)
-        self.view = DataCatalogView(dlg=dlg, app_context=self.app_context)
         self.mosaics = {}
         self.images = []
         self.image_max_size_pixels = Config.MAX_FILE_SIZE_PIXELS
@@ -59,66 +100,56 @@ class DataCatalogService(QObject):
         self.free_storage = None
         self.preview_idx = 0
 
+    # ---------- pushed state (the controller tells the service, the service never reads a widget) ----------
+
+    def set_selected_mosaic_ids(self, ids) -> None:
+        self._selected_mosaic_ids = tuple(ids or ())
+
+    def set_selected_image_ids(self, ids) -> None:
+        self._selected_image_ids = tuple(ids or ())
+
+    def set_mosaic_table_visible(self, visible: bool) -> None:
+        self._mosaic_table_visible = bool(visible)
+
 
     # Mosaics CRUD
-    def create_mosaic(self):
-        dialog = CreateMosaicDialog(self.dlg)
-        dialog.accepted.connect(lambda: self.create_mosaic_from_options(dialog))
-        dialog.setup()
-        dialog.deleteLater()
-    
-    def create_mosaic_from_options(self, mosaic_dialog: CreateMosaicDialog):
-        mosaic = mosaic_dialog.mosaic()
-        if mosaic_dialog.createMosaicCombo.currentIndex() == 0: # empty mosaic
-            self.api.create_mosaic(mosaic,callback=self.create_mosaic_callback)
-        else:
-            if mosaic_dialog.createMosaicCombo.currentIndex() == 1: # mosaic from files
-                image_paths = QFileDialog.getOpenFileNames(QApplication.activeWindow(), self.tr("Choose image to upload"), 
-                                                           filter='TIF files (*.tif *.tiff)')[0]
-            else: # mosaic from layers
-                dialog = UploadRasterLayersDialog(self.dlg)
-                # Get layers paths on accepting layers dialog
-                image_paths = []
-                def get_paths():
-                    for item in dialog.listWidget.selectedItems():
-                        image_paths.append(item.data(Qt.UserRole))
-                dialog.accepted.connect(get_paths)
-                # Show all acceptable raster layers in dialog
-                layers = []
-                for layer in self.app_context.project.mapLayers().values():
-                    if Path(layer.source()).suffix.lower() in ['.tif', '.tiff']:
-                        layers.append(layer)
-                dialog.setup(layers)
-                dialog.deleteLater()
-            if image_paths:
-                self.api.create_mosaic_from_images(mosaic, 
-                                                   callback=self.create_mosaic_from_images_callback,
-                                                   callback_kwargs={'image_paths' : image_paths,
-                                                                    'mosaic_name' : mosaic.name},
-                                                   error_handler=self.create_mosaic_from_images_error_handler,
-                                                   error_handler_kwargs={'image_paths' : image_paths,
-                                                                         'mosaic_name' : mosaic.name},
-                                                   image_paths=image_paths)            
-    
+    #
+    # The dialogs (create / update / confirm-delete) are `DataCatalogController`'s; a service
+    # builds none. What arrives here is the assembled request, and what leaves is a signal.
+
+    def create_mosaic(self, mosaic):
+        """Create an empty mosaic from an assembled request object."""
+        self.api.create_mosaic(mosaic, callback=self.create_mosaic_callback)
+
+    def create_mosaic_from_images(self, mosaic, image_paths: List):
+        """Create a mosaic and upload the chosen images into it."""
+        self.api.create_mosaic_from_images(mosaic,
+                                           callback=self.create_mosaic_from_images_callback,
+                                           callback_kwargs={'image_paths': image_paths,
+                                                            'mosaic_name': mosaic.name},
+                                           error_handler=self.create_mosaic_from_images_error_handler,
+                                           error_handler_kwargs={'image_paths': image_paths,
+                                                                 'mosaic_name': mosaic.name},
+                                           image_paths=image_paths)
+
     def create_mosaic_callback(self, response: QNetworkReply):
-        self.get_mosaics()
-        self.view.enable_mosaic_images_preview()
-        self.dlg.mosaicTable.clearSelection()
-    
+        self.get_mosaics()  # mosaicsChanged clears the selection
+        self.previewNavChanged.emit(0, 0)
+
     def create_mosaic_from_images_callback(self, response: QNetworkReply, image_paths: List, mosaic_name: str):
         mosaic_id = json.loads(response.readAll().data())['mosaic_id']
-        self.upload_images(response=None, 
+        self.upload_images(response=None,
                            mosaic_id=mosaic_id, mosaic_name=mosaic_name,
                            image_paths=image_paths[1:], uploaded=[image_paths[0]], failed=[])
-    
-    def create_mosaic_from_images_error_handler(self, 
-                                                response: QNetworkReply, 
-                                                image_paths: List, 
+
+    def create_mosaic_from_images_error_handler(self,
+                                                response: QNetworkReply,
+                                                image_paths: List,
                                                 mosaic_name: str):
-        self.view.alert(self.tr("<center>Creation of imagery collection '{mosaic_name}' failed"
-                                "<br>while trying to upload '{image}'").format(mosaic_name=mosaic_name,
-                                                                           image=Path(image_paths[0]).name))
-        self.dlg.mosaicTable.clearSelection()
+        alert(self.tr("<center>Creation of imagery collection '{mosaic_name}' failed"
+                      "<br>while trying to upload '{image}'").format(mosaic_name=mosaic_name,
+                                                                     image=Path(image_paths[0]).name))
+        self.mosaicSelectionCleared.emit()
 
     def get_mosaics(self):
         self.api.get_mosaics(callback=self.get_mosaics_callback)
@@ -129,9 +160,8 @@ class DataCatalogService(QObject):
         for item in data:
             mosaic = MosaicReturnSchema.from_dict(item)
             self.mosaics[mosaic.id] = mosaic
-        self.view.display_mosaics(list(self.mosaics.values()))
+        self.mosaicsChanged.emit(list(self.mosaics.values()))
         self.mosaicsUpdated.emit()
-        self.dlg.mosaicTable.clearSelection()
         self.app_context.mosaics = self.mosaics
 
     def get_mosaic(self, mosaic_id: UUID):
@@ -140,42 +170,34 @@ class DataCatalogService(QObject):
 
     def get_mosaic_callback(self, response: QNetworkReply):
         mosaic = MosaicReturnSchema.from_dict(json.loads(response.readAll().data()))
-        # Temporary forbit selection to prevent weird bug
-        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection)
         self.mosaics.update({mosaic.id: mosaic})
         self.mosaicsUpdated.emit()
-        self.view.display_mosaics(list(self.mosaics.values()))
-        # Allow selection back
-        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.ExtendedSelection) 
-        self.view.select_mosaic_cell(mosaic.id)
+        # The list is redrawn and this mosaic's cell reselected; the view guards the reselect
+        # against the selection-mode bug that the explicit No/Extended dance used to.
+        self.mosaicReselected.emit(list(self.mosaics.values()), mosaic.id)
         self.app_context.mosaics = self.mosaics
 
-    def update_mosaic(self):
-        mosaic = self.selected_mosaic()
-        dialog = UpdateMosaicDialog(self.dlg)
-        dialog.accepted.connect(lambda: self.api.update_mosaic(mosaic_id=mosaic.id, 
-                                                               mosaic=dialog.mosaic(), 
-                                                               callback=self.update_mosaic_callback, 
-                                                               callback_kwargs={'mosaic': mosaic}))
-        dialog.setup(mosaic)
-        dialog.deleteLater()
+    def update_mosaic(self, mosaic_id, mosaic):
+        """Apply an edited mosaic (the dialog was read by the controller)."""
+        self.api.update_mosaic(mosaic_id=mosaic_id,
+                               mosaic=mosaic,
+                               callback=self.update_mosaic_callback,
+                               callback_kwargs={'mosaic_id': mosaic_id})
 
-    def update_mosaic_callback(self, response: QNetworkReply, mosaic: MosaicReturnSchema):
-        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection)
-        self.dlg.mosaicTable.clearSelection()
-        self.get_mosaic(mosaic.id)
+    def update_mosaic_callback(self, response: QNetworkReply, mosaic_id):
+        self.mosaicSelectionCleared.emit()
+        self.get_mosaic(mosaic_id)
 
-    def delete_mosaics(self, 
-                       response: QNetworkReply, 
+    def delete_mosaics(self,
+                       response: QNetworkReply,
                        mosaics: List[MosaicReturnSchema],
-                       deleted: List[str], 
+                       deleted: List[str],
                        failed: List[str]):
         if len(mosaics) == 0:
             if failed:
                 self.api.delete_mosaic_error_handler(mosaics=failed)
-            self.get_mosaics()
-            self.view.enable_mosaic_images_preview()
-            self.dlg.mosaicTable.clearSelection()
+            self.get_mosaics()  # mosaicsChanged clears the selection
+            self.previewNavChanged.emit(0, 0)
         else:
             mosaic_to_delete = mosaics[0]
             non_deleted = mosaics[1:]
@@ -190,73 +212,21 @@ class DataCatalogService(QObject):
                                                          'failed': list(failed) + [mosaic_to_delete.name]},
                                   )
 
-    def confirm_mosaic_deletion(self):
-        mosaics = self.selected_mosaics()
-        if not mosaics:
-            return
-        mosaic_names = [mosaic.name for mosaic in mosaics]
-        if len(mosaic_names) == 1:
-            message = self.tr("<center>Delete imagery collection <b>'{name}'</b>?"
-                             ).format(name=mosaic_names[0])
-        elif len(mosaic_names) <= 3:
-            message = self.tr("<center>Delete following imagery collections:<br><b>'{names}'</b>?"
-                             ).format(names="', <br>'".join(mosaic_names))
-        else:
-            message = self.tr("<center>Delete <b>{len}</b> imagery collections?"
-                             ).format(len=len(mosaic_names))
-        box = QMessageBox(QMessageBox.Question, "Mapflow", message, parent=QApplication.activeWindow())
-        box.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
-        box_exec = box.exec()
-        if box_exec == QMessageBox.Ok:
-            self.delete_mosaics(response = None, mosaics=mosaics, deleted=[], failed=[])
-
-    def on_mosaic_selection(self, mosaic: MosaicReturnSchema):
-        # Clear previous images details
-        self.dlg.imageTable.clearSelection()
-        self.dlg.imageTable.setRowCount(0)
-        # Selecting a mosaic clears the image selection, so drop the cached image too — otherwise
-        # a stale selected_image would still feed imageIds into the next processing (a mosaic run
-        # would wrongly reuse the previously processed image).
-        self.app_context.selected_image = None
-        # Don't send GET requests if first selected mosaic didn't change
-        selected_mosaics = self.dlg.mosaicTable.selectedIndexes()
-        if len(selected_mosaics) > 1 and self.dlg.selected_mosaic_cell == selected_mosaics[0]:
-            pass
-        else:
-            self.dlg.selected_mosaic_cell = self.dlg.mosaicTable.selectedIndexes()[0]
-            self.get_mosaic_images(mosaic.id)
-        self.view.add_mosaic_cell_buttons()
-        self.view.show_mosaic_info(mosaic.name)
-
-
     # Images CRUD
-    def upload_images_to_mosaic(self):
+    def upload_images_to_mosaic(self, image_paths):
+        """Upload chosen image files into the selected mosaic (the file dialog is the
+        controller's). No-op without a selection or without files."""
         mosaic = self.selected_mosaic()
-        if not mosaic:
-            self.view.alert(self.tr("Please, select existing imagery collection"))
+        if not mosaic or not image_paths:
             return
-        image_paths = QFileDialog.getOpenFileNames(QApplication.activeWindow(), self.tr("Choose images to upload"), 
-                                                   filter='TIF files (*.tif *.tiff)')[0]
-        if image_paths:
-            self.upload_images(response=None, 
-                               mosaic_id=mosaic.id, mosaic_name=mosaic.name, 
-                               image_paths=image_paths, uploaded=[], failed=[])
+        self.upload_images(response=None,
+                           mosaic_id=mosaic.id, mosaic_name=mosaic.name,
+                           image_paths=image_paths, uploaded=[], failed=[])
 
     def upload_raster_layers_to_mosaic(self, layers_paths):
         mosaic = self.selected_mosaic()
-        if layers_paths:
+        if mosaic and layers_paths:
             self.upload_images(response=None, mosaic_id=mosaic.id, mosaic_name=mosaic.name, image_paths=layers_paths, uploaded=[], failed=[])
-
-    def choose_raster_layers(self):
-        dialog = UploadRasterLayersDialog(self.dlg)
-        dialog.accepted.connect(lambda: dialog.get_selected_rasters_list(callback=self.upload_raster_layers_to_mosaic))
-        # Show all acceptable (TIFF) raster layers
-        layers = []
-        for layer in self.app_context.project.mapLayers().values():
-            if Path(layer.source()).suffix.lower() in ['.tif', '.tiff']:
-                layers.append(layer)
-        dialog.setup(layers)
-        dialog.deleteLater()
 
     def upload_images(self,
                       response: QNetworkReply,
@@ -267,8 +237,8 @@ class DataCatalogService(QObject):
                       failed: Sequence[Union[Path, str]]):
         if len(image_paths) == 0:
             self.get_mosaic(mosaic_id)
-            self.dlg.mosaicTable.clearSelection()
-            self.dlg.raise_()
+            self.mosaicSelectionCleared.emit()
+            self.dialogShouldRaise.emit()
             self.mosaicsUpdated.emit()
             if failed:
                 self.api.upload_image_error_handler(response=response, mosaic_name=mosaic_name, image_paths=failed)
@@ -288,7 +258,7 @@ class DataCatalogService(QObject):
                                   " have size less than {size} pixels"
                                   " and file size less than {memory}").format(size=self.image_max_size_pixels,
                                                                               memory=helpers.get_readable_size(self.image_max_size_bytes))
-                self.view.alert(self.tr("<center><b>Error uploading '{name}'</b>").format(name=Path(image_to_upload).name)+"<br>"+message)
+                alert(self.tr("<center><b>Error uploading '{name}'</b>").format(name=Path(image_to_upload).name)+"<br>"+message)
                 return
             # Check if user has enough stogage
             image_size=Path(image_to_upload).stat().st_size
@@ -326,21 +296,21 @@ class DataCatalogService(QObject):
 
     def get_mosaic_images_callback(self, response: QNetworkReply):
         self.images = [ImageReturnSchema.from_dict(data) for data in json.loads(response.readAll().data())]
-        self.view.display_images(self.images)
-        if self.view.mosaic_table_visible:
-            self.view.display_mosaic_info(self.selected_mosaic(), self.images)
+        self.imagesChanged.emit(self.images)
+        if self._mosaic_table_visible:
+            self.mosaicInfoChanged.emit(self.selected_mosaic(), self.images)
             self.preview_idx = 0
             if len(self.images) > 0:
                 self.get_image_preview_s(self.images[self.preview_idx])
             else:
-                self.view.enable_mosaic_images_preview(len(self.images), self.preview_idx)
+                self.previewNavChanged.emit(len(self.images), self.preview_idx)
         self.app_context.images = self.images
-    
+
     def get_next_preview(self):
         try:
             self.preview_idx += 1
             self.get_image_preview_s(self.images[self.preview_idx])
-            self.view.display_image_number(self.preview_idx, len(self.images))
+            self.imageNumberChanged.emit(self.preview_idx, len(self.images))
         except IndexError:
             pass
 
@@ -348,7 +318,7 @@ class DataCatalogService(QObject):
         try:
             self.preview_idx += -1
             self.get_image_preview_s(self.images[self.preview_idx])
-            self.view.display_image_number(self.preview_idx, len(self.images))
+            self.imageNumberChanged.emit(self.preview_idx, len(self.images))
         except IndexError:
             pass
 
@@ -364,9 +334,9 @@ class DataCatalogService(QObject):
             if failed:
                 self.api.delete_image_error_handler(image_paths=failed)
             mosaic_id = self.selected_mosaic().id
-            self.dlg.mosaicTable.clearSelection()
+            self.mosaicSelectionCleared.emit()
             self.get_mosaic(mosaic_id)
-            self.dlg.imageTable.clearSelection()
+            self.imageSelectionCleared.emit()
         else:
             image_to_delete = images[0]
             non_deleted = images[1:] 
@@ -381,45 +351,12 @@ class DataCatalogService(QObject):
                                                         'failed': list(failed) + [image_to_delete.filename]},
                                  )
             
-    def confirm_image_deletion(self):
-        mosaic = self.selected_mosaic()
+    def delete_selected_images(self):
+        """Delete the selected images (the confirmation dialog is the controller's)."""
         images = self.selected_images()
         if not images:
             return
-        image_names = [image.filename for image in images]
-        if len(image_names) == 1:
-            message = self.tr("<center>Delete image <b>'{name}'</b> from '{mosaic}' imagery collection?"
-                             ).format(name=image_names[0], mosaic=mosaic.name)
-        elif len(image_names) <= 3:
-            message = self.tr("<center>Delete following images from '{mosaic}' imagery collection:<br><b>'{names}'</b>?"
-                             ).format(names="', <br>'".join(image_names), mosaic=mosaic.name)
-        else:
-            message = self.tr("<center>Delete <b>{len}</b> images from '{mosaic}' imagery collection?"
-                             ).format(len=len(image_names), mosaic=mosaic.name)
-        box = QMessageBox(QMessageBox.Question, "Mapflow", message, parent=QApplication.activeWindow())
-        box.setStandardButtons(QMessageBox.Cancel | QMessageBox.Ok)
-        box_exec = box.exec()
-        if box_exec == QMessageBox.Ok:
-            self.delete_images(response = None, images=images, deleted=[], failed=[])
-
-    def on_image_selection(self, image: ImageReturnSchema):
-        selected_images = self.dlg.imageTable.selectedIndexes()
-        selected_mosaics = self.dlg.mosaicTable.selectedIndexes()
-        if not selected_mosaics or (len(selected_images) > 1 and self.dlg.selected_image_cell == selected_images[0]):
-            pass
-        else:
-            self.dlg.selected_mosaic_cell = self.dlg.mosaicTable.selectedIndexes()[0]
-            self.get_image_preview_s(image)
-        self.view.show_image_info(image)
-        self.view.add_image_cell_buttons()
-        self.app_context.selected_image = image
-        return image
-
-    def image_info(self):
-        image = self.selected_image()
-        if not image:
-            return
-        self.view.full_image_info(image=image)
+        self.delete_images(response=None, images=images, deleted=[], failed=[])
 
     def get_image_preview_s(self,
                             image: ImageReturnSchema):
@@ -429,9 +366,9 @@ class DataCatalogService(QObject):
 
     def get_image_preview_s_callback(self, response: QNetworkReply):
         image = QImage.fromData(response.readAll().data())
-        self.view.show_preview_s(image)
-        if self.view.mosaic_table_visible:
-            self.view.enable_mosaic_images_preview(len(self.images), self.preview_idx)
+        self.previewChanged.emit(image)
+        if self._mosaic_table_visible:
+            self.previewNavChanged.emit(len(self.images), self.preview_idx)
 
     def rename_image_callback(self, response: QNetworkReply):
         new_image = ImageReturnSchema.from_dict(json.loads(response.readAll().data()))
@@ -439,15 +376,8 @@ class DataCatalogService(QObject):
             if image.id == new_image.id:
                 image.filename = new_image.filename
                 break
-        self.view.rename_image_in_table(new_image)
+        self.imageRenamedInTable.emit(new_image)
         self.iface.messageBar().pushMessage("Mapflow", "Image renamed")
-
-    def show_rename_image_dialog(self):
-        image = self.selected_image()
-        dialog = RenameImageDialog(self.dlg)
-        dialog.accepted.connect(lambda:self.rename_image(image.id, dialog.image()))
-        dialog.setup(image)
-        dialog.deleteLater()
 
     def rename_image(self, image_id, new_name: str):
         if not new_name or len(new_name) > 255:
@@ -471,19 +401,13 @@ class DataCatalogService(QObject):
         download_url = data.get("download_url")
         suggested_filename = data.get("filename", "image.tif")
         if not download_url:
-            self.view.alert(self.tr("Download URL not available"))
+            alert(self.tr("Download URL not available"))
             return
-        save_path, _ = QFileDialog.getSaveFileName(
-            QApplication.activeWindow(),
-            self.tr("Save image as"),
-            suggested_filename,
-            "TIF files (*.tif *.tiff);;All files (*)"
-        )
-        if not save_path:
-            return
-        self._download_file_from_url(download_url, save_path)
+        # The save-as prompt is the controller's; it calls back into `save_downloaded`.
+        self.downloadUrlReady.emit(download_url, suggested_filename)
 
-    def _download_file_from_url(self, url: str, save_path: str):
+    def save_downloaded(self, url: str, save_path: str):
+        """Fetch `url` and write it to `save_path` (the path came from the controller's dialog)."""
         request = QNetworkRequest(QUrl(url))
         nam = self.api.http.nam
         reply = nam.get(request)
@@ -491,7 +415,7 @@ class DataCatalogService(QObject):
 
     def _save_downloaded_file(self, reply: QNetworkReply, save_path: str):
         if reply.error() != QNetworkReply.NoError:
-            self.view.alert(self.tr("Failed to download image: {}").format(reply.errorString()))
+            alert(self.tr("Failed to download image: {}").format(reply.errorString()))
             reply.deleteLater()
             return
         data = reply.readAll().data()
@@ -500,53 +424,12 @@ class DataCatalogService(QObject):
                 f.write(data)
             self.iface.messageBar().pushMessage("Mapflow", self.tr("Image saved to {}").format(save_path))
         except OSError as e:
-            self.view.alert(self.tr("Failed to save file: {}").format(str(e)))
+            alert(self.tr("Failed to save file: {}").format(str(e)))
         reply.deleteLater()
 
-    # Functions that depend on mosaic or image selection
-    def add_mosaic_or_image(self):
-        if self.view.mosaic_table_visible:
-            self.create_mosaic()
-        else:
-            self.upload_images_to_mosaic()
-
-    def delete_mosaic_or_image(self):
-        image = self.selected_image()
-        mosaic = self.selected_mosaic()
-        if image:
-            self.confirm_image_deletion()
-        elif mosaic:
-            self.confirm_mosaic_deletion()
-
-    def switch_to_mosaics_table(self):
-        mosaic = self.selected_mosaic()
-        self.view.show_mosaics_table(mosaic.name)
-        self.view.display_mosaic_info(mosaic, self.images)
-        self.get_mosaic_images(mosaic.id)
-
-    def check_image_selection(self):
-        image = self.selected_image()
-        if image:
-            self.on_image_selection(image)
-        else:
-            # Keep the cached image in sync with the table: deselecting must not leave a stale
-            # selected_image that would be picked up when building processing params.
-            self.app_context.selected_image = None
-            self.view.clear_image_info()
-
-    def check_mosaic_selection(self):
-        mosaic = self.selected_mosaic()
-        if mosaic:
-            self.on_mosaic_selection(mosaic)
-        else:
-            self.view.clear_mosaic_info()
-    
     def refresh_catalog(self):
-        if self.view.mosaic_table_visible:
-            self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection) 
-            self.get_mosaics()
-            self.dlg.mosaicTable.clearSelection()
-            self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        if self._mosaic_table_visible:
+            self.get_mosaics()  # mosaicsChanged clears the selection
         else:
             if self.selected_mosaic():
                 self.get_mosaic_images(self.selected_mosaic().id)
@@ -565,12 +448,11 @@ class DataCatalogService(QObject):
             self.image_max_size_bytes = int(data_limit.maxUploadFileSize)
         if data_limit.memoryLimit:
             self.free_storage = free
-        self.view.show_storage(taken, free)
+        self.storageChanged.emit(taken, free)
 
-    # Selection
+    # Selection (resolved from ids pushed by the controller)
     def selected_mosaics(self, limit=None) -> List[MosaicReturnSchema]:
-        ids = self.view.selected_mosaic_ids(limit=limit)
-        # limit None will give full selection
+        ids = self._selected_mosaic_ids[:limit]
         mosaics = (self.mosaics.get(id) for id in ids)
         return [m for m in mosaics if m is not None]
 
@@ -580,9 +462,9 @@ class DataCatalogService(QObject):
             return None
         self.app_context.selected_mosaic = first[0]
         return first[0]
-        
+
     def selected_images(self, limit=None) -> List[MosaicReturnSchema]:
-        ids = self.view.selected_images_indecies(limit=limit)
+        ids = self._selected_image_ids[:limit]
         images = [i for i in self.images if i.id in ids]
         return images
 
@@ -594,33 +476,28 @@ class DataCatalogService(QObject):
 
     # Provider
     def set_catalog_provider(self, providers):
-        """ Sets current provider to 'My imagery' if catalog table cell was clicked.
-        """
-        # Check current provider
-        current_provider = providers[self.dlg.providerIndex()]
-        my_imagery_index = None
-        if not isinstance (current_provider, MyImageryProvider):
-            # Get index of My imagery provider
-            for index in range(len(providers)):
-                provider = providers[index]
-                if isinstance(provider, MyImageryProvider):
-                    my_imagery_index = index
-            # Set My imagery data source
-            if my_imagery_index:
-                self.dlg.sourceCombo.setCurrentIndex(my_imagery_index)
+        """Ask the panel to switch the data source to 'My imagery'.
+
+        Called by other services (area calculator, provider), so it cannot read the source combo
+        itself — deciding whether a switch is needed and doing it is the controller's, off this
+        signal. The provider list is carried because only the caller has it."""
+        self.switchToMyImageryRequested.emit(providers)
+
+    def select_mosaic_cell(self, mosaic_id):
+        """Ask the panel to select a mosaic's cell. Called by other services (a service reaches
+        no view of its own, nor another service's)."""
+        self.sourceMosaicSelected.emit(mosaic_id)
 
     def show_my_imagery_source(self,
                                source_params: MyImageryParams):
-        self.dlg.mosaicTable.clearSelection()
         if source_params.myImagery.imageIds: # if the source was an image:
             image_id = source_params.myImagery.imageIds[0] # get full image info to obtain mosaic_id
             self.get_image(image_id)
-        self.view.show_my_imagery_source(source_params)
+        self.mySourceShown.emit(source_params)
 
     def get_image_callback(self, response: QNetworkReply):
         image = ImageReturnSchema.from_dict(json.loads(response.readAll().data()))
-        self.view.select_mosaic_cell(image.mosaic_id)
-        self.view.show_source_image_connection = self.dlg.imageTableFilled.connect(lambda: self.view.select_image_cell(image.id))
+        self.sourceImageReady.emit(image)
 
     def get_image_error_handler(self, response: QNetworkReply) -> None:
         response_data = json.loads(response.readAll().data())
@@ -629,9 +506,8 @@ class DataCatalogService(QObject):
             error_summary = self.tr("Source imagery collection with id '{}' was not found ").format(error_params['uid'])
         else:
             error_summary = self.tr("Source image with id '{}' was not found in any of your imagery collections").format(error_params['uid'])
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=error_summary).show()
-        self.dlg.stackedLayout.setCurrentIndex(0)
+        self.imageSourceError.emit(error_summary)
+        self.catalogResetToMosaics.emit()
         for key in self.app_context.allow_enable_processing:
             self.app_context.allow_enable_processing[key] = True
 

--- a/mapflow/functional/service/provider_service.py
+++ b/mapflow/functional/service/provider_service.py
@@ -444,7 +444,7 @@ class ProviderService(QObject):
             image_id = provider.myImagery.imageIds[0]
             self.data_catalog_service.get_image(image_id)
         elif provider.myImagery.mosaicId:
-            self.data_catalog_service.view.select_mosaic_cell(provider.myImagery.mosaicId)
+            self.data_catalog_service.select_mosaic_cell(provider.myImagery.mosaicId)
         my_imagery_tab = self.dlg.tabWidget.findChild(QWidget, "catalogTab") 
         self.dlg.tabWidget.setCurrentWidget(my_imagery_tab)
         self.data_catalog_service.set_catalog_provider(self.providers)

--- a/mapflow/functional/view/data_catalog_view.py
+++ b/mapflow/functional/view/data_catalog_view.py
@@ -341,6 +341,36 @@ class DataCatalogView(QObject):
                 for row in selected_rows[:limit]]
         return pids
     
+    def display_mosaics_and_reselect(self, mosaics: list, mosaic_id):
+        """Redraw the mosaic list and reselect one cell. Selection is forbidden across the redraw
+        to dodge a Qt selection-model bug that the plain display path can trigger."""
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.NoSelection)
+        self.display_mosaics(mosaics)
+        self.dlg.mosaicTable.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.select_mosaic_cell(mosaic_id)
+
+    def clear_mosaic_selection(self):
+        self.dlg.mosaicTable.clearSelection()
+
+    def clear_image_selection(self):
+        self.dlg.imageTable.clearSelection()
+
+    def clear_image_table(self):
+        """Selecting a mosaic wipes the image table before its images are fetched."""
+        self.dlg.imageTable.clearSelection()
+        self.dlg.imageTable.setRowCount(0)
+
+    def reset_to_mosaics_table(self):
+        self.dlg.stackedLayout.setCurrentIndex(0)
+
+    def raise_dialog(self):
+        self.dlg.raise_()
+
+    def bind_source_image(self, image_id):
+        """After the image table refills, select the source image's row (a one-shot connection)."""
+        self.show_source_image_connection = self.dlg.imageTableFilled.connect(
+            lambda: self.select_image_cell(image_id))
+
     def select_mosaic_cell(self, mosaic_id):
         try:
             self.show_mosaics_table(None)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -37,6 +37,7 @@ from .functional.service.search_service import SearchService
 from .functional.view.aoi_view import AoiView
 from .functional.view.search_view import SearchView
 from .functional.view.processing_view import ProcessingView
+from .functional.view.data_catalog_view import DataCatalogView
 from .functional.service import (DataCatalogService,
                                  ProcessingService,
                                  ProjectService,
@@ -207,6 +208,15 @@ class Mapflow(QObject):
                                                     self.result_loader,
                                                     self.app_context.plugin_version,
                                                     app_context=self.app_context)
+        # The My Imagery panel's view. Built here, not by the service (a service holds no view);
+        # DataCatalogController renders through it.
+        self.data_catalog_view = DataCatalogView(dlg=self.dlg, app_context=self.app_context)
+        # The catalog tables' selection is resolved by the service (into mosaics/images) and by
+        # AreaCalculatorService (for the AOI area) — both told the ids, neither reading the table.
+        # The push runs before those handlers, so it is connected here, above them, in the raw
+        # signal's connection order (same rule as the processings/search tables).
+        self.dlg.mosaicTable.itemSelectionChanged.connect(self.push_catalog_mosaic_selection)
+        self.dlg.imageTable.itemSelectionChanged.connect(self.push_catalog_image_selection)
         # DataCatalogController is built after PreviewService (below): its two preview buttons
         # wire to that service, which in turn needs processing_service for the in-template
         # placement rules.
@@ -277,7 +287,9 @@ class Mapflow(QObject):
                                               data_catalog_service=self.data_catalog_service)
         self.data_catalog_controller = DataCatalogController(self.dlg,
                                                              self.data_catalog_service,
-                                                             self.preview_service)
+                                                             self.preview_service,
+                                                             view=self.data_catalog_view,
+                                                             app_context=self.app_context)
         # Before SearchService, which resolves sortable columns through it. Was created further
         # down with the provider-dialog wiring; construction order is load-bearing here.
         self.config_search_columns = ConfigColumns()
@@ -585,6 +597,16 @@ class Mapflow(QObject):
         rather than touching the metadata table.
         """
         self.app_context.selected_search_indices = self.search_view.selected_local_indices()
+
+    def push_catalog_mosaic_selection(self):
+        """Hand the selected mosaic-row ids to `DataCatalogService`, which resolves them into
+        mosaics. A service reads no table."""
+        self.data_catalog_service.set_selected_mosaic_ids(
+            self.data_catalog_view.selected_mosaic_ids())
+
+    def push_catalog_image_selection(self):
+        self.data_catalog_service.set_selected_image_ids(
+            self.data_catalog_view.selected_images_indecies())
 
     def setup_add_layer_menu(self):
         self.add_layer_menu.addAction(self.draw_aoi)

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -64,7 +64,6 @@ DIALOG_PARAMS = {"dlg", "dialog", "maindialog", "main_dialog"}
 ALLOWED = {
     # service/ and api/ importing Qt widgets — Phase C moves this to view/.
     ("widget-import", "mapflow.functional.service.alert_service"),
-    ("widget-import", "mapflow.functional.service.data_catalog"),
     ("widget-import", "mapflow.functional.service.processing_service"),
     ("widget-import", "mapflow.functional.service.provider_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
@@ -82,7 +81,6 @@ ALLOWED = {
     ("service-imports-dialogs", "mapflow.functional.service.area_calculator_service"),
     ("service-imports-dialogs", "mapflow.functional.service.data_catalog"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
-    ("service-imports-view", "mapflow.functional.service.data_catalog"),
     ("view-imports-service", "mapflow.functional.view.processing_view"),
 }
 

--- a/tests/qgis/test_catalog_selection_state.py
+++ b/tests/qgis/test_catalog_selection_state.py
@@ -4,49 +4,55 @@ Regression: after processing an IMAGE from a mosaic, selecting another MOSAIC (o
 the image) left app_context.selected_image stale, so the next processing reused the old image's
 imageIds instead of the newly selected mosaic. Selecting a mosaic and clearing the image
 selection must both drop the cached image.
+
+The selection orchestration moved from the service to `DataCatalogController` in C2.3 (a service
+reads no table), so these drive the controller.
 """
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from mapflow.functional.service.data_catalog import DataCatalogService
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller.data_catalog_controller import DataCatalogController
 from mapflow.functional.app_context import AppContext
 
 
-def _service():
-    svc = DataCatalogService.__new__(DataCatalogService)
-    svc.dlg = MagicMock()
-    # len() must work on the "selected indexes" used inside on_mosaic_selection.
-    svc.dlg.mosaicTable.selectedIndexes.return_value = [MagicMock()]
-    svc.view = MagicMock()
-    svc.api = MagicMock()
-    svc.app_context = AppContext()
-    return svc
+def _controller():
+    controller = DataCatalogController.__new__(DataCatalogController)
+    QObject.__init__(controller)
+    controller.dlg = MagicMock()
+    # len() must work on the "selected indexes" used by the dedup guard in on_mosaic_selection.
+    controller.dlg.mosaicTable.selectedIndexes.return_value = [MagicMock()]
+    controller.view = MagicMock()
+    controller.service = MagicMock()
+    controller.app_context = AppContext()
+    return controller
 
 
 def test_selecting_mosaic_clears_cached_image():
-    svc = _service()
-    svc.app_context.selected_image = SimpleNamespace(id="old-image-id")
+    controller = _controller()
+    controller.app_context.selected_image = SimpleNamespace(id="old-image-id")
 
-    svc.on_mosaic_selection(SimpleNamespace(id="mosaic-2", name="Mosaic 2"))
+    controller.on_mosaic_selection(SimpleNamespace(id="mosaic-2", name="Mosaic 2"))
 
-    assert svc.app_context.selected_image is None
+    assert controller.app_context.selected_image is None
 
 
 def test_deselecting_image_clears_cached_image():
-    svc = _service()
-    svc.app_context.selected_image = SimpleNamespace(id="old-image-id")
-    svc.selected_image = MagicMock(return_value=None)  # nothing selected in the image table
+    controller = _controller()
+    controller.app_context.selected_image = SimpleNamespace(id="old-image-id")
+    controller.service.selected_image.return_value = None  # nothing selected in the image table
 
-    svc.check_image_selection()
+    controller.check_image_selection()
 
-    assert svc.app_context.selected_image is None
+    assert controller.app_context.selected_image is None
 
 
 def test_selecting_image_still_sets_cached_image():
-    svc = _service()
+    controller = _controller()
     image = SimpleNamespace(id="new-image-id")
-    svc.selected_image = MagicMock(return_value=image)
+    controller.service.selected_image.return_value = image
 
-    svc.check_image_selection()
+    controller.check_image_selection()
 
-    assert svc.app_context.selected_image is image
+    assert controller.app_context.selected_image is image

--- a/tests/qgis/test_data_catalog_controller.py
+++ b/tests/qgis/test_data_catalog_controller.py
@@ -1,0 +1,159 @@
+"""QGIS-tier tests for the My Imagery wiring after C2.3.
+
+`DataCatalogService` announces what the panel must show and is told the selection; the controller
+renders and owns the dialogs. These build the *real* `DataCatalogController.__init__` against a
+real service (for its signals) and a mock view/dlg, so a connection that stops being made fails
+here — a test that wired its own connections could not (the C2.2b lesson).
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.controller import data_catalog_controller as controller_module
+from mapflow.functional.controller.data_catalog_controller import DataCatalogController
+from mapflow.functional.service.data_catalog import DataCatalogService
+from mapflow.model.provider.default import MyImageryProvider, ImagerySearchProvider
+
+
+def _service():
+    service = DataCatalogService.__new__(DataCatalogService)
+    QObject.__init__(service)  # it is the announce signals we are wiring
+    service.tr = lambda text: text
+    return service
+
+
+def _controller(service):
+    """A real controller, wired by its own __init__. Kept referenced by the caller — a collected
+    QObject drops its Qt connections."""
+    return DataCatalogController(
+        dlg=MagicMock(),
+        data_catalog_service=service,
+        preview_service=MagicMock(),
+        view=MagicMock(),
+        app_context=MagicMock())
+
+
+# ---------- the service announces, the controller renders ----------
+
+def test_a_mosaic_list_is_drawn_and_the_selection_cleared():
+    service = _service()
+    controller = _controller(service)
+
+    service.mosaicsChanged.emit(["m1", "m2"])
+
+    controller.view.display_mosaics.assert_called_once_with(["m1", "m2"])
+    controller.view.clear_mosaic_selection.assert_called_once()
+
+
+def test_a_reselect_redraws_and_reselects():
+    service = _service()
+    controller = _controller(service)
+
+    service.mosaicReselected.emit(["m1"], "m1")
+
+    controller.view.display_mosaics_and_reselect.assert_called_once_with(["m1"], "m1")
+
+
+def test_images_preview_and_storage_reach_the_view():
+    service = _service()
+    controller = _controller(service)
+
+    service.imagesChanged.emit(["i1"])
+    controller.view.display_images.assert_called_once_with(["i1"])
+
+    service.previewChanged.emit("a-qimage")
+    controller.view.show_preview_s.assert_called_once_with("a-qimage")
+
+    service.storageChanged.emit(10, 90)
+    controller.view.show_storage.assert_called_once_with(10, 90)
+
+
+def test_a_source_image_selects_its_mosaic_and_binds_its_row():
+    service = _service()
+    controller = _controller(service)
+    image = SimpleNamespace(id="img-1", mosaic_id="mos-1")
+
+    service.sourceImageReady.emit(image)
+
+    controller.view.select_mosaic_cell.assert_called_once_with("mos-1")
+    controller.view.bind_source_image.assert_called_once_with("img-1")
+
+
+def test_a_source_error_opens_an_error_widget():
+    service = _service()
+    controller = _controller(service)
+
+    assert controller is not None  # keep it alive: a collected QObject drops its connections
+
+    with patch.object(controller_module, "ErrorMessageWidget") as widget:
+        service.imageSourceError.emit("not found")
+
+    widget.assert_called_once()
+    widget.return_value.show.assert_called_once()
+
+
+def test_a_download_url_prompts_for_a_path_and_then_saves():
+    service = _service()
+    controller = _controller(service)
+    assert controller is not None  # keep it alive: a collected QObject drops its connections
+    service.save_downloaded = MagicMock()
+
+    with patch.object(controller_module.QFileDialog, "getSaveFileName",
+                      return_value=("/tmp/out.tif", "")):
+        service.downloadUrlReady.emit("https://x/y.tif", "y.tif")
+
+    service.save_downloaded.assert_called_once_with("https://x/y.tif", "/tmp/out.tif")
+
+
+def test_a_cancelled_save_dialog_downloads_nothing():
+    service = _service()
+    controller = _controller(service)
+    assert controller is not None  # keep it alive: a collected QObject drops its connections
+    service.save_downloaded = MagicMock()
+
+    with patch.object(controller_module.QFileDialog, "getSaveFileName", return_value=("", "")):
+        service.downloadUrlReady.emit("https://x/y.tif", "y.tif")
+
+    service.save_downloaded.assert_not_called()
+
+
+# ---------- switching the data source to My Imagery ----------
+
+def test_switch_points_the_source_combo_at_my_imagery():
+    service = _service()
+    controller = _controller(service)
+    controller.dlg.providerIndex.return_value = 0  # currently on a non-My-Imagery provider
+    providers = [ImagerySearchProvider(proxy="https://e/rest"), MyImageryProvider()]
+
+    service.switchToMyImageryRequested.emit(providers)
+
+    controller.dlg.sourceCombo.setCurrentIndex.assert_called_once_with(1)
+
+
+def test_switch_is_a_noop_when_already_on_my_imagery():
+    service = _service()
+    controller = _controller(service)
+    controller.dlg.providerIndex.return_value = 0
+    providers = [MyImageryProvider(), ImagerySearchProvider(proxy="https://e/rest")]
+
+    service.switchToMyImageryRequested.emit(providers)
+
+    controller.dlg.sourceCombo.setCurrentIndex.assert_not_called()
+
+
+# ---------- the empty-mosaic create path ----------
+
+def test_creating_an_empty_mosaic_calls_the_service():
+    service = _service()
+    service.create_mosaic = MagicMock()
+    service.create_mosaic_from_images = MagicMock()
+    controller = _controller(service)
+    mosaic_dialog = MagicMock()
+    mosaic_dialog.createMosaicCombo.currentIndex.return_value = 0
+    mosaic_dialog.mosaic.return_value = "the-mosaic"
+
+    controller._create_mosaic_from_options(mosaic_dialog)
+
+    service.create_mosaic.assert_called_once_with("the-mosaic")
+    service.create_mosaic_from_images.assert_not_called()


### PR DESCRIPTION
DataCatalogService drove the mosaic/image tables, built the create/update/delete/rename/upload
dialogs, read the table selections and called the view directly. A service may do none of that
(spec/007 § Services), and the cost was concrete: two other services reached through
`data_catalog_service.view` and into its dialog-bound `set_catalog_provider`.

The service now does requests, response parsing and the mosaic/image state, and nothing else. It
announces what the panel must show through signals (mosaicsChanged, imagesChanged, previewChanged,
mosaicInfoChanged, storageChanged, …) and is told the current selection through set_selected_mosaic
_ids / set_selected_image_ids. DataCatalogController owns every dialog, reads the tables, pushes the
selection, and renders. DataCatalogView is built in mapflow.py and handed to the controller, the
same shape ProcessingView took in C2.2b — which clears service-imports-view. With no QtWidgets or
mosaic/image/upload dialog imports left, widget-import clears too. self.dlg stays only to build
DataCatalogApi(dlg=…), so dialog-param and service-imports-dialogs (the MainDialog hint) wait for
C2.6.

The catalog-table selection is pushed from mapflow.py on itemSelectionChanged, connected above the
controller and AreaCalculatorService — both resolve that selection through the service now, and Qt
calls slots in connection order, so the push must precede its readers (the rule from C2.2a/b).

Two couplings that really belong to ProviderService (C2.4) were untangled just enough to remove the
view-reach: set_catalog_provider (called by the area and provider services) now emits
switchToMyImageryRequested for the controller to act on, and provider_service selects a mosaic cell
through the new select_mosaic_cell service method instead of reaching data_catalog_service.view.

storageChanged is pyqtSignal(object), not int: byte counts run into the billions and PyQt's int is
32-bit, which wrapped a multi-GB quota to a negative until fixed.

## Manual test
My Imagery tab: the mosaic list loads and the storage quota shows real GB figures (not negative).
Select a mosaic — its images load, its info panel fills, the first preview shows, ‹ › page through
previews. Create a collection (empty, from files, from raster layers); edit one; delete one or
several (with the confirmation dialog). Open a collection, upload images, rename an image, download
an image (the save-as dialog appears), delete images. 'Go to source' on a processing whose source
is My Imagery focuses the tab and selects the mosaic/image.

Regression surface: selecting a mosaic must clear any cached selected image (or a mosaic run reuses
the previous image); deselecting must clear it too — both are the AreaCalculator/processing path.
The data-source combo must auto-switch to My Imagery when a catalog action needs it. All selection
reads flow through the pushed ids, so a mis-ordered push shows as stale/empty selection.
