### PR TITLE
refactor: the message tier moves to infra, out of the service layer

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -285,16 +285,32 @@ The state that motivates it, as measured on `dev`:
   missed both data_catalog ones. A further 26 sites opt out but pass their own handler, which is
   correct and out of scope.)
 
+**Layering sub-phase (empties `ALLOWED`).** The message/report tiers are being reclassified to a new
+`infra/` tier — a spec delta approved by the user (spec/006 § Where each tier lives, spec/007 §§
+Target structure / Layer rules / Services now put both tiers in `infra/`, not `service/`). This runs
+first because the reporter must be reachable from an `api` before the api can call it.
+
+[ready-for-review] MR-1 the message tier (`alert_service`) → `mapflow/infra/`. Clears
+    `widget-import·alert_service` and `view-imports-service·processing_view`. Pure move; `infra`
+    layer added to `test_layering`. `report_http_error` stays in the moved file until step 2.
+[ ] MR-2 `processing_service` stops building `ErrorMessageWidget`/`QMessageBox` — routes through the
+    infra reporter + `alert_info`. Clears `widget-import` + `service-imports-dialogs` for it.
+[ ] MR-3a `data_catalog_api`'s 6 `ErrorMessageWidget` sites → infra reporter. Clears
+    `api-imports-dialogs·data_catalog_api`.
+[ ] MR-3b `data_catalog_api` upload-progress `QProgressBar` → `DataCatalogController`. Clears
+    `widget-import·data_catalog_api` → **`ALLOWED` empty**.
+
 [ ] 1. Signature and throttle for the HTTP path
 `response_signature(response)` = Qt error code + endpoint path; `http._request_path` already
 computes that path, query-free, because it lands in a mail body. Carry `suppressed_count` into
 the dialog text and report body the way the exception path does.
 
 [ ] 2. One reporter, in `infra/`
-Both entry points behind one module owning the throttle, the dialog and the suppressed-count
-wording. This **moves `report_http_error` out of `AlertService`**, where the preview step put it:
-a service may import `infra/`, so it never needed to be in the message tier. `AlertService` keeps
-the message tier, which is what `spec/007_architecture.md` assigns it.
+Both entry points behind one module (`infra/reporter.py`) owning the throttle, the dialog and the
+suppressed-count wording. This folds `report_http_error` in next to `report_unexpected_error`;
+`report_http_error` currently lives in the moved `alert_service` (message tier) and comes out into
+the reporter here. Both tiers are in `infra/` (the reclassification above), so this is a move within
+`infra/`, not across a layer boundary.
 
 [ ] 3. Restore the six silent request paths
 With the throttle covering them, opting out has no remaining justification — `spec/006` already

--- a/mapflow/functional/controller/data_catalog_controller.py
+++ b/mapflow/functional/controller/data_catalog_controller.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import QMessageBox, QApplication, QFileDialog
 
 from ..service.data_catalog import DataCatalogService
 from ..service.preview_service import PreviewService
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ..view.data_catalog_view import DataCatalogView
 from ...dialogs.main_dialog import MainDialog
 from ...dialogs.mosaic_dialog import CreateMosaicDialog, UpdateMosaicDialog

--- a/mapflow/functional/controller/project_processing_controller.py
+++ b/mapflow/functional/controller/project_processing_controller.py
@@ -2,7 +2,7 @@ from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QMessageBox, QWidget
 
 from ..app_context import AppContext
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ..service.processing_service import ProcessingService
 from ..service.project_service import ProjectService
 from ...config import config, Config

--- a/mapflow/functional/controller/provider_controller.py
+++ b/mapflow/functional/controller/provider_controller.py
@@ -8,7 +8,7 @@ would be controller-to-controller. It stays in the composition root, driving vie
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QMessageBox
 
-from ..service.alert_service import alert, alert_warning
+from ...infra.alert_service import alert, alert_warning
 from ..service.provider_service import ProviderService
 from ..view.provider_view import ProviderView
 from ...model.provider import create_provider

--- a/mapflow/functional/controller/search_controller.py
+++ b/mapflow/functional/controller/search_controller.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from PyQt5.QtCore import QCoreApplication, QObject
 from PyQt5.QtWidgets import QMessageBox
 
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ..service.local_filter_service import FilterCriteria, LocalFilterService
 from ..service.preview_service import PreviewService
 from ..service.provider_service import ProviderService

--- a/mapflow/functional/controller/template_controller.py
+++ b/mapflow/functional/controller/template_controller.py
@@ -3,7 +3,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from ..app_context import AppContext
 from ..service.aoi_service import AoiService
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ..service.template_service import TemplateService
 from ..view.search_view import SearchView
 from ..view.template_view import TemplateView

