### PR TITLE
refactor: ProcessingService reads no widget at all

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,22 +105,17 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-[ ] C2.2c The last widget read: `startProcessing.isEnabled()` in `validate_context_params`.
-    Now unblocked — C2.3 and C2.4 have both stopped writing that button, so its state can be pushed
-    instead of read. Clears `dialog-param` / `widget-import` for `processing_service` together with
-    C2.6 (`ProcessingApi(dlg=...)`).
+[ready-for-review] C2.2c The last widget read: `startProcessing.isEnabled()` left
+    `validate_context_params` for the start-panel round trip (`start_enabled` on `set_start_panel`).
+    `ProcessingService` now touches no widget — `self.dlg` remains only to build `ProcessingApi`.
+    `dialog-param` / `widget-import` for `processing_service` still wait for C2.6 (the api's `dlg`,
+    and the QMessageBox/QApplication alert construction).
 
 #### Group B — the service reaches into other regions' widgets
 
 No view of its own, and the widgets belong to two or three other regions. These need pushed state,
 which is why they are last.
 
-[ready-for-review] C2.4 `ProviderService` → `ProviderController` + `ProviderView` (+ SearchView)
-    Read path (called by `processing_service`) reads the search selection off `app_context`
-    (`selected_search_indices` + new `selected_search_image_ids`); the duplicate cluster announces
-    via signals wired in `mapflow.py` to the view owning each widget. `dlg` param dropped entirely —
-    **both** allowlist entries (`widget-import` + `dialog-param`) cleared. Dead `get_data_provider`
-    / `get_current_provider_index` removed.
 [ ] C2.5 `AreaCalculatorService` (17, plus the `use_imagery_extent` checkbox it is handed directly)
     → `ProcessingController` (`spec/007_architecture.md` assigns it "AOI and provider selection,
     cost")

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -157,7 +157,8 @@ class ProcessingController(QObject):
             params=self.processing_view.read_processing_start_params(),
             enabled_blocks=self.processing_view.enabled_blocks(),
             has_option_widgets=self.processing_view.has_option_widgets(),
-            aoi_layer_chosen=self.processing_view.aoi_layer_chosen())
+            aoi_layer_chosen=self.processing_view.aoi_layer_chosen(),
+            start_enabled=self.processing_view.start_enabled())
 
     def start_processing(self, *args) -> None:
         """The Start button. The button is the start panel's, so its click is this controller's."""

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -149,6 +149,7 @@ class ProcessingService(QObject):
     #: What the start panel says, refreshed via `startPanelNeeded`. `None` params means the panel
     #: has never answered — treated as "no parameters", which is what an empty panel means anyway.
     _start_params = None
+    _start_enabled = True
     _enabled_blocks = ()
     #: Whether the option checkboxes have been built yet. A model that declares blocks is quoted
     #: only once they exist, so "no widgets" is not the same as "no blocks ticked".
@@ -218,14 +219,21 @@ class ProcessingService(QObject):
         self._filter = terms or ""
 
     def set_start_panel(self, params, enabled_blocks=(), has_option_widgets: bool = False,
-                        aoi_layer_chosen: bool = False) -> None:
-        """The start panel's current reading, answering `startPanelNeeded`. `aoi_layer_chosen`
-        rides along because the only code that reads it runs inside the same validation pass that
-        asks for this — so one synchronous push carries the whole panel."""
+                        aoi_layer_chosen: bool = False, start_enabled: bool = True) -> None:
+        """The start panel's current reading, answering `startPanelNeeded`. `aoi_layer_chosen` and
+        `start_enabled` ride along because the only code that reads them runs inside the same
+        validation pass that asks for this — so one synchronous push carries the whole panel."""
         self._start_params = params
         self._enabled_blocks = tuple(enabled_blocks or ())
         self._has_option_widgets = bool(has_option_widgets)
         self._aoi_layer_chosen = bool(aoi_layer_chosen)
+        self._start_enabled = bool(start_enabled)
+
+    def _read_start_enabled(self) -> bool:
+        """Whether Start is currently enabled, refreshed from the panel. `validate_context_params`
+        asks before deciding whether it may set the 'Set AOI' reason (see there)."""
+        self.startPanelNeeded.emit()
+        return self._start_enabled
 
     def _read_start_panel(self):
         """Refresh `_start_params` from whoever owns the panel, then return it."""
@@ -380,11 +388,11 @@ class ProcessingService(QObject):
         if planned_selection_error:
             return planned_selection_error
         if not self.app_context.aoi:
-            # The only widget this service still reads. It exists because "the button is currently
-            # enabled" means "an earlier check already set a reason", and re-reporting "Set AOI"
-            # over that reason would hide it. The button is written from DataCatalogView and
-            # ProviderService too, so this cannot become pushed state until they stop (C2.2c).
-            if self.dlg.startProcessing.isEnabled():
+            # "Start is enabled" means no earlier check has claimed the problems label, so it is
+            # safe to set the 'Set AOI' reason; if it is disabled, another concern already set a
+            # reason and re-reporting 'Set AOI' over it would hide it. Pushed synchronously rather
+            # than read off the widget — this is what made the service widget-free.
+            if self._read_start_enabled():
                 if not self.app_context.user_role.can_start_processing:
                     error = self.tr('Not enough rights to start processing in a shared project ({})').format(self.app_context.user_role.value)
                 else:

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -133,6 +133,12 @@ class ProcessingView:
     def set_start_enabled(self, enabled: bool) -> None:
         self.dlg.startProcessing.setEnabled(enabled)
 
+    def start_enabled(self) -> bool:
+        """Whether Start is currently enabled. Read by `validate_context_params` to tell 'no check
+        has claimed the problems label yet' from 'another concern already disabled the button and
+        set a reason' — which is why it must not blank that reason with its own."""
+        return self.dlg.startProcessing.isEnabled()
+
     def clear_problem_and_enable_start(self) -> None:
         """AREA/NONE billing: nothing blocks a start, so drop any leftover reason and enable it."""
         self.dlg.startProcessing.setEnabled(True)

--- a/tests/qgis/test_processing_start_panel.py
+++ b/tests/qgis/test_processing_start_panel.py
@@ -116,6 +116,8 @@ def test_reading_the_panel_fills_it_before_returning():
     controller.processing_view.has_option_widgets.return_value = True
     controller.processing_view.aoi_layer_chosen.return_value = True
 
+    controller.processing_view.start_enabled.return_value = False
+
     returned = service._read_start_panel()
 
     assert returned is params
@@ -123,6 +125,37 @@ def test_reading_the_panel_fills_it_before_returning():
     assert service._enabled_blocks == (True, False)
     assert service._has_option_widgets is True
     assert service._aoi_layer_chosen is True
+
+
+def test_reading_start_enabled_fills_it_synchronously():
+    """The last widget read the service used to make (`startProcessing.isEnabled()`) is now the
+    same synchronous round trip: it asks, the controller answers off the real button, and the
+    answer is back before `_read_start_enabled` returns."""
+    service = _service()
+    controller = _controller(service)
+    controller.processing_view.start_enabled.return_value = False
+
+    assert service._read_start_enabled() is False
+
+    controller.processing_view.start_enabled.return_value = True
+    assert service._read_start_enabled() is True
+
+
+def test_context_validation_sets_the_aoi_reason_only_when_start_is_enabled():
+    """The read guards a message: if the button is enabled nothing else has claimed the problems
+    label, so 'Set AOI' may be shown; if it is disabled another concern owns the label and this
+    must stay silent rather than overwrite it."""
+    service = _service()
+    controller = _controller(service)
+    service.app_context = SimpleNamespace(aoi=None,
+                                          user_role=SimpleNamespace(can_start_processing=True))
+    service.planned_processing_selection_error = lambda: None
+
+    controller.processing_view.start_enabled.return_value = True
+    assert service.validate_context_params() == "Set AOI to start processing"
+
+    controller.processing_view.start_enabled.return_value = False
+    assert service.validate_context_params() is None
 
 
 def test_with_no_controller_listening_the_panel_reads_empty():


### PR DESCRIPTION
refactor: ProcessingService reads no widget at all

The one widget read left after C2.2b was `startProcessing.isEnabled()` in validate_context_params.
It could not go while DataCatalogView and ProviderService still wrote that button — a pushed copy
would have gone stale under their writes. C2.3 and C2.4 stopped them, so it goes now.

The read tells "no earlier check has claimed the problems label" (button enabled) from "another
concern already set a reason there" (button disabled) — the guard that keeps 'Set AOI' from blanking
a live reason. It joins the start-panel round trip: validate_context_params emits startPanelNeeded
and reads the pushed `start_enabled` the controller answers with, the same synchronous inversion the
rest of the panel already used. `set_start_panel` carries one more field; no new signal.

ProcessingService now holds `self.dlg` only to build ProcessingApi(dlg=…). It touches no widget.
The dialog-param and widget-import allowlist entries stay until C2.6 removes the api's dlg and the
QMessageBox/QApplication alert construction.

## Manual test
With no AOI set and Start enabled, the problems label reads "Set AOI to start processing" (or the
shared-project rights message). Set an imagery source that disables Start with its own reason (e.g.
select a search image below a provider's minimum, or a mixed-provider selection): that reason must
stay — leaving the AOI unset must NOT overwrite it with "Set AOI". Regression surface: the AREA/NONE
billing path still enables Start with the problems label cleared.
