### PR TITLE
refactor: providers leave the dialog for a controller and views

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,32 +105,22 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-[ready-for-review] C2.2b The start panel → `ProcessingController`
-    `read_processing_start_params` ×2, `disable_processing_start` ×3, `set_processing_cost`,
-    `clear_processing_name` ×2, `startProcessing`, `cornfirmProcessingStart`, `modelCombo`,
-    `modelOptions`/`modelOptionsLayout`/`enabled_blocks`, `processingName`, plus the four
-    cross-region reads (search selection, AOI layer) now pushed via `app_context` /
-    `set_start_panel`. `ProcessingView` moved to `mapflow.py`; `service-imports-view` cleared.
 [ ] C2.2c The last widget read: `startProcessing.isEnabled()` in `validate_context_params`.
-    Blocked until `DataCatalogView` (C2.3) and `ProviderService` (C2.4) stop writing that button —
-    only then can its state be pushed instead of read. Clears `dialog-param` / `widget-import`
-    for `processing_service` together with C2.6 (`ProcessingApi(dlg=...)`).
-[ready-for-review] C2.3 `DataCatalogService` → `DataCatalogController` + `DataCatalogView`
-    Service now announces (signals) and is told the selection (`set_selected_*`); the controller
-    owns every dialog and renders. `ProcessingView`-style: `DataCatalogView` built in `mapflow.py`.
-    `service-imports-view` + `widget-import` cleared for data_catalog; `dialog-param` +
-    `service-imports-dialogs` stay until C2.6 (`DataCatalogApi(dlg=…)` + the `MainDialog` hint).
+    Now unblocked — C2.3 and C2.4 have both stopped writing that button, so its state can be pushed
+    instead of read. Clears `dialog-param` / `widget-import` for `processing_service` together with
+    C2.6 (`ProcessingApi(dlg=...)`).
 
 #### Group B — the service reaches into other regions' widgets
 
 No view of its own, and the widgets belong to two or three other regions. These need pushed state,
 which is why they are last.
 