--- a/mapflow/functional/service/aoi_service.py
+++ b/mapflow/functional/service/aoi_service.py
@@ -11,7 +11,7 @@ from ..app_context import AppContext
 from ..geometry import geometry_from_geojson
 # Severity-named so the icon is chosen inside AlertService: picking a QMessageBox.Icon here
 # would mean importing QtWidgets, which a service may not do.
-from .alert_service import alert_info, alert_warning, ask_text
+from ...infra.alert_service import alert_info, alert_warning, ask_text
 from ...schema.template import (AddAoisSchema,
                                 AddSingleAoiSchema,
                                 AOI_NAME_MAX_LENGTH,

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -11,7 +11,7 @@ from qgis.core import QgsRasterLayer
 from ...schema.data_catalog import PreviewSize, MosaicReturnSchema, ImageReturnSchema, UserLimitSchema
 from ...schema import MyImageryParams
 from ..api.data_catalog_api import DataCatalogApi
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ...http import Http
 from ...functional import helpers
 from ...functional.app_context import AppContext

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -10,7 +10,7 @@ from qgis.core import (QgsCoordinateReferenceSystem, QgsFeature, QgsGeometry,
 from .. import helpers
 from .. import layer_utils
 from ..app_context import AppContext
-from .alert_service import alert, alert_info, alert_warning, report_http_error
+from ...infra.alert_service import alert, alert_info, alert_warning, report_http_error
 from ...config import OSM
 from ...errors import ImageIdRequired
 from ...schema.catalog import MultiPreviewList, PreviewType

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -39,7 +39,7 @@ from ...schema.template import (
     ProcessingTemplateDTO,
     ProcessingTemplateDetails,
 )
-from ..service.alert_service import alert, alert_info
+from ...infra.alert_service import alert, alert_info
 from ..app_context import AppContext
 from ...model.provider import ImagerySearchProvider
 from ...config import Config

--- a/mapflow/functional/service/provider_service.py
+++ b/mapflow/functional/service/provider_service.py
@@ -13,7 +13,7 @@ from ...model.provider import(ImagerySearchProvider,
                                BasicAuth,
                                ProvidersList,
                                create_provider)
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 from ...schema import (DataProviderParams, 
                        MyImageryParams, 
                        ImagerySearchParams, 

--- a/mapflow/functional/service/search_service.py
+++ b/mapflow/functional/service/search_service.py
@@ -8,12 +8,12 @@ from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 from qgis.core import QgsGeometry, QgsVectorLayer
 
 from ..app_context import AppContext
-from .alert_service import alert, alert_info
+from ...infra.alert_service import alert, alert_info
 from ...http import api_message_parser
 from ...model.provider import ImagerySearchProvider, ProviderInterface
 from ...schema import ImageCatalogRequestSchema, ImageCatalogResponseSchema
 from ...schema.catalog import ProductType
-from .alert_service import report_http_error
+from ...infra.alert_service import report_http_error
 
 logger = logging.getLogger(__name__)
 

--- a/mapflow/functional/service/session_service.py
+++ b/mapflow/functional/service/session_service.py
@@ -22,7 +22,7 @@ from ...errors import ProxyIsAlreadySet
 from ...http import Http
 # The icon-carrying helpers rather than `alert(..., icon=QMessageBox.X)`: naming an icon would
 # mean importing PyQt5.QtWidgets, which a service may not do (`spec/007_architecture.md`).
-from .alert_service import alert_info, alert_warning
+from ...infra.alert_service import alert_info, alert_warning
 
 logger = logging.getLogger(__name__)
 

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -39,7 +39,7 @@ from ..app_context import AppContext
 from ...config import Config
 from ..geometry import geometry_from_geojson
 from ..helpers import utc_date_from_iso
-from .alert_service import (alert, alert_confirm, alert_info, alert_warning,
+from ...infra.alert_service import (alert, alert_confirm, alert_info, alert_warning,
                             ask_text, report_http_error)
 from ...errors import ErrorMessage
 from ...http import api_message_parser

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -11,7 +11,7 @@ from ...schema.template import (ProcessingTemplateDTO, TemplateAoiDTO,
                                 AoiProcessingLink, TemplateProcessingSchema,
                                 NoAoiProcessingsRow)
 from ...config import config
-from ..service.alert_service import alert
+from ...infra.alert_service import alert
 
 class ProcessingView:
     """

--- a/mapflow/i18n/mapflow.pro
+++ b/mapflow/i18n/mapflow.pro
@@ -39,7 +39,7 @@ SOURCES = ../mapflow.py\
           ../functional/api/project_api.py\
           ../functional/controller/processing_controller.py\
           ../functional/controller/project_processing_controller.py\
-          ../functional/service/alert_service.py\
+          ../infra/alert_service.py\
           ../functional/service/aoi_service.py\
           ../functional/service/area_calculator_service.py\
           ../functional/service/data_catalog.py\

--- a/mapflow/infra/__init__.py
+++ b/mapflow/infra/__init__.py
@@ -1,0 +1,8 @@
+"""Infrastructure tier (`spec/007_architecture.md`).
+
+Modules every layer may import and that may hold Qt: the message tier (`alert_service`) and, as the
+error-reporting phase and Phase D fill it in, the report tier. It exists because a service may not
+import a widget yet the message/report tiers must build one, and a view may not import a service yet
+views legitimately raise alerts — `infra/` is the one layer reachable from services, views, apis and
+controllers alike.
+"""

--- a/mapflow/infra/alert_service.py
+++ b/mapflow/infra/alert_service.py
@@ -78,8 +78,8 @@ class AlertService(QObject):
         # gives for the same import: the dialog pulls in the Qt widget tree, and keeping it lazy
         # lets a headless context construct this service without one. Showing dialogs is this
         # tier's job, so the dependency itself is not the thing being avoided.
-        from ...dialogs.error_message_widget import ErrorMessageWidget
-        from ...http import get_error_report_body
+        from ..dialogs.error_message_widget import ErrorMessageWidget
+        from ..http import get_error_report_body
         response_body = response.readAll().data().decode()
         error_summary, email_body = get_error_report_body(
             response=response,

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -46,7 +46,7 @@ from .functional.service.account_service import AccountService
 from .functional.service.session_service import SessionService
 from .functional.service.workdir_service import WorkdirService
 from .functional.view.workdir_view import WorkdirView
-from .functional.service.alert_service import AlertService, alert
+from .infra.alert_service import AlertService, alert
 from .functional.service.area_calculator_service import AreaCalculatorService
 # HTTP
 from .http import (Http,

--- a/spec/006_error_reporting.md
+++ b/spec/006_error_reporting.md
@@ -41,21 +41,28 @@ the other two tiers discard.
 
 ### Where each tier lives
 
-The **message** tier is `AlertService`, a service: `alert_*`, `ask_text` and anything else that
-needs a synchronous answer from the user. It owns the Qt types so its callers do not import
-them — a service asking the user a question is not a reason to hand control to something that
-can see a dialog.
+Both tiers live in `infra/` (`mapflow/infra/`): `alert_service` for the message tier, the reporter
+for the report tier. `infra/` is the one layer every other layer may import, and the one layer
+allowed to hold Qt types (`spec/007_architecture.md` § Layer rules).
 
-The **report** tier lives in `infra/`, not in a service. Two reasons, and the second is the
-binding one:
+The **message** tier is `AlertService`, in `infra/` — **not a service**: `alert_*`, `ask_text` and
+anything else that needs a synchronous answer from the user. It owns the Qt types so its callers do
+not import them. It is in `infra/`, not `service/`, because a service may not import a widget yet
+this tier builds `QMessageBox`/`QInputDialog`, and because a view may not import a service yet views
+legitimately raise message-tier alerts (e.g. the processings table's failed/finished
+notifications). `infra/` is the only home reachable from services, views, apis and controllers
+alike; a service-tier message helper is neither.
+
+The **report** tier lives in `infra/` too. Two reasons, and the second is the binding one:
 
 - it is reached from `Http`, which is itself infra and must not depend on a service singleton;
 - every layer may import `infra/`, so putting it there makes it reachable from services, api
   modules and controllers alike, whereas a service-tier reporter is reachable only downward.
 
-A service that needs to report an unexpected failure imports the reporter from `infra/`. It does
-not emit a signal for someone else to report on its behalf, and it does not construct
-`ErrorMessageWidget`.
+A service or api that needs to report an unexpected failure imports the reporter from `infra/`. It
+does not emit a signal for someone else to report on its behalf, and it does not construct
+`ErrorMessageWidget`. The reporter itself may import `ErrorMessageWidget` from `dialogs/` (an
+`infra → dialogs` edge, kept lazy so a headless context need not build the widget tree).
 
 ### Volume limit
 

--- a/spec/007_architecture.md
+++ b/spec/007_architecture.md
@@ -58,7 +58,8 @@ mapflow/
   schema/              shapes that cross the network
   model/               types the plugin owns and persists locally
   errors/
-  infra/               http, error_guard, report_throttle, log_config
+  infra/               http, error_guard, report_throttle, log_config,
+                       alert_service (message tier), reporter (report tier)
 ```
 
 Deleted: `requests/`, `entity/`, `functional/` as a container, `constants.py`.
@@ -110,8 +111,9 @@ below it and from `model/`, `errors/`, `infra/`, `config`, `helpers`, `geometry`
 | `mapflow.py` | everything | contain domain logic |
 | `controller/` | service, view, model, schema | touch `Http`, hold domain state |
 | `view/` | model, schema, dialogs | issue requests, contain business rules |
-| `service/` | api, model, schema, other services | import `view/`, `dialogs/`, or touch a widget |
+| `service/` | api, model, schema, infra, other services | import `view/`, `dialogs/`, or touch a widget |
 | `api/` | model, schema, infra | know about widgets or business rules |
+| `infra/` | dialogs, model, schema, errors, config, Qt | hold domain state or business rules |
 | `model/` | schema, errors, config | import anything above it |
 | `schema/` | errors, config | import `model/`, or anything above it |
 
@@ -119,6 +121,12 @@ below it and from `model/`, `errors/`, `infra/`, `config`, `helpers`, `geometry`
 layering violation is an instance of it, and it is mechanically checkable — a service
 module must not import `PyQt5.QtWidgets`, `dialogs`, or `view`, and must not receive a
 `dlg` argument.
+
+**`infra/` is the exception that proves it: the one layer that may hold Qt, and the one
+every other layer may import.** The message tier (`alert_service`) and the report tier
+(`reporter`) live there for exactly that reason — a service may not build a `QMessageBox`
+and a view may not import a service, yet both must be able to alert. `infra/` holds
+cross-cutting mechanism (transport, reporting, alerts, logging), never domain state.
 
 **The rule that keeps the import cycle dead: `schema/` may not import `model/`.** The
 dependency between the two runs one way only, so the cycle cannot be reintroduced by
@@ -143,7 +151,6 @@ State and business rules. Each owns one question, and nobody else answers it.
 | `ProjectService` | projects CRUD, sharing, roles, the current project | |
 | `ResultService` | downloading and loading processing results, applying styles | from `layer_utils.ResultsLoader` |
 | `AreaCalculatorService` | area computation and limit comparison | unchanged |
-| `AlertService` | the *message* tier of `spec/006_error_reporting.md` | unchanged |
 
 Services communicate through Qt signals, never by calling a controller. Several already do
 this (`DataCatalogService.mosaicsUpdated`); it becomes the rule. A service that needs to tell

--- a/tests/functional/test_infra_alert_service.py
+++ b/tests/functional/test_infra_alert_service.py
@@ -1,0 +1,27 @@
+"""The message tier lives in `mapflow/infra/`, not `functional/service/` (error-reporting phase).
+
+A service may not import a widget and a view may not import a service, yet both raise message-tier
+alerts — so `alert_service` moved to the `infra/` layer, which every layer may import and which may
+hold Qt (`spec/006_error_reporting.md` § Where each tier lives; `spec/007_architecture.md` § Layer
+rules). This pins the new home and guards the old one from coming back.
+"""
+import importlib
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[2] / "mapflow"
+
+
+def test_the_message_tier_is_importable_from_infra():
+    # Safe in the no-QGIS functional tier: alert_service imports only PyQt5, not qgis.core.
+    module = importlib.import_module("mapflow.infra.alert_service")
+    for name in ("AlertService", "alert", "alert_info", "alert_warning", "alert_error",
+                 "alert_confirm", "ask_text", "report_http_error"):
+        assert hasattr(module, name), f"infra.alert_service is missing {name}"
+
+
+def test_the_old_service_path_is_gone():
+    """The file must not come back under `functional/service/` — that is the layer violation the
+    move removed. Checked on disk rather than by import: importing the old package pulls in qgis,
+    which the functional tier lacks, so an import would fail for the wrong reason."""
+    assert not (PLUGIN / "functional" / "service" / "alert_service.py").exists()
+    assert (PLUGIN / "infra" / "alert_service.py").exists()

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -30,6 +30,7 @@ LAYERS = {
     "service": "functional/service",
     "controller": "functional/controller",
     "view": "functional/view",
+    "infra": "infra",
     "dialogs": "dialogs",
     "model": "model",
     "schema": "schema",
@@ -47,11 +48,17 @@ UNCLASSIFIED = {
 }
 
 #: What each layer may depend on. Absent from a layer's set means forbidden.
+#:
+#: `infra` is the one tier every layer may import and the one that may hold Qt (the message tier
+#: `alert_service` and the report tier live there — a service may not import a widget, and a view
+#: may not import a service, yet both raise alerts). It appears in each importer's set below, and
+#: has its own row for what it may reach: `dialogs` (the report widget) and the domain layers.
 MAY_IMPORT = {
-    "controller": {"service", "view", "model", "schema", "errors", "dialogs"},
-    "view": {"model", "schema", "errors", "dialogs"},
-    "service": {"api", "service", "model", "schema", "errors"},
-    "api": {"model", "schema", "errors"},
+    "controller": {"service", "view", "infra", "model", "schema", "errors", "dialogs"},
+    "view": {"infra", "model", "schema", "errors", "dialogs"},
+    "service": {"api", "service", "infra", "model", "schema", "errors"},
+    "api": {"infra", "model", "schema", "errors"},
+    "infra": {"infra", "dialogs", "model", "schema", "errors"},
     "model": {"model", "schema", "errors"},
     "schema": {"schema", "errors"},
 }
@@ -62,18 +69,15 @@ MAY_IMPORT = {
 DIALOG_PARAMS = {"dlg", "dialog", "maindialog", "main_dialog"}
 
 ALLOWED = {
-    # service/ and api/ importing Qt widgets — Phase C moves this to view/.
-    ("widget-import", "mapflow.functional.service.alert_service"),
+    # service/ and api/ still constructing the error-report widget or an alert. Cleared as the
+    # error-reporting phase routes them through the infra reporter / message tier.
     ("widget-import", "mapflow.functional.service.processing_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
-    # Reaching upwards for dialogs and views. One entry per module, so it clears only when
-    # that module is clean — fixing four of five imports leaves the exemption in place. These
-    # remaining ones are all the error-report widget (ErrorMessageWidget) construction still in
-    # a service/api, and one view reaching the alert helper — cleared by the error-reporting phase,
-    # which is sequenced after Phase C.
+    # The error-report widget (ErrorMessageWidget) still constructed inside a service/api. One
+    # entry per module, so it clears only when that module is clean. Cleared as the error-reporting
+    # phase routes each through the infra reporter.
     ("api-imports-dialogs", "mapflow.functional.api.data_catalog_api"),
     ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
-    ("view-imports-service", "mapflow.functional.view.processing_view"),
 }
 
 #: Cycles that exist today, as the set of modules involved so the entry survives a change of

--- a/tests/qgis/behavioral/conftest.py
+++ b/tests/qgis/behavioral/conftest.py
@@ -59,7 +59,7 @@ def alerts():
     """
     from PyQt5.QtWidgets import QFileDialog, QInputDialog, QMessageBox
 
-    from mapflow.functional.service.alert_service import AlertService
+    from mapflow.infra.alert_service import AlertService
 
     recorded = []
 
@@ -112,7 +112,7 @@ def fresh_singletons():
     from qgis.core import QgsSettings
 
     from mapflow.functional.app_context import AppContext
-    from mapflow.functional.service.alert_service import AlertService
+    from mapflow.infra.alert_service import AlertService
     from mapflow.functional.service.provider_service import ProviderService
 
     for service in (AlertService, ProviderService):


### PR DESCRIPTION
The error-reporting phase begins by resolving a contradiction Phase C2 left standing: spec/006 said
the message tier "is AlertService, a service", while spec/007's rule (enforced by test_layering)
says a service imports no widget. AlertService is under functional/service/ AND imports QtWidgets,
and the allowlist masked it. It also cannot be reached the way it needs to be: a view may raise a
message-tier alert (the processings table's failed/finished notifications do), but a view may not
import a service.

Both point the same way, so alert_service.py moves to a new infra/ tier — the one layer every other
layer may import and the one allowed to hold Qt. spec/006 § "Where each tier lives" and spec/007
(§ Target structure, § Layer rules, § Services) are edited to match; test_layering gains an `infra`
layer with its own import rule and `infra` added to what service/view/api/controller may import.

Two allowlist entries clear: `widget-import` on alert_service (it is no longer a service), and
`view-imports-service` on processing_view (its `import alert` is now a view→infra edge, which the
rule permits — the import path changes, the view's body does not).

Pure relocation: 16 production import sites, 2 test imports and the i18n source list repoint to
`mapflow.infra.alert_service`; no behaviour changes. report_http_error stays in the moved file for
now — MR-4 folds it into the unified reporter.

## Manual test
none — a pure move. Every alert/confirm/ask-text/HTTP-error dialog the plugin showed before still
shows. Regression surface: the plugin must still boot (the AlertService singleton is constructed
from its new path), and any alert path — a failed processing, a delete confirmation, a login error —
must still raise its dialog.
