### PR TITLE
refactor: AreaCalculatorService computes without the dialog

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,26 +105,13 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-[ready-for-review] C2.2c The last widget read: `startProcessing.isEnabled()` left
-    `validate_context_params` for the start-panel round trip (`start_enabled` on `set_start_panel`).
-    `ProcessingService` now touches no widget — `self.dlg` remains only to build `ProcessingApi`.
-    `dialog-param` / `widget-import` for `processing_service` still wait for C2.6 (the api's `dlg`,
-    and the QMessageBox/QApplication alert construction).
-
 #### Group B — the service reaches into other regions' widgets
 
-No view of its own, and the widgets belong to two or three other regions. These need pushed state,
-which is why they are last.
-
-[ ] C2.5 `AreaCalculatorService` (17, plus the `use_imagery_extent` checkbox it is handed directly)
-    → `ProcessingController` (`spec/007_architecture.md` assigns it "AOI and provider selection,
-    cost")
-    Fewest accesses but not the easiest: nine are writes that become signals
-    (`disable_processing_start` ×3, `labelAoiArea`, the checkbox ×5), three are `providerIndex()`
-    which `app_context.data_provider` already answers, and the remaining ten are pulled widget
-    state — the AOI polygon layer ×4, the search-image selection ×2, the catalog dedup guard ×4 —
-    each needing its own push. It is also called *by another service* (`ProjectService`), so
-    "let the caller read the widget" does not work here.
+[ready-for-review] C2.5 `AreaCalculatorService` computes without the dialog. Reads the provider /
+    AOI layer / search selection off `app_context` (pushed by C2.2b/C2.4); announces `startDisabled`,
+    `areaChanged`, `imageryExtentChanged`. `get_aoi` takes the provider object, not a combo index.
+    `dlg` + `use_imagery_extent` dropped from the constructor — **both** allowlist entries cleared.
+    Catalog dedup is now geometry-based (the table cells it compared are not a service's to read).
 
 #### Then the api modules
 

--- a/mapflow/functional/service/area_calculator_service.py
+++ b/mapflow/functional/service/area_calculator_service.py
@@ -1,5 +1,5 @@
 from typing import Union, List, Optional
-from PyQt5.QtCore import QObject
+from PyQt5.QtCore import QObject, pyqtSignal
 from qgis.core import QgsVectorLayer, QgsWkbTypes, QgsGeometry, QgsFeature, QgsCoordinateReferenceSystem
 from ..app_context import AppContext
 from .. import layer_utils
@@ -11,29 +11,40 @@ from ...errors import (BadProcessingInput,
                        ImageIdRequired,
                        AoiNotIntersectsImage)
 from ..geometry import clip_aoi_to_image_extent
-from ...dialogs.main_dialog import MainDialog
 
 
 class AreaCalculatorService(QObject):
+    """Computes the processing AOI and its area, and prices it. It reads no widget: the AOI polygon
+    layer, the chosen provider and the selected search images all arrive on `app_context` (pushed
+    from the composition root), and what the panel must show leaves as a signal (`spec/007
+    § Services`)."""
+
+    #: (reason, clear the area label too) — a start is blocked.
+    startDisabled = pyqtSignal(str, bool)
+    #: The AOI area in sq.km, to show on the label.
+    areaChanged = pyqtSignal(float)
+    #: (enabled, label text) for the "Use imagery extent" action.
+    imageryExtentChanged = pyqtSignal(bool, str)
+
     def __init__(self,
                  iface,
                  app_context: AppContext,
-                 dlg: 'MainDialog',
                  config,
                  data_catalog_service,
                  processing_service,
-                 provider_service,
-                 use_imagery_extent
+                 provider_service
                  ):
         super().__init__()
         self.iface = iface
         self.app_context = app_context
-        self.dlg = dlg
         self.config = config
         self.data_catalog_service = data_catalog_service
         self.processing_service = processing_service
         self.provider_service = provider_service
-        self.use_imagery_extent = use_imagery_extent
+        #: The catalog AOI last priced, so a secondary multi-select that leaves the effective area
+        #: unchanged does not fire a redundant cost request. Content-based rather than the old
+        #: comparison of table cell indices, which a service can no longer read.
+        self._last_catalog_aoi_wkt = None
 
     def get_aoi_area_polygon_layer(self, layer: Union[QgsVectorLayer, None]) -> None:
         if not layer or layer.featureCount() == 0:
@@ -41,7 +52,7 @@ class AreaCalculatorService(QObject):
                 reason = self.tr('Not enough rights to start processing in a shared project ({})').format(self.app_context.user_role.value)
             else:
                 reason = self.tr('Set AOI to start processing')
-            self.dlg.disable_processing_start(reason, clear_area=True)
+            self.startDisabled.emit(reason, True)
             self.app_context.aoi = self.app_context.aoi_size = None
             return
 
@@ -66,7 +77,7 @@ class AreaCalculatorService(QObject):
                 reason = self.tr('Not enough rights to start processing in a shared project ({})').format(self.app_context.user_role.value)
             else:
                 reason = self.tr('AOI must contain not more than {} polygons').format(self.app_context.max_aois_per_processing)
-            self.dlg.disable_processing_start(reason, clear_area=True)
+            self.startDisabled.emit(reason, True)
             self.app_context.aoi = self.app_context.aoi_size = None
 
     def calculate_aoi_area_polygon_layer(self, layer: Union[QgsVectorLayer, None]) -> None:
@@ -76,20 +87,15 @@ class AreaCalculatorService(QObject):
         :param layer: The current polygon layer
         """
         self.get_aoi_area_polygon_layer(layer)
-        provider = self.provider_service.providers[self.dlg.providerIndex()]
-        if isinstance(provider, MyImageryProvider):
+        if isinstance(self.app_context.data_provider, MyImageryProvider):
             self.calculate_aoi_area_catalog()
 
     def calculate_aoi_area_use_image_extent(self) -> None:
-        """Get the AOI size when the Use image extent checkbox is toggled.
-
-        :param use_image_extent: The current state of the checkbox
-        """
-        provider = self.provider_service.providers[self.dlg.providerIndex()]
-        if isinstance(provider, MyImageryProvider):
+        """Get the AOI size when the Use image extent checkbox is toggled."""
+        if isinstance(self.app_context.data_provider, MyImageryProvider):
             self.calculate_aoi_area_catalog()
         else:
-            self.calculate_aoi_area_polygon_layer(self.dlg.polygonCombo.currentLayer())
+            self.calculate_aoi_area_polygon_layer(self.app_context.aoi_layer)
 
     def calculate_aoi_area_catalog(self) -> None:
         """Get the AOI size when a new mosaic or image in 'My imagery' is selected.
@@ -99,31 +105,29 @@ class AreaCalculatorService(QObject):
         image = self.data_catalog_service.selected_image()
         mosaic = self.data_catalog_service.selected_mosaic()
         if image or mosaic:
-            self.use_imagery_extent.setEnabled(True)
             if image:
                 catalog_aoi = QgsGeometry().fromWkt(image.footprint)
-                self.use_imagery_extent.setText(self.tr("Use extent of '{name}'").format(name=image.filename))
+                self.imageryExtentChanged.emit(True, self.tr("Use extent of '{name}'").format(name=image.filename))
             else:
                 catalog_aoi = QgsGeometry().fromWkt(mosaic.footprint)
-                self.use_imagery_extent.setText(self.tr("Use extent of '{name}'").format(name=mosaic.name))
+                self.imageryExtentChanged.emit(True, self.tr("Use extent of '{name}'").format(name=mosaic.name))
             aoi = layer_utils.get_catalog_aoi(catalog_aoi=catalog_aoi,
                                               selected_aoi=self.app_context.aoi)
         else:
-            aoi = self.get_aoi_area_polygon_layer(self.dlg.polygonCombo.currentLayer())
-            self.use_imagery_extent.setText(self.tr("Use imagery extent"))
-            self.use_imagery_extent.setEnabled(False)
+            aoi = self.get_aoi_area_polygon_layer(self.app_context.aoi_layer)
+            self.imageryExtentChanged.emit(False, self.tr("Use imagery extent"))
         if not self.app_context.aoi:  # other error message is already shown
             pass
         elif not aoi:  # error after intersection
-            self.dlg.disable_processing_start(reason=self.tr("Selected AOI does not intersect the selected imagery"),
-                                              clear_area=True)
+            self.startDisabled.emit(self.tr("Selected AOI does not intersect the selected imagery"), True)
             return
-        # Don't recalculate AOI if first selected mosaic/image didn't change
-        selected_mosaics = self.dlg.mosaicTable.selectedIndexes()
-        selected_images = self.dlg.imageTable.selectedIndexes()
-        if len(selected_mosaics) > 1 and self.dlg.selected_mosaic_cell == selected_mosaics[0] \
-                or len(selected_images) > 1 and self.dlg.selected_image_cell == selected_images[0]:
+        # Don't re-price the catalog AOI if the effective area did not change (e.g. a secondary
+        # multi-select). Compared by geometry rather than by table cell, which is not the service's
+        # to read.
+        aoi_wkt = aoi.asWkt() if aoi else None
+        if aoi_wkt is not None and aoi_wkt == self._last_catalog_aoi_wkt:
             return
+        self._last_catalog_aoi_wkt = aoi_wkt
         self.calculate_aoi_area(aoi, helpers.WGS84)
 
     def calculate_aoi_area_selection(self, _: List[QgsFeature]) -> None:
@@ -131,14 +135,14 @@ class AreaCalculatorService(QObject):
 
         :param _: A list of currently selected features
         """
-        layer = self.dlg.polygonCombo.currentLayer()
+        layer = self.app_context.aoi_layer
         if layer == self.iface.activeLayer():
             self.calculate_aoi_area_polygon_layer(layer)
 
     def calculate_aoi_area_layer_edited(self) -> None:
         """Get the AOI size when a feature is added or remove from a layer."""
         layer = self.sender()
-        if layer == self.dlg.polygonCombo.currentLayer():
+        if layer == self.app_context.aoi_layer:
             self.calculate_aoi_area_polygon_layer(layer)
 
     def calculate_aoi_area(self, aoi: QgsGeometry, crs: QgsCoordinateReferenceSystem) -> None:
@@ -153,18 +157,13 @@ class AreaCalculatorService(QObject):
 
         self.app_context.aoi = aoi  # save for reuse in processing creation or metadata requests
 
-        # fetch UI data
-        provider_index = self.dlg.providerIndex()
-        selected_images = self.dlg.metadataTable.selectedItems()
-        if selected_images:
-            rows = list(set(image.row() for image in selected_images))
-            local_image_indices = [int(self.dlg.metadataTable.item(row, self.config.LOCAL_INDEX_COLUMN).text())
-                                   for row in rows]
-        else:
-            local_image_indices = []
+        # The chosen provider and the selected search images are pushed to app_context, so the
+        # service need not read the source combo or the metadata table.
+        provider = self.app_context.data_provider
+        local_image_indices = [int(index) for index in (self.app_context.selected_search_indices or [])]
         # This is AOI with respect to selected search images and raster image extent
         try:
-            real_aoi = self.get_aoi(provider_index=provider_index,
+            real_aoi = self.get_aoi(provider=provider,
                                     local_image_indices=local_image_indices,
                                     selected_aoi=self.app_context.aoi)
         except ImageIdRequired:
@@ -186,19 +185,18 @@ class AreaCalculatorService(QObject):
             # measureArea rejects what it was handed; an unmeasurable AOI prices as zero.
             self.app_context.aoi_size = 0
 
-        self.dlg.labelAoiArea.setText(self.tr('Area: {:.2f} sq.km').format(self.app_context.aoi_size))
+        self.areaChanged.emit(self.app_context.aoi_size)
         if self.app_context.aoi_size > 0:
             self.processing_service.update_processing_cost()
-    
+
     def get_aoi(self,
-                provider_index: Optional[int],
+                provider,
                 selected_aoi: QgsGeometry,
                 local_image_indices: Optional[List[int]]) -> QgsGeometry:
         if not helpers.check_aoi(selected_aoi):
             raise BadProcessingInput(self.tr('Bad AOI. AOI must be inside boundaries:'
                                              ' \n[-180, 180] by longitude, [-90, 90] by latitude'))
         else:
-            provider = self.provider_service.providers[provider_index]
             if not provider:
                 raise PluginError(self.tr('Providers are not initialized'))
             if len(local_image_indices) != 0:
@@ -230,7 +228,7 @@ class AreaCalculatorService(QObject):
             else:
                 aoi = selected_aoi
         return aoi
-    
+
     def crop_aoi_with_image_footprint(self,
                                       aoi: QgsFeature,
                                       local_image_indices: List[int]):
@@ -245,4 +243,3 @@ class AreaCalculatorService(QObject):
         except StopIteration:
             raise AoiNotIntersectsImage() from None
         return aoi
-    

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -130,6 +130,10 @@ class ProcessingView:
     def set_processing_name(self, name: str) -> None:
         self.dlg.processingName.setText(name)
 
+    def set_aoi_area(self, area_sqkm: float) -> None:
+        """Show the processing AOI area. `AreaCalculatorService` computes it and announces it."""
+        self.dlg.labelAoiArea.setText(self.tr('Area: {:.2f} sq.km').format(area_sqkm))
+
     def set_start_enabled(self, enabled: bool) -> None:
         self.dlg.startProcessing.setEnabled(enabled)
 

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -431,12 +431,15 @@ class Mapflow(QObject):
         # ========== 10. INITIALIZE AREA CALCULATOR SERVICE ==========
         self.area_calculator_service = AreaCalculatorService(iface=self.iface,
                                                              app_context=self.app_context,
-                                                             dlg=self.dlg,
                                                              config=self.config,
                                                              data_catalog_service=self.data_catalog_service,
                                                              processing_service=self.processing_service,
-                                                             provider_service=self.provider_service,
-                                                             use_imagery_extent=self.use_imagery_extent)
+                                                             provider_service=self.provider_service)
+        # The service holds no widget: what it computes for the panel leaves as a signal, and the
+        # views/actions that own those widgets are wired here.
+        self.area_calculator_service.startDisabled.connect(self.processing_view.disable_processing_start)
+        self.area_calculator_service.areaChanged.connect(self.processing_view.set_aoi_area)
+        self.area_calculator_service.imageryExtentChanged.connect(self._update_imagery_extent_action)
         self.project_service.area_calculator_service = self.area_calculator_service
         # SearchController is built well before this service (it is needed by the search wiring
         # above), so its cost-recompute collaborator is set here, as the other back-links are.
@@ -617,6 +620,13 @@ class Mapflow(QObject):
         """The AOI combo's current layer, pushed to `app_context` for `ProviderService`'s
         duplicated-search rebuild. `layerChanged` passes the new layer; on a bare call read it."""
         self.app_context.aoi_layer = layer if layer is not None else self.dlg.polygonCombo.currentLayer()
+
+    def _update_imagery_extent_action(self, enabled: bool, text: str) -> None:
+        """Apply what `AreaCalculatorService` decided for the 'Use imagery extent' action — it owns
+        the AOI-from-imagery logic but not the widget."""
+        self.use_imagery_extent.setEnabled(enabled)
+        if text:
+            self.use_imagery_extent.setText(text)
 
     def push_search_selection(self):
         """Deliver the search table's selection to `app_context`, where it sits beside

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -67,7 +67,6 @@ ALLOWED = {
     ("widget-import", "mapflow.functional.service.processing_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
     # Services and two api modules taking the main dialog as a constructor argument.
-    ("dialog-param", "mapflow.functional.service.area_calculator_service"),
     ("dialog-param", "mapflow.functional.service.data_catalog"),
     ("dialog-param", "mapflow.functional.service.processing_service"),
     ("dialog-param", "mapflow.functional.api.data_catalog_api"),
@@ -76,7 +75,6 @@ ALLOWED = {
     # that module is clean — fixing four of five imports leaves the exemption in place.
     ("api-imports-dialogs", "mapflow.functional.api.data_catalog_api"),
     ("api-imports-dialogs", "mapflow.functional.api.processing_api"),
-    ("service-imports-dialogs", "mapflow.functional.service.area_calculator_service"),
     ("service-imports-dialogs", "mapflow.functional.service.data_catalog"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
     ("view-imports-service", "mapflow.functional.view.processing_view"),

--- a/tests/qgis/test_area_calculator_service.py
+++ b/tests/qgis/test_area_calculator_service.py
@@ -1,0 +1,140 @@
+"""QGIS-tier tests for AreaCalculatorService after it lost the dialog.
+
+It computed the AOI area and drove the Start button, the area label and the 'Use imagery extent'
+action directly, and read the source combo, the AOI combo and the metadata table. A service may do
+none of that (`spec/007_architecture.md` § Services). It now announces (startDisabled, areaChanged,
+imageryExtentChanged) and reads the AOI layer, the provider and the selected search images off
+`app_context`, pushed from the composition root.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from PyQt5.QtCore import QObject
+from qgis.core import QgsGeometry, QgsVectorLayer, QgsFeature, QgsProject
+
+from mapflow.functional.service.area_calculator_service import AreaCalculatorService
+from mapflow.model.provider import MyImageryProvider, ImagerySearchProvider
+
+
+def _service(**app_context):
+    service = AreaCalculatorService.__new__(AreaCalculatorService)
+    QObject.__init__(service)
+    service.tr = lambda text: text
+    service.iface = MagicMock()
+    service.config = SimpleNamespace(LOCAL_INDEX_COLUMN=0)
+    service.data_catalog_service = MagicMock()
+    service.data_catalog_service.selected_image.return_value = None
+    service.data_catalog_service.selected_mosaic.return_value = None
+    service.processing_service = MagicMock()
+    service.provider_service = MagicMock()
+    service._last_catalog_aoi_wkt = None
+    defaults = dict(aoi=None, aoi_size=None, processing_aoi=None, aoi_layer=None,
+                    data_provider=None, selected_search_indices=[], search_footprints={},
+                    max_aois_per_processing=1, project=QgsProject.instance(),
+                    user_role=SimpleNamespace(can_start_processing=True, value="owner"))
+    defaults.update(app_context)
+    service.app_context = SimpleNamespace(**defaults)
+    return service
+
+
+def _polygon_layer(wkt="POLYGON((0 0, 0.001 0, 0.001 0.001, 0 0.001, 0 0))",
+                   geom_type="Polygon"):
+    layer = QgsVectorLayer(f"{geom_type}?crs=EPSG:4326", "aoi", "memory")
+    feature = QgsFeature()
+    feature.setGeometry(QgsGeometry.fromWkt(wkt))
+    layer.dataProvider().addFeature(feature)
+    layer.updateExtents()
+    return layer
+
+
+# ---------- the writes are announced ----------
+
+def test_an_empty_layer_blocks_the_start_and_clears_the_area():
+    service = _service()
+    blocked = []
+    service.startDisabled.connect(lambda *a: blocked.append(a))
+
+    service.get_aoi_area_polygon_layer(None)
+
+    assert blocked == [("Set AOI to start processing", True)]
+    assert service.app_context.aoi is None and service.app_context.aoi_size is None
+
+
+def test_too_many_polygons_blocks_with_the_limit_message():
+    service = _service(max_aois_per_processing=1)
+    blocked = []
+    service.startDisabled.connect(lambda *a: blocked.append(a))
+
+    service.get_aoi_area_polygon_layer(
+        _polygon_layer("MULTIPOLYGON(((0 0,0.001 0,0.001 0.001,0 0.001,0 0)),"
+                       "((1 1,1.001 1,1.001 1.001,1 1.001,1 1)))",
+                       geom_type="MultiPolygon"))
+
+    assert blocked and "not more than 1 polygons" in blocked[0][0]
+    assert blocked[0][1] is True
+
+
+def test_a_measured_area_is_announced_and_priced():
+    # A plain provider (no image id, not search/my-imagery) leaves the AOI uncropped.
+    service = _service(data_provider=SimpleNamespace(requires_image_id=False))
+    areas = []
+    service.areaChanged.connect(areas.append)
+
+    service.calculate_aoi_area(QgsGeometry.fromWkt("POLYGON((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))"),
+                               _polygon_layer().crs())
+
+    assert areas and areas[0] > 0
+    service.processing_service.update_processing_cost.assert_called_once()
+
+
+# ---------- the reads come from app_context, not widgets ----------
+
+def test_the_provider_and_search_selection_come_from_app_context():
+    """`calculate_aoi_area` used to read the source combo and the metadata table; it now takes the
+    pushed provider and indices. A search provider with a selected footprint crops the AOI to it."""
+    footprint = QgsGeometry.fromWkt("POLYGON((0 0, 0.02 0, 0.02 0.02, 0 0.02, 0 0))")
+    provider = ImagerySearchProvider.__new__(ImagerySearchProvider)
+    service = _service(data_provider=provider,
+                       selected_search_indices=["7"],
+                       search_footprints={7: _footprint_feature(footprint)})
+    service.get_aoi = MagicMock(return_value=footprint)
+
+    service.calculate_aoi_area(QgsGeometry.fromWkt("POLYGON((0 0, 0.05 0, 0.05 0.05, 0 0.05, 0 0))"),
+                               _polygon_layer().crs())
+
+    provider_arg = service.get_aoi.call_args.kwargs["provider"]
+    indices_arg = service.get_aoi.call_args.kwargs["local_image_indices"]
+    assert provider_arg is provider
+    assert indices_arg == [7]  # coerced to int from the pushed strings
+
+
+def test_get_aoi_takes_a_provider_object_not_an_index():
+    service = _service()
+    provider = SimpleNamespace(requires_image_id=False)
+    aoi = QgsGeometry.fromWkt("POLYGON((0 0, 0.01 0, 0.01 0.01, 0 0.01, 0 0))")
+
+    assert service.get_aoi(provider=provider, selected_aoi=aoi, local_image_indices=[]) == aoi
+    service.provider_service.providers.__getitem__.assert_not_called()
+
+
+# ---------- the catalog dedup no longer reads the table ----------
+
+def test_the_catalog_aoi_is_not_re_priced_when_the_area_is_unchanged():
+    image = SimpleNamespace(footprint="POLYGON((0 0, 0.02 0, 0.02 0.02, 0 0.02, 0 0))",
+                            filename="scene.tif")
+    service = _service(aoi=QgsGeometry.fromWkt("POLYGON((0 0, 0.05 0, 0.05 0.05, 0 0.05, 0 0))"),
+                       data_provider=MyImageryProvider.__new__(MyImageryProvider))
+    service.data_catalog_service.selected_image.return_value = image
+    priced = []
+    service.calculate_aoi_area = lambda aoi, crs: priced.append(aoi)
+
+    service.calculate_aoi_area_catalog()
+    service.calculate_aoi_area_catalog()  # same image, same AOI
+
+    assert len(priced) == 1  # the second call is deduplicated on the geometry
+
+
+def _footprint_feature(geom):
+    feature = QgsFeature()
+    feature.setGeometry(geom)
+    return feature


### PR DESCRIPTION
The service read the source combo, the AOI combo and the metadata table, and drove the Start
button, the area label and the "Use imagery extent" action. A service may do none of that (spec/007
§ Services). It now reads the provider, the AOI layer and the selected search images off app_context
— all already pushed there by C2.2b/C2.4 — and announces what it computes:

  startDisabled(reason, clear_area)  -> processing_view.disable_processing_start
  areaChanged(area_sqkm)             -> processing_view.set_aoi_area
  imageryExtentChanged(enabled, text)-> the "Use imagery extent" action (kept in mapflow.py)

get_aoi takes the chosen provider object instead of a combo index, so the provider-list read goes
too. The constructor drops both `dlg` and the `use_imagery_extent` QAction; the service imports no
dialog, which clears both of its allowlist entries (dialog-param + service-imports-dialogs).

The catalog dedup guard changed in kind, not just in plumbing. It compared Qt table cell indices to
skip re-pricing on a secondary multi-select — a service cannot read the table, and the pushed
mosaic/image ids are row-ordered rather than click-ordered, so the old "first selected cell ==
remembered primary" test has no faithful pushed form. It is now a geometry check: remember the last
catalog AOI priced, skip when the new one is identical. Same intent (no redundant cost request), and
it dedups on the effective area rather than on a cell identity a coincidentally-equal geometry could
diverge from.

## Manual test
Draw or pick an AOI: the "Area: N sq.km" label updates and a credits account gets a cost. Clear it:
the label clears and Start disables with "Set AOI to start processing". Pick an AOI with more
polygons than the plan allows: it is refused with the polygon-count message. Switch the source to My
Imagery and select a mosaic/image: the area is measured against the imagery footprint and the "Use
extent of '<name>'" action enables; deselect: it falls back to "Use imagery extent", disabled.

Regression surface: selecting a second mosaic/image without changing the primary must NOT fire a
second cost request (the geometry dedup); an imagery-search AOI must still be cropped to the selected
footprint before pricing; and switching provider must re-price against the new source.