-[ ] C2.4 `ProviderService` (38) → `ProviderController`, with reads pushed from `SearchController`
-    Spans three views: `metadataTable` ×11 (`SearchView`), `sourceCombo`/`zoomCombo`/`providerCombo`
-    ×8 (`ProviderView`), `modelCombo`/`modelOptions` ×5 (`ProcessingView`), plus `tabWidget` ×4 and
-    `startProcessing` ×2. The largest of the six and the one most likely to want splitting into two
-    MRs — decide once C2.3 has shown how much pushed state costs.
+[ready-for-review] C2.4 `ProviderService` → `ProviderController` + `ProviderView` (+ SearchView)
+    Read path (called by `processing_service`) reads the search selection off `app_context`
+    (`selected_search_indices` + new `selected_search_image_ids`); the duplicate cluster announces
+    via signals wired in `mapflow.py` to the view owning each widget. `dlg` param dropped entirely —
+    **both** allowlist entries (`widget-import` + `dialog-param`) cleared. Dead `get_data_provider`
+    / `get_current_provider_index` removed.
 [ ] C2.5 `AreaCalculatorService` (17, plus the `use_imagery_extent` checkbox it is handed directly)
     → `ProcessingController` (`spec/007_architecture.md` assigns it "AOI and provider selection,
     cost")

--- a/mapflow/functional/app_context.py
+++ b/mapflow/functional/app_context.py
@@ -41,6 +41,10 @@ class AppContext:
     # what is sent for processing/cost (matches the displayed area); falls back to `aoi`.
     processing_aoi: Optional[QgsGeometry] = None
     aoi_size: Optional[float] = None
+    # The polygon layer currently chosen as the AOI (the AOI combo's layer). Pushed from the
+    # composition root so `ProviderService` can rebuild a duplicated search over it without
+    # reading the combo.
+    aoi_layer: Optional[QgsVectorLayer] = None
     # The list of layers usable as an AOI lives on AoiService — nothing else reads it.
 
     # === User/Account State ===
@@ -87,6 +91,10 @@ class AppContext:
     # a service may not read) so `ProcessingService` can gate planned processing and look up a
     # provider's minimum area — it is the key into `search_footprints` above, so it lives beside it.
     selected_search_indices: List[str] = field(default_factory=list)
+    # The image id of every selected search-result row, in the same order — pushed alongside
+    # `selected_search_indices` so `ProviderService` can build the processing's imageIds without
+    # reading the metadata table.
+    selected_search_image_ids: List[str] = field(default_factory=list)
     search_page_offset: int = 0
     # Raw imagery-search results as returned by the API for the current view (regular search
     # or template) — a GeoJSON FeatureCollection with a per-feature ``local_index``. Retained

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -488,6 +488,11 @@ class DataCatalogService(QObject):
         no view of its own, nor another service's)."""
         self.sourceMosaicSelected.emit(mosaic_id)
 
+    def clear_mosaic_selection(self):
+        """Ask the panel to clear the mosaic selection. Called by ProviderService when it
+        duplicates a My Imagery source — it holds no view to do it itself."""
+        self.mosaicSelectionCleared.emit()
+
     def show_my_imagery_source(self,
                                source_params: MyImageryParams):
         if source_params.myImagery.imageIds: # if the source was an image:

--- a/mapflow/functional/service/provider_service.py
+++ b/mapflow/functional/service/provider_service.py
@@ -2,8 +2,7 @@
 import logging
 from typing import Optional
 
-from PyQt5.QtCore import Qt, QObject
-from PyQt5.QtWidgets import QTableWidgetItem, QWidget
+from PyQt5.QtCore import QObject, pyqtSignal
 from qgis.core import QgsVectorLayer, QgsFeature
 
 from . import DataCatalogService
@@ -45,16 +44,54 @@ def normalized_product_types(product_types) -> set:
 
 
 class ProviderService(QObject):
+    """Provider selection, validation and the duplicate-a-processing rebuild — as requests and
+    state, not widgets. It holds no dialog: the source/provider/zoom combos are `ProviderView`'s,
+    the model combo and its options `ProcessingView`'s, the search table `SearchView`'s. What the
+    service needs off those it is *told* (`app_context.selected_search_*`, the setters below); what
+    it wants drawn it *announces* (the signals below), for `ProviderController` (and, for the
+    search table, `SearchController`) to render. See `spec/007_architecture.md` § Services.
+    """
     _instance: Optional['ProviderService'] = None
     _initialized: bool = False
-    
-    def __init__(self, providers: ProvidersList, dlg, app_context: AppContext, config: Config, data_catalog_service: DataCatalogService):
+
+    # ---------- what the provider panel and the start button must show (announced, never drawn) ----------
+    #: A start is blocked, with this reason (the search-selection error path).
+    startDisabled = pyqtSignal(str)
+    #: A duplicate step (or its recovery) leaves the Start button usable.
+    startEnabled = pyqtSignal()
+    #: The provider list changed — refill the provider combo from this {name: api_name}.
+    providersListChanged = pyqtSignal(object)
+    #: The imagery sources changed — ({name: api_name}, [default names]) for the raster combos.
+    imagerySourcesChanged = pyqtSignal(object, object)
+    #: Duplication picked this model in the combo.
+    modelSelected = pyqtSignal(str)
+    #: Duplication resolved which option checkboxes to tick (by label).
+    modelOptionsSet = pyqtSignal(object)
+    #: Duplication chose a data provider: (source combo index, zoom or None).
+    dataProviderSelected = pyqtSignal(int, object)
+    #: Duplication matched an existing source by name.
+    sourceSelectedByName = pyqtSignal(str)
+    #: Duplication needs the provider index set (the imagery-search source, or a freshly added
+    #: user provider).
+    providerIndexSet = pyqtSignal(int)
+    #: Duplication set the zoom (a user provider carries its own).
+    zoomSet = pyqtSignal(str)
+    #: Duplication of a My Imagery source: reset the mosaic table and show the catalog tab.
+    myImageryDuplicated = pyqtSignal()
+    #: Duplication of an imagery search: the per-row column values to fill the metadata table with.
+    imagerySearchDuplicated = pyqtSignal(object)
+
+    #: The search table's selection, pushed from the composition root — the service reads no table.
+    #: `selected_search_indices` / `selected_search_image_ids` live on `app_context` beside
+    #: `search_footprints` (the dict they key into); the polygon layer used to rebuild a duplicated
+    #: search is pushed to `app_context.aoi_layer`.
+
+    def __init__(self, providers: ProvidersList, app_context: AppContext, config: Config, data_catalog_service: DataCatalogService):
         if ProviderService._initialized:
             return
         super().__init__()
         ProviderService._initialized = True
         self.providers = providers
-        self.dlg = dlg
         self.app_context = app_context
         self.config = config
         self.data_catalog_service = data_catalog_service
@@ -70,46 +107,44 @@ class ProviderService(QObject):
         if cls._instance is None:
             raise RuntimeError("ProviderService not initialized.")
         return cls._instance
-    
+
     @classmethod
-    def get_instance(cls, providers: ProvidersList, dlg, app_context: AppContext, config: Config, data_catalog_service: DataCatalogService) -> 'ProviderService':
+    def get_instance(cls, providers: ProvidersList, app_context: AppContext, config: Config, data_catalog_service: DataCatalogService) -> 'ProviderService':
         if cls._instance is None:
-            cls._instance = cls(providers, dlg, app_context, config, data_catalog_service)
+            cls._instance = cls(providers, app_context, config, data_catalog_service)
         return cls._instance
-        
-    def get_current_provider_index(self):
-        return self.dlg.providerIndex()
-    
-    def get_data_provider(self):
-        return self.providers[self.dlg.providerIndex()]
-    
+
+    # ---------- the search selection, read off app_context (pushed, never a table) ----------
+
+    def _selected_search_indices(self):
+        return list(self.app_context.selected_search_indices or [])
+
+    def _selected_search_image_ids(self):
+        return list(self.app_context.selected_search_image_ids or [])
+
     def update_providers_list(self, new_providers):
         for provider in self.providers:
             if isinstance(provider, MyImageryProvider):
                 self.my_imagery_provider_instance = provider
             if isinstance(provider, ImagerySearchProvider):
                 self.imagery_search_provider_instance = provider
-    
-    def update_providers(self) -> None:
-        """Update imagery & providers dropdown list after edit/add/remove
-        It works both ways: if providers is specified, it updates the settings;
-        otherwise loads providers list from settings
-        """
+
+    def update_providers(self, current_model: str = "") -> None:
+        """Persist the user providers and announce the refreshed combo list. The current model is
+        passed in (a `ProcessingView` read) so this touches no widget."""
         self.user_providers.to_settings(self.app_context.settings)
         provider_names = {p.name: getattr(p, 'api_name', p.name) for p in self.providers}
-        for name, api_name in provider_names.items():
-            self.dlg.providerCombo.addItem(name, api_name)
-        self.set_available_imagery_sources(self.dlg.modelCombo.currentText())
-    
+        self.providersListChanged.emit(provider_names)
+        self.set_available_imagery_sources(current_model)
+
     def set_available_imagery_sources(self, wd: str) -> None:
-        """Set the list of imagery sources (all search goes through the Mapflow catalog)."""
+        """Announce the list of imagery sources (all search goes through the Mapflow catalog)."""
         if self.providers == self.basemap_providers:
             # Providers did not change
             return
         self.providers = self.basemap_providers
         provider_names = {p.name: getattr(p, 'api_name', p.name) for p in self.providers}
-        self.dlg.set_raster_sources(provider_names=provider_names,
-                                    default_provider_names=['Mapbox', '🌍 Mapbox Satellite'])
+        self.imagerySourcesChanged.emit(provider_names, ['Mapbox', '🌍 Mapbox Satellite'])
 
     def get_provider_params(self, provider, zoom):
         meta = {'source-app': 'qgis',
@@ -141,13 +176,12 @@ class ProviderService(QObject):
             provider_names, product_types = [], []
             image_ids, selection_error = None, ""
 
-            selected_images = self.dlg.metadataTable.selectedItems()
-            if selected_images:
-                local_image_indices = self.get_local_image_indices(selected_images)
+            if self._selected_search_indices():
+                local_image_indices = self.get_local_image_indices()
                 provider_names, product_types = self.get_search_providers(local_image_indices)
                 image_ids, selection_error = self.get_search_images_ids(provider_names, product_types)
                 if selection_error:
-                    self.dlg.disable_processing_start(selection_error)
+                    self.startDisabled.emit(selection_error)
                 self.imagery_search_provider_instance.image_ids = image_ids
                 provider_name = provider_names[0] if provider_names else None # the same for all [i] if there was no 'selection_error'
             else:
@@ -181,14 +215,9 @@ class ProviderService(QObject):
             elif mosaic:
                 provider_text += " ({name})". format(name=mosaic.name)
         elif isinstance(provider, ImagerySearchProvider):
-            selected_cells = self.dlg.metadataTable.selectedItems()
-            if not selected_cells:
-                image_id = None
-                selected_rows_count = 0
-            else:
-                id_column_index = self.config.SEARCH_ID_COLUMN_INDEX
-                selected_rows_count = len({cell.row() for cell in selected_cells})
-                image_id = self.dlg.metadataTable.item(selected_cells[0].row(), id_column_index).text()
+            selected_image_ids = self._selected_search_image_ids()
+            selected_rows_count = len(self._selected_search_indices())
+            image_id = selected_image_ids[0] if selected_image_ids else None
             if selected_rows_count > 1:
                 provider_text += " ({count} images selected)".format(count=selected_rows_count)
             elif image_id:
@@ -207,11 +236,10 @@ class ProviderService(QObject):
             if not self.imagery_search_provider_instance.image_ids:
                 error = self.tr("This provider requires image ID. Use search tab to find imagery for you requirements, "
                                 "and select image in the table.")
-        # Check for zoom errors by examining the UI state
+        # Check for zoom errors by examining the current selection state
         if not error and isinstance(provider, ImagerySearchProvider):
-            selected_images = self.dlg.metadataTable.selectedItems()
-            if selected_images:
-                local_image_indices = self.get_local_image_indices(selected_images)
+            if self._selected_search_indices():
+                local_image_indices = self.get_local_image_indices()
                 provider_names, product_types = self.get_search_providers(local_image_indices)
                 # Check for zoom consistency
                 if local_image_indices:
@@ -283,14 +311,13 @@ class ProviderService(QObject):
                                                                providerMinArea=provider_min_area)
         return None
 
-    def get_local_image_indices(self, selected_images):
+    def get_local_image_indices(self):
+        """The `local_index` of every selected search row. Pushed from the search table, so this
+        reads no widget; the ints match `search_footprints`' keys."""
         try:
-            rows = list(set(image.row() for image in selected_images))
-            local_image_indices = [int(self.dlg.metadataTable.item(row, self.config.LOCAL_INDEX_COLUMN).text()) 
-                                   for row in rows]
-        except (AttributeError, KeyError):
-            local_image_indices = []
-        return local_image_indices
+            return [int(index) for index in self._selected_search_indices()]
+        except (TypeError, ValueError):
+            return []
     
     def get_search_providers(self, local_image_indices):
         try:
@@ -306,20 +333,7 @@ class ProviderService(QObject):
         return provider_names, product_types
     
     def get_search_images_ids(self, provider_names, product_types):
-        selected_cells = self.dlg.metadataTable.selectedItems()
-        if not selected_cells:
-            image_ids = None
-        else:
-            id_column_index = self.config.SEARCH_ID_COLUMN_INDEX
-            rows = sorted({cell.row() for cell in selected_cells})
-            image_ids = []
-            for row in rows:
-                cell = self.dlg.metadataTable.item(row, id_column_index)
-                text = cell.text() if cell is not None else ""
-                if text:
-                    image_ids.append(text)
-            if not image_ids:
-                image_ids = None
+        image_ids = [image_id for image_id in self._selected_search_image_ids() if image_id] or None
         selection_error = ""
         try:
             if len(set(provider_names)) > 1:
@@ -359,7 +373,7 @@ class ProviderService(QObject):
         alert(message)
         for key in self.app_context.allow_enable_processing:
             self.app_context.allow_enable_processing[key] = True
-        self.dlg.startProcessing.setEnabled(True)
+        self.startEnabled.emit()
 
     def duplicate_provider(self, processing: ProcessingDTO):
         message = self.tr("Duplication failed on copying data source")
@@ -383,12 +397,14 @@ class ProviderService(QObject):
     def duplicate_model(self, processing: ProcessingDTO):
         message = self.tr("Duplication failed on copying model")
         try:
-            if self.dlg.modelCombo.findText(processing.workflowDef.name) == -1: # index is -1, the item is not found
+            # Whether the model is available is a question about the account's workflow defs, not
+            # about the combo — the combo is filled from them. Asking the model avoids the widget.
+            if self.app_context.get_workflow_def(processing.workflowDef.name) is None:
                 self._abort_duplication(
                     self.tr("Model '{wd}' is not enabled for your account").format(wd=processing.workflowDef.name)
                 )
-            else: # item is found
-                self.dlg.modelCombo.setCurrentText(processing.workflowDef.name)
+            else:
+                self.modelSelected.emit(processing.workflowDef.name)
         except DUPLICATION_FAILURES:
             self._abort_duplication(message)
         except Exception:
@@ -398,19 +414,13 @@ class ProviderService(QObject):
     def duplicate_model_options(self, processing):
         message = self.tr("Duplication failed on copying model options")
         try:
-            model_options = []
-            enabled_options = []
-            for checkbox in self.dlg.modelOptions:
-                model_options.append(checkbox.text())
-            for block in processing.blocks:
-                if block.enabled:
-                    enabled_options.append(block.displayName)
+            # The available options are the current model's optional blocks (the checkboxes are
+            # built from them), so read them from the workflow def rather than the widgets.
+            wd = self.app_context.get_workflow_def(processing.workflowDef.name)
+            model_options = [block.displayName for block in wd.optional_blocks] if wd else []
+            enabled_options = [block.displayName for block in processing.blocks if block.enabled]
             options_to_enable = [option for option in enabled_options if option in model_options]
-            for checkbox in self.dlg.modelOptions:
-                if checkbox.text() in options_to_enable:
-                    checkbox.setChecked(True)
-                else:
-                    checkbox.setChecked(False) 
+            self.modelOptionsSet.emit(options_to_enable)
             deleted_options = [enabled_option for enabled_option in enabled_options if enabled_option not in model_options]
             if deleted_options:
                 self._abort_duplication(
@@ -425,38 +435,32 @@ class ProviderService(QObject):
 
     def duplicate_data_provider(self, provider: DataProviderParams):
         provider_name = provider.dataProvider.providerName
-        index = self.dlg.sourceCombo.findData(provider_name)
+        # The combo index equals the provider's index in `providers` (set_raster_sources fills it
+        # in that order), so resolve availability against `providers` instead of the combo.
+        index = next((i for i, p in enumerate(self.providers)
+                      if getattr(p, 'api_name', p.name) == provider_name), -1)
         if index == -1:
             self._abort_duplication(
                 self.tr("Provider '{provider}' is not enabled for your account").format(provider=provider_name)
             )
         else:
-            self.dlg.sourceCombo.setCurrentIndex(index)
-            if provider.dataProvider.zoom:
-                self.dlg.zoomCombo.setCurrentText(str(provider.dataProvider.zoom))
-            else:
-                self.dlg.zoomCombo.setCurrentIndex(0)
-    
+            zoom = str(provider.dataProvider.zoom) if provider.dataProvider.zoom else None
+            self.dataProviderSelected.emit(index, zoom)
+
     def duplicate_my_imagery(self, provider: MyImageryParams):
-        self.dlg.mosaicTable.clearSelection()
+        self.data_catalog_service.clear_mosaic_selection()
         if provider.myImagery.imageIds:
             self.app_context.allow_enable_processing['my_image_loaded'] = False
             image_id = provider.myImagery.imageIds[0]
             self.data_catalog_service.get_image(image_id)
         elif provider.myImagery.mosaicId:
             self.data_catalog_service.select_mosaic_cell(provider.myImagery.mosaicId)
-        my_imagery_tab = self.dlg.tabWidget.findChild(QWidget, "catalogTab") 
-        self.dlg.tabWidget.setCurrentWidget(my_imagery_tab)
+        self.myImageryDuplicated.emit()
         self.data_catalog_service.set_catalog_provider(self.providers)
 
     def duplicate_imagery_search(self, provider: ImagerySearchParams):
-        self.dlg.sourceCombo.setCurrentIndex(self.imagery_search_provider_index)
+        self.providerIndexSet.emit(self.imagery_search_provider_index)
         image_ids = list(provider.imagerySearch.imageIds or [])
-        # Setup table to have one row per duplicated image id (Bug #3 fix)
-        self.dlg.metadataTable.clearContents()
-        self.dlg.metadataTable.setRowCount(len(image_ids))
-        imagery_search_tab = self.dlg.tabWidget.findChild(QWidget, "providersTab")
-        self.dlg.tabWidget.setCurrentWidget(imagery_search_tab)
         # Only name, zoom and id are returned, so we map column indices to per-row value lookups
         def per_row_columns(row, image_id):
             return {
@@ -479,7 +483,9 @@ class ProviderService(QObject):
         # Fill the layer with one feature per (AOI x image_id) combination.
         # Individual image footprints aren't downloaded for duplicated processings,
         # so every row shares the AOI geometry — sufficient for selection-driven cost recalc.
-        aoi_features = list(self.dlg.polygonCombo.currentLayer().getFeatures())
+        # The AOI layer is pushed to app_context (the combo is not this service's to read).
+        aoi_layer = self.app_context.aoi_layer
+        aoi_features = list(aoi_layer.getFeatures()) if aoi_layer is not None else []
         for row, image_id in enumerate(image_ids):
             row_columns = per_row_columns(row, image_id)
             for aoi_feature in aoi_features:
@@ -493,12 +499,6 @@ class ProviderService(QObject):
                 self.app_context.metadata_layer.commitChanges()
         self.app_context.metadata_layer.updateExtents()
         self.app_context.meta_layer_table_connection = self.app_context.metadata_layer.selectionChanged.connect(self.selection_sync_callback)
-        # Fill metadata table with the returned values
-        for row, image_id in enumerate(image_ids):
-            for column, value in per_row_columns(row, image_id).items():
-                table_item = QTableWidgetItem()
-                table_item.setData(Qt.DisplayRole, value)
-                self.dlg.metadataTable.setItem(row, column, table_item)
         # Create pseudo footprints dict keyed by local_index so multi-image cost requests resolve correctly.
         # local_index is stored as a string in the in-memory layer field (no explicit type was given when
         # the layer was created), but the rest of the codebase expects integer keys
@@ -513,25 +513,25 @@ class ProviderService(QObject):
             _coerce_local_index(feature.attribute("local_index")): feature
             for feature in self.app_context.metadata_layer.getFeatures()
         }
-        self.dlg.metadataTableFilled.emit()
-        for row in range(len(image_ids)):
-            self.dlg.metadataTable.selectRow(row)
+        # The table fill and row selection belong to the search table (SearchView/SearchController);
+        # hand over one row of column→value maps per image and let it draw and select them.
+        self.imagerySearchDuplicated.emit(
+            [per_row_columns(row, image_id) for row, image_id in enumerate(image_ids)])
 
-    
     def duplicate_user_provider(self, provider: UserDefinedParams):
         duplicated_provider = None
         for p in self.providers:
             if isinstance(p, UsersProvider) and p.url == provider.userDefined.url:
                 duplicated_provider = p
-                self.dlg.sourceCombo.setCurrentText(duplicated_provider.name)
+                self.sourceSelectedByName.emit(duplicated_provider.name)
         if not duplicated_provider:
             provider_dict = dict(option_name=provider.userDefined.sourceType.lower(),
                                 name=self.tr("Duplicated user provider"),
                                 url=provider.userDefined.url,
-                                crs=(provider.userDefined.crs.upper() 
-                                     if provider.userDefined.crs 
+                                crs=(provider.userDefined.crs.upper()
+                                     if provider.userDefined.crs
                                      else None),
-                                credentials=BasicAuth(str(provider.userDefined.rasterLogin), 
+                                credentials=BasicAuth(str(provider.userDefined.rasterLogin),
                                                         str(provider.userDefined.rasterPassword))
                                                         if provider.userDefined.rasterLogin
                                                         else BasicAuth(),
@@ -540,8 +540,8 @@ class ProviderService(QObject):
             self.user_providers.append(duplicated_provider)
             provider_index = len(self.providers)
             self.update_providers()
-            self.dlg.setProviderIndex(provider_index)
-        self.dlg.zoomCombo.setCurrentText(str(provider.userDefined.zoom))
+            self.providerIndexSet.emit(provider_index)
+        self.zoomSet.emit(str(provider.userDefined.zoom))
 
     def duplicate_aoi(self, provider):
         if isinstance(provider, ImagerySearchParams):
@@ -551,7 +551,7 @@ class ProviderService(QObject):
         else: # if other two are True - enable start
             self.app_context.allow_enable_processing['aoi_loaded'] = True
             if False not in self.app_context.allow_enable_processing.values():
-                self.dlg.startProcessing.setEnabled(True)
+                self.startEnabled.emit()
     
     @property
     def basemap_providers(self):
@@ -564,9 +564,6 @@ class ProviderService(QObject):
                 return index
         return -1
 
-
-def get_data_provider():
-    return ProviderService.instance().get_data_provider()
 
 def update_providers_list(new_providers):
     ProviderService.instance().update_providers_list(new_providers)

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -403,6 +403,17 @@ class ProcessingView:
     def show_user_provider_info(self, source_params) -> str:
         return self.dlg.show_user_provider_info(source_params)
 
+    def select_model(self, name: str) -> None:
+        """Duplicating a processing: pick its model. Its availability was checked before this is
+        emitted, so setting the text here always lands on a real entry."""
+        self.dlg.modelCombo.setCurrentText(name)
+
+    def set_checked_options(self, enabled_labels) -> None:
+        """Duplicating a processing: tick the option checkboxes whose label is in `enabled_labels`,
+        untick the rest."""
+        for checkbox in self.dlg.modelOptions:
+            checkbox.setChecked(checkbox.text() in enabled_labels)
+
     # ---------- the review / rating panel ----------
 
     def set_rating_labels(self, processing_name: str, rating: int = 0, feedback: str = "") -> None:

--- a/mapflow/functional/view/provider_view.py
+++ b/mapflow/functional/view/provider_view.py
@@ -32,6 +32,30 @@ class ProviderView(QObject):
     def set_provider_index(self, index: int) -> None:
         self.dlg.setProviderIndex(index)
 
+    def add_providers(self, provider_names: dict) -> None:
+        """Append {name: api_name} entries to the provider combo (the list changed)."""
+        for name, api_name in provider_names.items():
+            self.dlg.providerCombo.addItem(name, api_name)
+
+    def set_raster_sources(self, provider_names: dict, default_provider_names) -> None:
+        """Rebuild both source combos from the current providers, defaulting to the given names."""
+        self.dlg.set_raster_sources(provider_names=provider_names,
+                                    default_provider_names=default_provider_names)
+
+    def select_data_provider(self, index: int, zoom) -> None:
+        """Duplicating a processing: pick the source by index, and its zoom (index 0 = native)."""
+        self.dlg.sourceCombo.setCurrentIndex(index)
+        if zoom:
+            self.dlg.zoomCombo.setCurrentText(str(zoom))
+        else:
+            self.dlg.zoomCombo.setCurrentIndex(0)
+
+    def select_source_by_name(self, name: str) -> None:
+        self.dlg.sourceCombo.setCurrentText(name)
+
+    def set_zoom_text(self, zoom: str) -> None:
+        self.dlg.zoomCombo.setCurrentText(str(zoom))
+
     # ---------- the zoom combo ----------
 
     def enable_zoom(self, enabled: bool) -> None:

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 
 from PyQt5.QtCore import QObject, Qt, pyqtSignal
 from PyQt5.QtGui import QBrush, QColor
-from PyQt5.QtWidgets import QAbstractItemView, QMenu, QPushButton, QToolButton, QWidget
+from PyQt5.QtWidgets import QAbstractItemView, QMenu, QPushButton, QTableWidgetItem, QToolButton, QWidget
 
 from ..helpers import utc_date_from_iso
 from ...dialogs.main_dialog import MainDialog
@@ -288,6 +288,35 @@ class SearchView(QObject):
             return []
         return [self.dlg.metadataTable.item(cell.row(), self.config.LOCAL_INDEX_COLUMN).text()
                 for cell in selected]
+
+    def selected_image_ids(self) -> List[str]:
+        """The image id of every selected row, in row order. Pushed to `app_context` beside the
+        local indices so `ProviderService` builds a processing's imageIds without a table."""
+        selected = self.dlg.metadataTable.selectedItems()
+        if not selected:
+            return []
+        id_column = self.config.SEARCH_ID_COLUMN_INDEX
+        image_ids = []
+        for row in sorted({cell.row() for cell in selected}):
+            item = self.dlg.metadataTable.item(row, id_column)
+            image_ids.append(item.text() if item is not None else "")
+        return image_ids
+
+    def fill_duplicated_search(self, rows) -> None:
+        """Rebuild the results table for a duplicated processing: one row per image, each a map of
+        column index → value. Emits `metadataTableFilled` and selects every row, the way a real
+        search does, so the cost recalculation the selection drives runs."""
+        table = self.dlg.metadataTable
+        table.clearContents()
+        table.setRowCount(len(rows))
+        for row, columns in enumerate(rows):
+            for column, value in columns.items():
+                item = QTableWidgetItem()
+                item.setData(Qt.DisplayRole, value)
+                table.setItem(row, column, item)
+        self.dlg.metadataTableFilled.emit()
+        for row in range(len(rows)):
+            table.selectRow(row)
 
     def selected_zoom(self) -> Optional[str]:
         """The zoom of the first selected row. Different zooms across a multi-selection are not

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -230,10 +230,14 @@ class Mapflow(QObject):
         self.project_view = ProjectView(self.dlg)
         
         self.provider_service = ProviderService.get_instance(providers=ProvidersList([]),
-                                                            dlg=self.dlg,
                                                             app_context=self.app_context,
                                                             config=self.config,
                                                             data_catalog_service=self.data_catalog_service)
+        # The provider/source combos are ProviderView's; the service announces the list, this
+        # renders it. Wired here, before the first `update_providers()` below fires them.
+        self.provider_view = ProviderView(dlg=self.dlg)
+        self.provider_service.providersListChanged.connect(self.provider_view.add_providers)
+        self.provider_service.imagerySourcesChanged.connect(self.provider_view.set_raster_sources)
 
         self.processing_service = ProcessingService(http=self.http,
                                                     dlg=self.dlg,
@@ -257,7 +261,7 @@ class Mapflow(QObject):
         if errors:
             self.alert(self.tr('We failed to import providers from the settings. Please add them again'),
                     icon=QMessageBox.Warning)
-        self.provider_service.update_providers()
+        self.provider_service.update_providers(self.dlg.modelCombo.currentText())
 
         # ========== 9. ADD LAYER MENU ==========
         self.add_layer_menu = QMenu()
@@ -463,6 +467,10 @@ class Mapflow(QObject):
             self.project_processing_controller.load_results)
         # Calculate AOI size
         self.dlg.polygonCombo.layerChanged.connect(self.area_calculator_service.calculate_aoi_area_polygon_layer)
+        # Push the chosen AOI layer so ProviderService can rebuild a duplicated search over it
+        # without reading the combo. Seed it with the current layer, then follow every change.
+        self.app_context.aoi_layer = self.dlg.polygonCombo.currentLayer()
+        self.dlg.polygonCombo.layerChanged.connect(self.push_aoi_layer)
         self.dlg.mosaicTable.itemSelectionChanged.connect(self.area_calculator_service.calculate_aoi_area_catalog)
         self.dlg.imageTable.itemSelectionChanged.connect(self.area_calculator_service.calculate_aoi_area_catalog)
         self.monitor_polygon_layer_feature_selection([
@@ -485,8 +493,7 @@ class Mapflow(QObject):
         # ========== 13. PROVIDERS ==========
         # searchImageryButton and the metadata table's double/cell-click previews are wired by
         # SearchController (constructed above); the add/edit/remove buttons and the zoom combo by
-        # ProviderController, which owns those handlers.
-        self.provider_view = ProviderView(dlg=self.dlg)
+        # ProviderController, which owns those handlers. `provider_view` is built in section 7.
         self.provider_controller = ProviderController(
             provider_service=self.provider_service,
             provider_view=self.provider_view,
@@ -497,6 +504,22 @@ class Mapflow(QObject):
             edit_button=self.dlg.editProvider,
             remove_button=self.dlg.removeProvider,
             zoom_combo=self.dlg.zoomCombo)
+        # ProviderService announces the rest of the provider panel; render it through the views it
+        # spans. The provider-list signals are wired in section 7 (they fire at first load, before
+        # this point); these are the duplicate-a-processing writes.
+        self.provider_service.startEnabled.connect(lambda: self.processing_view.set_start_enabled(True))
+        self.provider_service.startDisabled.connect(
+            lambda reason: self.processing_view.disable_processing_start(reason, False))
+        self.provider_service.modelSelected.connect(self.processing_view.select_model)
+        self.provider_service.modelOptionsSet.connect(self.processing_view.set_checked_options)
+        self.provider_service.dataProviderSelected.connect(self.provider_view.select_data_provider)
+        self.provider_service.sourceSelectedByName.connect(self.provider_view.select_source_by_name)
+        self.provider_service.providerIndexSet.connect(self.provider_view.set_provider_index)
+        self.provider_service.zoomSet.connect(self.provider_view.set_zoom_text)
+        self.provider_service.myImageryDuplicated.connect(self.provider_view.show_catalog_tab)
+        self.provider_service.imagerySearchDuplicated.connect(self.search_view.fill_duplicated_search)
+        self.provider_service.imagerySearchDuplicated.connect(
+            lambda _rows: self.provider_view.show_imagery_search_tab())
 
         self.search_controller.connect_table_selection()
         self.app_context.meta_layer_table_connection = None
@@ -590,13 +613,20 @@ class Mapflow(QObject):
         """
         self.project_processing_controller.push_selection()
 
+    def push_aoi_layer(self, layer=None):
+        """The AOI combo's current layer, pushed to `app_context` for `ProviderService`'s
+        duplicated-search rebuild. `layerChanged` passes the new layer; on a bare call read it."""
+        self.app_context.aoi_layer = layer if layer is not None else self.dlg.polygonCombo.currentLayer()
+
     def push_search_selection(self):
-        """Deliver the search table's selected image indices to `app_context`, where they sit
-        beside `search_footprints` — the dict they are the key into. `ProcessingService` reads
-        them from there for the planned-processing gate and the provider-minimum-area check,
-        rather than touching the metadata table.
+        """Deliver the search table's selection to `app_context`, where it sits beside
+        `search_footprints` — the dict the indices key into. `ProcessingService` reads the indices
+        for the planned-processing gate and the provider-minimum-area check; `ProviderService`
+        reads the indices and the image ids to build the processing's imageIds — neither touches
+        the metadata table.
         """
         self.app_context.selected_search_indices = self.search_view.selected_local_indices()
+        self.app_context.selected_search_image_ids = self.search_view.selected_image_ids()
 
     def push_catalog_mosaic_selection(self):
         """Hand the selected mosaic-row ids to `DataCatalogService`, which resolves them into

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -65,13 +65,11 @@ ALLOWED = {
     # service/ and api/ importing Qt widgets — Phase C moves this to view/.
     ("widget-import", "mapflow.functional.service.alert_service"),
     ("widget-import", "mapflow.functional.service.processing_service"),
-    ("widget-import", "mapflow.functional.service.provider_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
     # Services and two api modules taking the main dialog as a constructor argument.
     ("dialog-param", "mapflow.functional.service.area_calculator_service"),
     ("dialog-param", "mapflow.functional.service.data_catalog"),
     ("dialog-param", "mapflow.functional.service.processing_service"),
-    ("dialog-param", "mapflow.functional.service.provider_service"),
     ("dialog-param", "mapflow.functional.api.data_catalog_api"),
     ("dialog-param", "mapflow.functional.api.processing_api"),
     # Reaching upwards for dialogs and views. One entry per module, so it clears only when

--- a/tests/functional/test_provider_service_duplication.py
+++ b/tests/functional/test_provider_service_duplication.py
@@ -28,21 +28,26 @@ from mapflow.functional.service import provider_service as provider_service_modu
 
 
 def _service():
-    """A ProviderService with just enough surface for the duplicate_* recovery path."""
+    """A ProviderService with just enough surface for the duplicate_* recovery path.
+
+    It holds no dialog now — re-enabling the Start button leaves as `startEnabled`, so the
+    fixture records that signal instead of inspecting a widget.
+    """
+    from PyQt5.QtCore import QObject
+
     ProviderService = provider_service_module.ProviderService
 
     ProviderService._instance = None
     ProviderService._initialized = False
 
     service = ProviderService.__new__(ProviderService)
-    service.dlg = MagicMock()
-    # Iterating a bare MagicMock raises TypeError, which would muddy which exception the
-    # handler actually saw; an empty list keeps the failure attributable to the DTO.
-    service.dlg.modelOptions = []
+    QObject.__init__(service)  # startEnabled is a signal
     service.app_context = SimpleNamespace(
         allow_enable_processing={"aoi_loaded": False, "my_mosaic_loaded": False}
     )
     service.tr = lambda message: message
+    service._start_reenabled = []
+    service.startEnabled.connect(lambda: service._start_reenabled.append(True))
     return service
 
 
@@ -51,7 +56,7 @@ def _assert_dialog_recovered(service):
         "every allow_enable_processing flag must be reset, or the dialog stays "
         "partially disabled"
     )
-    service.dlg.startProcessing.setEnabled.assert_called_with(True)
+    assert service._start_reenabled, "the Start button must be re-enabled (startEnabled emitted)"
 
 
 def test_abort_duplication_resets_flags_and_reenables_start():

--- a/tests/qgis/test_imagery_search_multi.py
+++ b/tests/qgis/test_imagery_search_multi.py
@@ -20,38 +20,13 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 
-def _make_table(rows):
-    """rows: list[list[str]] — table[r][c] = cell text. Returns a mock metadataTable."""
-    table = MagicMock()
-
-    def item(row, col):
-        try:
-            text = rows[row][col]
-        except IndexError:
-            return None
-        cell = MagicMock()
-        cell.text.return_value = text
-        return cell
-
-    table.item.side_effect = item
-
-    def selected_items():
-        selected = []
-        for r, row_cells in enumerate(rows):
-            for c, _ in enumerate(row_cells):
-                cell = MagicMock()
-                cell.row.return_value = r
-                cell.column.return_value = c
-                selected.append(cell)
-        return selected
-
-    table.selectedItems.side_effect = selected_items
-    return table
-
-
 def _make_service(rows, provider_names, product_types, zooms=None,
                   min_areas=None, aoi_size=None):
-    """Build the minimum ProviderService surface needed by the methods under test."""
+    """Build the minimum ProviderService surface needed by the methods under test.
+
+    The service reads no table now — the search selection is pushed to `app_context`
+    (`selected_search_indices` + `selected_search_image_ids`), so the fixture pushes there.
+    """
     from mapflow.functional.service.provider_service import ProviderService
     from mapflow.config import Config
 
@@ -59,9 +34,6 @@ def _make_service(rows, provider_names, product_types, zooms=None,
 
     ProviderService._instance = None
     ProviderService._initialized = False
-
-    dlg = MagicMock()
-    dlg.metadataTable = _make_table(rows)
 
     footprints = {}
     zooms = zooms or [None] * len(provider_names)
@@ -80,10 +52,14 @@ def _make_service(rows, provider_names, product_types, zooms=None,
 
         feature.attribute.side_effect = attribute
         footprints[idx] = feature
-    app_context = SimpleNamespace(search_footprints=footprints, aoi_size=aoi_size)
+    # The local index of each selected row is its position; the image id is the ID column.
+    selected_indices = [str(i) for i in range(len(provider_names))]
+    selected_image_ids = [row[config.SEARCH_ID_COLUMN_INDEX] for row in rows]
+    app_context = SimpleNamespace(search_footprints=footprints, aoi_size=aoi_size,
+                                  selected_search_indices=selected_indices,
+                                  selected_search_image_ids=selected_image_ids)
 
     service = ProviderService.__new__(ProviderService)
-    service.dlg = dlg
     service.app_context = app_context
     service.config = config
     service.imagery_search_provider_instance = SimpleNamespace(requires_id=None, image_ids=None)
@@ -283,42 +259,37 @@ class TestDuplicateImagerySearchMultiRow:
         from mapflow.functional.service.provider_service import ProviderService
         from mapflow.config import ConfigColumns
 
+        from PyQt5.QtCore import QObject
+
         ProviderService._instance = None
         ProviderService._initialized = False
 
         config = Config()
         service = ProviderService.__new__(ProviderService)
+        QObject.__init__(service)  # imagerySearchDuplicated is a signal now
         service.config = config
         service.config_search_columns = ConfigColumns().METADATA_TABLE_ATTRIBUTES
         service.tr = lambda msg: msg
-        service.app_context = SimpleNamespace(metadata_layer=None,
-                                              search_footprints={},
-                                              meta_layer_table_connection=None)
-        service.selection_sync_callback = lambda *_a, **_kw: None
-
-        dlg = MagicMock()
-        dlg.metadataTable = MagicMock()
-        row_count_holder = {"n": 0}
-        dlg.metadataTable.setRowCount.side_effect = lambda n: row_count_holder.__setitem__("n", n)
-        dlg.metadataTable.rowCount.side_effect = lambda: row_count_holder["n"]
-        set_items = []
-        dlg.metadataTable.setItem.side_effect = lambda r, c, item: set_items.append((r, c, item))
         # A real QgsGeometry, not a MagicMock: duplicate_imagery_search builds a real
         # in-memory QgsVectorLayer and calls QgsFeature.setGeometry(), which rejects
         # anything that is not a genuine geometry. This is why the file sits in the
-        # qgis tier — see the module docstring.
+        # qgis tier — see the module docstring. The AOI layer is pushed to app_context now.
         from qgis.core import QgsGeometry
         aoi_feature = MagicMock()
         aoi_feature.geometry.return_value = QgsGeometry.fromWkt("POLYGON((0 0, 0 1, 1 1, 1 0, 0 0))")
-        layer = MagicMock()
-        layer.getFeatures.return_value = [aoi_feature]
-        dlg.polygonCombo.currentLayer.return_value = layer
-        dlg.tabWidget.findChild.return_value = MagicMock()
-        dlg.sourceCombo = MagicMock()
-        dlg.metadataTableFilled = MagicMock()
-        service.dlg = dlg
+        aoi_layer = MagicMock()
+        aoi_layer.getFeatures.return_value = [aoi_feature]
+        service.app_context = SimpleNamespace(metadata_layer=None,
+                                              search_footprints={},
+                                              meta_layer_table_connection=None,
+                                              aoi_layer=aoi_layer)
+        service.selection_sync_callback = lambda *_a, **_kw: None
         type(service).imagery_search_provider_index = property(lambda self: 0)
         service.providers = []
+
+        # The table fill is announced as a signal for SearchView to draw; capture what it carries.
+        duplicated_rows = []
+        service.imagerySearchDuplicated.connect(duplicated_rows.append)
 
         image_ids = ["img-1", "img-2", "img-3"]
         params = ImagerySearchParams(
@@ -328,19 +299,14 @@ class TestDuplicateImagerySearchMultiRow:
         )
         service.duplicate_imagery_search(params)
 
-        assert row_count_holder["n"] == 3, "Should create one table row per imageId"
+        assert len(duplicated_rows) == 1
+        rows = duplicated_rows[0]
+        assert len(rows) == 3, "Should hand over one row per imageId"
 
         id_col = config.SEARCH_ID_COLUMN_INDEX
-        id_items = [(r, item) for (r, c, item) in set_items if c == id_col]
-        assert len(id_items) == 3
-        # Read the value off the real QTableWidgetItem rather than inspecting mock call
-        # history: the service constructs genuine items (setData(Qt.DisplayRole, value)),
-        # so there is no call_args_list — and asserting on stored state is the better
-        # check anyway, since it survives a refactor that sets the text differently.
-        from PyQt5.QtCore import Qt
-        seen_ids = {item.data(Qt.DisplayRole) for _r, item in id_items}
+        seen_ids = {row[id_col] for row in rows}
         assert seen_ids == set(image_ids)
-        # Keys must be ints — `get_local_image_indices` casts the table text via int(),
+        # Keys must be ints — `get_local_image_indices` casts the local index via int(),
         # so a string-keyed dict would KeyError downstream and leave the request without dataProvider.
         keys = list(service.app_context.search_footprints.keys())
         assert all(isinstance(k, int) for k in keys)

--- a/tests/qgis/test_provider_duplicate_signals.py
+++ b/tests/qgis/test_provider_duplicate_signals.py
@@ -1,0 +1,121 @@
+"""The duplicate-a-processing cluster announces what the form must become, rather than writing it.
+
+ProviderService used to rebuild the start form directly — set the model combo, tick option
+checkboxes, pick the source, fill the metadata table. It touches no widget now (spec/007 §
+Services): each step emits a signal that `mapflow.py` wires to the view that owns the widget
+(ProcessingView, ProviderView, SearchView). These pin the payloads those signals carry, so a
+mis-wire in the composition root is the only way the form can go wrong — not the service.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.service import provider_service as provider_service_module
+from mapflow.functional.service.provider_service import ProviderService
+from mapflow.schema.processing import (DataProviderParams, DataProviderSchema,
+                                       MyImageryParams, MyImagerySchema)
+
+
+def _service(workflow_defs=None, providers=None):
+    ProviderService._instance = None
+    ProviderService._initialized = False
+    service = ProviderService.__new__(ProviderService)
+    QObject.__init__(service)
+    service.tr = lambda message: message
+    service.providers = providers if providers is not None else []
+    service.data_catalog_service = MagicMock()
+    defs = workflow_defs or {}
+    service.app_context = SimpleNamespace(
+        allow_enable_processing={"aoi_loaded": False, "my_mosaic_loaded": False, "my_image_loaded": False},
+        get_workflow_def=lambda name: defs.get(name))
+    return service
+
+
+def _record(signal):
+    seen = []
+    signal.connect(lambda *args: seen.append(args if len(args) != 1 else args[0]))
+    return seen
+
+
+# ---------- the model ----------
+
+def test_an_available_model_is_announced_not_written():
+    service = _service(workflow_defs={"Buildings": SimpleNamespace(optional_blocks=[])})
+    picked = _record(service.modelSelected)
+
+    service.duplicate_model(SimpleNamespace(workflowDef=SimpleNamespace(name="Buildings")))
+
+    assert picked == ["Buildings"]
+
+
+def test_a_missing_model_aborts_and_re_enables_start():
+    service = _service(workflow_defs={})  # "Roads" not enabled for the account
+    picked = _record(service.modelSelected)
+    reenabled = _record(service.startEnabled)
+
+    with patch.object(provider_service_module, "alert"):
+        service.duplicate_model(SimpleNamespace(workflowDef=SimpleNamespace(name="Roads")))
+
+    assert picked == []
+    assert reenabled == [()]
+
+
+def test_the_options_to_tick_are_the_processings_enabled_blocks_present_in_the_model():
+    model = SimpleNamespace(optional_blocks=[SimpleNamespace(displayName="Trees"),
+                                             SimpleNamespace(displayName="Cars")])
+    service = _service(workflow_defs={"Buildings": model})
+    ticked = _record(service.modelOptionsSet)
+
+    processing = SimpleNamespace(
+        workflowDef=SimpleNamespace(name="Buildings"),
+        blocks=[SimpleNamespace(displayName="Trees", enabled=True),
+                SimpleNamespace(displayName="Cars", enabled=False)])
+    with patch.object(provider_service_module, "alert"):
+        service.duplicate_model_options(processing)
+
+    # Only the enabled block that still exists in the model is ticked.
+    assert ticked == [["Trees"]]
+
+
+# ---------- the data provider ----------
+
+def test_an_available_data_provider_is_announced_with_its_index_and_zoom():
+    providers = [SimpleNamespace(name="Mapbox", api_name="mapbox"),
+                 SimpleNamespace(name="Sentinel", api_name="sentinel")]
+    service = _service(providers=providers)
+    chosen = _record(service.dataProviderSelected)
+
+    provider = DataProviderParams(DataProviderSchema(providerName="sentinel", zoom="15"))
+    service.duplicate_data_provider(provider)
+
+    assert chosen == [(1, "15")]
+
+
+def test_a_data_provider_not_on_the_account_aborts():
+    service = _service(providers=[SimpleNamespace(name="Mapbox", api_name="mapbox")])
+    chosen = _record(service.dataProviderSelected)
+    reenabled = _record(service.startEnabled)
+
+    provider = DataProviderParams(DataProviderSchema(providerName="gone", zoom="15"))
+    with patch.object(provider_service_module, "alert"):
+        service.duplicate_data_provider(provider)
+
+    assert chosen == []
+    assert reenabled == [()]
+
+
+# ---------- my imagery ----------
+
+def test_duplicating_a_my_imagery_mosaic_drives_the_catalog_through_its_service():
+    service = _service(providers=[])
+    shown = _record(service.myImageryDuplicated)
+
+    provider = MyImageryParams(MyImagerySchema(imageIds=None, mosaicId="m-1"))
+    service.duplicate_my_imagery(provider)
+
+    # The catalog is another region: reached through its service, never its view.
+    service.data_catalog_service.clear_mosaic_selection.assert_called_once()
+    service.data_catalog_service.select_mosaic_cell.assert_called_once_with("m-1")
+    service.data_catalog_service.set_catalog_provider.assert_called_once()
+    assert shown == [()]  # bring the catalog tab forward


### PR DESCRIPTION
ProviderService read the metadata table, the model combo and its options, the source/zoom combos,
the AOI combo and the tab widget, and it wrote most of them to rebuild the form when duplicating a
processing. A service may touch none of that (spec/007 § Services), and the entanglement was the
worst of the six: it spanned four views, exposed a module-function API that ProcessingService
imports and calls, and reached through another service's view.

The service now holds no dialog — the dlg parameter is gone entirely, which clears both of its
allowlist entries (widget-import and dialog-param) in this one change. It keeps the provider list,
the selection/validation logic and the duplicate-a-processing rebuild as requests and state; what
it needs off the widgets it is told, and what it wants drawn it announces.

The read path (get_provider_params / setup_provider_info / validate_provider_params and their
helpers) is called by ProcessingService — service to service, so it stays here and reads the search
selection off app_context instead of the table: selected_search_indices (pushed since C2.2b) plus a
new selected_search_image_ids, both set in mapflow.push_search_selection from SearchView. The
module-function signatures are unchanged, so ProcessingService's call sites are not touched.

The write path — the duplicate cluster — emits signals the composition root wires to the view that
owns each widget: model and options to ProcessingView, source/zoom/tabs to ProviderView, the
metadata-table rebuild to SearchView.fill_duplicated_search. Several widget reads became questions
about state that does not need a widget: whether a model is available is get_workflow_def, not the
combo; the option labels are the workflow def's optional blocks, not the checkboxes; whether a
provider is available is an index into `providers` by api_name, since set_raster_sources fills the
combo in that order. The AOI layer the duplicated search is rebuilt over is pushed to
app_context.aoi_layer on the polygon combo's layerChanged, rather than read from the combo.

get_data_provider and get_current_provider_index were dead (no callers) and are removed.

## Manual test
Add / edit / remove an imagery provider: the source combo updates, a name collision is refused.
Change the model: its imagery sources narrow. Run an imagery search, select one and several images:
the cost updates and a mixed-provider selection is blocked. Duplicate a processing from the
processings table for each source type — a basemap provider (source + zoom restored), My Imagery (a
mosaic and an image; the catalog tab comes forward), an imagery search (one metadata row per image,
all selected, the search tab forward), and a user-defined provider (added if missing, its zoom
restored). A duplication that can't complete (model no longer enabled, option removed, provider
gone) alerts and leaves the Start button usable.

Regression surface: the planned-processing gate and the provider-minimum-area check both read the
search selection through app_context now — a mis-ordered push shows as an empty selection (start
allowed when it should be blocked, or vice versa). The initial provider/source combo population
happens through signals wired before the first update_providers(), so an empty source combo at
startup means that wiring moved below the call.
