### PR TITLE
refactor: the api clients drop the dialog, finishing Phase C2

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -105,25 +105,25 @@ controllers: the processings table is `ProjectProcessingController`'s region and
 in the plugin. **The allowlist entries clear only when the second lands** — C2.2a shrinks the
 service without finishing it, which is the price of a reviewable diff.
 
-#### Group B — the service reaches into other regions' widgets
-
-[ready-for-review] C2.5 `AreaCalculatorService` computes without the dialog. Reads the provider /
-    AOI layer / search selection off `app_context` (pushed by C2.2b/C2.4); announces `startDisabled`,
-    `areaChanged`, `imageryExtentChanged`. `get_aoi` takes the provider object, not a combo index.
-    `dlg` + `use_imagery_extent` dropped from the constructor — **both** allowlist entries cleared.
-    Catalog dedup is now geometry-based (the table cells it compared are not a service's to read).
-
 #### Then the api modules
 
-[ ] C2.6 `ProcessingApi` and `DataCatalogApi` — different in kind: they hold the dialog only to
-    pass it to the result loader, so this is a constructor change, not a view extraction. Last
-    because the result loader's own home is decided in Phase D.
+[ready-for-review] C2.6 `ProcessingApi` and `DataCatalogApi` drop the `dlg` constructor argument —
+    the last one held only to pass through. `ProcessingApi` never used it; `DataCatalogApi` used it
+    once (writing "Preview is unavailable"), now announced via `previewUnavailable` for the view.
+    Dropping it let `ProcessingService` and `DataCatalogService` drop their own `dlg` too. Six
+    allowlist entries cleared: all four `dialog-param`, `processing_api`'s `api-imports-dialogs`,
+    `data_catalog`'s `service-imports-dialogs`.
 
 Each MR deletes its own entries from `tests/functional/test_layering.py`'s `ALLOWED` — removing
 them is part of the MR, not a follow-up. `test_the_allowlist_has_no_stale_entries` then fails if an
 exemption outlives its violation, so the list cannot silently drift.
 
-Acceptance: `ALLOWED` is empty, and `MAY_IMPORT` holds with no exemptions.
+**Phase C2 done: every service is widget-free.** The six entries still in `ALLOWED` are not C2's:
+they are the error-report widget (`ErrorMessageWidget`) and alert (`QMessageBox`) construction still
+inside `processing_service` / `data_catalog_api` / `alert_service`, plus `processing_view` importing
+the alert helper. Those are the **error-reporting phase**'s to clear (spec/006, sequenced after
+Phase C). Acceptance ("`ALLOWED` empty, `MAY_IMPORT` with no exemptions") is reached there, not at
+C2.6.
 
 ### Phase C3 — fix what the refactoring found
 

--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -12,7 +12,6 @@ from ...schema.data_catalog import PreviewSize, MosaicCreateSchema, ImageReturnS
 from ...http import Http, get_error_report_body, data_catalog_message_parser
 from ...functional import layer_utils
 from ...dialogs.error_message_widget import ErrorMessageWidget
-from ...dialogs.main_dialog import MainDialog
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +22,13 @@ class DataCatalogApi(QObject):
     """
     mosaicsUpdated = pyqtSignal()
 
+    #: A preview could not be loaded — the view should say so in the preview pane. The api holds
+    #: no widget; what it used to write to `imagePreview` it now announces.
+    previewUnavailable = pyqtSignal()
+
     def __init__(self,
                  http: Http,
                  server: str,
-                 dlg: MainDialog,
                  iface,
                  result_loader,
                  plugin_version):
@@ -34,7 +36,6 @@ class DataCatalogApi(QObject):
         self.server = server
         self.http = http
         self.iface = iface
-        self.dlg = dlg
         self.result_loader = result_loader
         self.plugin_version = plugin_version
 
@@ -304,7 +305,7 @@ class DataCatalogApi(QObject):
                      )
 
     def preview_s_error_handler(self, response: QNetworkReply):
-        self.dlg.imagePreview.setText("Preview is unavailable")
+        self.previewUnavailable.emit()
     
     def get_image_preview_l(self,
                             image: ImageReturnSchema,

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -4,7 +4,6 @@ from uuid import UUID
 
 from PyQt5.QtCore import QObject
 from ...http import Http
-from ...dialogs.main_dialog import MainDialog
 from ...schema.processing import (
     PostProcessingSchema,
     UpdateProcessingSchema,
@@ -33,13 +32,11 @@ class ProcessingApi(QObject):
 
     def __init__(self,
                  http: Http,
-                 dlg: MainDialog,
                  iface,
                  result_loader):
         super().__init__()
         self.http = http
         self.iface = iface
-        self.dlg = dlg
         self.result_loader = result_loader
 
     # project CRUD

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -8,7 +8,6 @@ from PyQt5.QtGui import QImage
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.core import QgsRasterLayer
 
-from ...dialogs.main_dialog import MainDialog
 from ...schema.data_catalog import PreviewSize, MosaicReturnSchema, ImageReturnSchema, UserLimitSchema
 from ...schema import MyImageryParams
 from ..api.data_catalog_api import DataCatalogApi
@@ -79,20 +78,16 @@ class DataCatalogService(QObject):
     def __init__(self,
                  http: Http,
                  server: str,
-                 dlg: MainDialog,
                  iface,
                  result_loader,
                  plugin_version,
                  app_context: AppContext):
         super().__init__()
-        #: Held only to build `DataCatalogApi(dlg=…)`; the service itself touches no widget. The
-        #: dlg parameter and the api's own use of it are removed in C2.6.
-        self.dlg = dlg
         self.iface = iface
         self.app_context = app_context
         self.result_loader = result_loader
         self.plugin_version = plugin_version
-        self.api = DataCatalogApi(http=http, server=server, dlg=dlg, iface=iface, result_loader=self.result_loader, plugin_version=self.plugin_version)
+        self.api = DataCatalogApi(http=http, server=server, iface=iface, result_loader=self.result_loader, plugin_version=self.plugin_version)
         self.mosaics = {}
         self.images = []
         self.image_max_size_pixels = Config.MAX_FILE_SIZE_PIXELS

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -13,7 +13,6 @@ from .provider_service import (get_provider_params,
                                duplicate_provider_and_model)
                                
 from .. import helpers
-from ...dialogs.main_dialog import MainDialog
 from ...errors import (BadProcessingInput,
                        ErrorMessage,
                        PluginError,
@@ -160,19 +159,16 @@ class ProcessingService(QObject):
 
     def __init__(self,
                  http: Http,
-                 dlg: MainDialog,
                  iface,
                  result_loader: ResultsLoader,
                  app_context: AppContext,
                  timer_interval):
         super().__init__()
         self.http = http
-        self.dlg = dlg
         self.iface = iface
         self.result_loader = result_loader
         self.app_context = app_context
         self.api = ProcessingApi(http=http,
-                                 dlg=dlg,
                                  iface=iface,
                                  result_loader=self.result_loader)
         self.processings = {}

--- a/mapflow/functional/view/data_catalog_view.py
+++ b/mapflow/functional/view/data_catalog_view.py
@@ -332,6 +332,9 @@ class DataCatalogView(QObject):
         self.dlg.imagePreview.setPixmap(QPixmap.fromImage(preview_image))
         self.dlg.imagePreview.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
 
+    def set_preview_unavailable(self):
+        self.dlg.imagePreview.setText(self.tr("Preview is unavailable"))
+
     def selected_mosaic_ids(self, limit=None):
         # Add unique selected rows
         selected_rows = list(set(index.row() for index in self.dlg.mosaicTable.selectionModel().selectedIndexes()))

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -203,7 +203,6 @@ class Mapflow(QObject):
 
         self.data_catalog_service = DataCatalogService(self.http,
                                                     self.server,
-                                                    self.dlg,
                                                     self.iface,
                                                     self.result_loader,
                                                     self.app_context.plugin_version,
@@ -211,6 +210,9 @@ class Mapflow(QObject):
         # The My Imagery panel's view. Built here, not by the service (a service holds no view);
         # DataCatalogController renders through it.
         self.data_catalog_view = DataCatalogView(dlg=self.dlg, app_context=self.app_context)
+        # A failed preview used to be written to the pane by the api; it announces now, the view draws.
+        self.data_catalog_service.api.previewUnavailable.connect(
+            self.data_catalog_view.set_preview_unavailable)
         # The catalog tables' selection is resolved by the service (into mosaics/images) and by
         # AreaCalculatorService (for the AOI area) — both told the ids, neither reading the table.
         # The push runs before those handlers, so it is connected here, above them, in the raw
@@ -240,7 +242,6 @@ class Mapflow(QObject):
         self.provider_service.imagerySourcesChanged.connect(self.provider_view.set_raster_sources)
 
         self.processing_service = ProcessingService(http=self.http,
-                                                    dlg=self.dlg,
                                                     iface=self.iface,
                                                     result_loader=self.result_loader,
                                                     app_context=self.app_context,

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -66,16 +66,12 @@ ALLOWED = {
     ("widget-import", "mapflow.functional.service.alert_service"),
     ("widget-import", "mapflow.functional.service.processing_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
-    # Services and two api modules taking the main dialog as a constructor argument.
-    ("dialog-param", "mapflow.functional.service.data_catalog"),
-    ("dialog-param", "mapflow.functional.service.processing_service"),
-    ("dialog-param", "mapflow.functional.api.data_catalog_api"),
-    ("dialog-param", "mapflow.functional.api.processing_api"),
     # Reaching upwards for dialogs and views. One entry per module, so it clears only when
-    # that module is clean — fixing four of five imports leaves the exemption in place.
+    # that module is clean — fixing four of five imports leaves the exemption in place. These
+    # remaining ones are all the error-report widget (ErrorMessageWidget) construction still in
+    # a service/api, and one view reaching the alert helper — cleared by the error-reporting phase,
+    # which is sequenced after Phase C.
     ("api-imports-dialogs", "mapflow.functional.api.data_catalog_api"),
-    ("api-imports-dialogs", "mapflow.functional.api.processing_api"),
-    ("service-imports-dialogs", "mapflow.functional.service.data_catalog"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
     ("view-imports-service", "mapflow.functional.view.processing_view"),
 }

--- a/tests/qgis/test_api_no_dialog.py
+++ b/tests/qgis/test_api_no_dialog.py
@@ -1,0 +1,41 @@
+"""QGIS-tier tests: the api clients hold no dialog (C2.6, the last of Phase C2).
+
+`ProcessingApi` and `DataCatalogApi` took the main dialog as a constructor argument — the last
+`dlg` parameters in the api/service layers. `ProcessingApi` never used it; `DataCatalogApi` used it
+in one place, to write "Preview is unavailable" into the preview pane, which is now announced for
+the view to draw. Dropping the parameter is what let `ProcessingService` and `DataCatalogService`
+drop their own `dlg` too, clearing four `dialog-param` allowlist entries.
+"""
+import inspect
+from unittest.mock import MagicMock
+
+from PyQt5.QtCore import QObject
+
+from mapflow.functional.api.processing_api import ProcessingApi
+from mapflow.functional.api.data_catalog_api import DataCatalogApi
+from mapflow.functional.service.processing_service import ProcessingService
+from mapflow.functional.service.data_catalog import DataCatalogService
+
+
+def test_no_api_or_service_constructor_takes_a_dialog():
+    for cls in (ProcessingApi, DataCatalogApi, ProcessingService, DataCatalogService):
+        params = set(inspect.signature(cls.__init__).parameters)
+        assert "dlg" not in params, f"{cls.__name__} still takes a dlg"
+
+
+def test_processing_api_builds_without_a_dialog():
+    api = ProcessingApi(http=MagicMock(), iface=MagicMock(), result_loader=MagicMock())
+    assert not hasattr(api, "dlg")
+
+
+def test_a_failed_preview_is_announced_not_drawn():
+    """The api used to write straight into the preview pane; it emits instead, and the view (wired
+    in mapflow.py) renders. Announcing keeps the api widget-free."""
+    api = DataCatalogApi.__new__(DataCatalogApi)
+    QObject.__init__(api)
+    announced = []
+    api.previewUnavailable.connect(lambda: announced.append(True))
+
+    api.preview_s_error_handler(MagicMock())
+
+    assert announced == [True]

--- a/tests/qgis/test_data_catalog.py
+++ b/tests/qgis/test_data_catalog.py
@@ -84,11 +84,9 @@ class TestDownloadApiUrl:
         """API client constructs correct download URL."""
         from mapflow.functional.api.data_catalog_api import DataCatalogApi
 
-        dlg_mock = MagicMock()
         api = DataCatalogApi(
             http=http_mock,
             server="https://whitemaps.mapflow.ai/rest",
-            dlg=dlg_mock,
             iface=MagicMock(),
             result_loader=MagicMock(),
             plugin_version="1.0.0",

--- a/tests/qgis/test_processing_templates.py
+++ b/tests/qgis/test_processing_templates.py
@@ -227,7 +227,7 @@ class TestTemplateSchemas:
 class TestTemplateApi:
     def setup_method(self):
         self.http = MagicMock()
-        self.api = ProcessingApi(http=self.http, dlg=MagicMock(), iface=MagicMock(), result_loader=MagicMock())
+        self.api = ProcessingApi(http=self.http, iface=MagicMock(), result_loader=MagicMock())
 
     def test_get_templates_path(self):
         callback = MagicMock()


### PR DESCRIPTION
ProcessingApi and DataCatalogApi were the last things below the controller layer holding the main
dialog. ProcessingApi never used it — it was stored and forgotten. DataCatalogApi used it once, to
write "Preview is unavailable" into the preview pane from a network error handler; that is now a
previewUnavailable signal the view draws (wired in mapflow.py), so the api touches no widget.

Dropping the apis' dlg removed the only reason ProcessingService and DataCatalogService still took a
dlg of their own — each merely forwarded it to its api (processing since C2.2c, catalog since C2.3).
So all four constructors lose the parameter and the MainDialog type-hint import that came with it.

Six layering allowlist entries clear: all four dialog-param exemptions, ProcessingApi's
api-imports-dialogs, and DataCatalogService's service-imports-dialogs.

With this, every service in the plugin is widget-free — the goal of Phase C2. The six entries still
in ALLOWED are not C2's to clear: they are the error-report widget (ErrorMessageWidget) and alert
(QMessageBox) construction still inside processing_service, data_catalog_api and alert_service, plus
processing_view importing the alert helper. Those belong to the error-reporting phase (spec/006),
which is sequenced after Phase C; the allowlist comment and the WAL now say so, so the empty-list
acceptance is not mistaken for something C2.6 left undone.

## Manual test
none — no user-visible behaviour changes. The one moved effect (a failed image preview showing
"Preview is unavailable" in the My Imagery preview pane) still happens; force it by selecting an
image whose small preview 404s. Regression surface: the plugin still boots (the two services and two
apis are constructed without a dlg), and processings/My-Imagery still load.
