### PR TITLE
refactor: ProcessingService reports errors through the infra tier, not its own dialog

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -293,8 +293,11 @@ first because the reporter must be reachable from an `api` before the api can ca
 [ready-for-review] MR-1 the message tier (`alert_service`) → `mapflow/infra/`. Clears
     `widget-import·alert_service` and `view-imports-service·processing_view`. Pure move; `infra`
     layer added to `test_layering`. `report_http_error` stays in the moved file until step 2.
-[ ] MR-2 `processing_service` stops building `ErrorMessageWidget`/`QMessageBox` — routes through the
-    infra reporter + `alert_info`. Clears `widget-import` + `service-imports-dialogs` for it.
+[ready-for-review] MR-2 `processing_service` stops building `ErrorMessageWidget`/`QMessageBox` —
+    the error handler routes through `report_http_error` (given the already-read body, which gained
+    a `response_body` param so `readAll` is not called twice); the four `alert(…, QMessageBox.X)`
+    calls become `alert_info`/`alert_warning`/`alert_confirm`. Clears `widget-import` +
+    `service-imports-dialogs` for processing_service.
 [ ] MR-3a `data_catalog_api`'s 6 `ErrorMessageWidget` sites → infra reporter. Clears
     `api-imports-dialogs·data_catalog_api`.
 [ ] MR-3b `data_catalog_api` upload-progress `QProgressBar` → `DataCatalogController`. Clears

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -5,8 +5,7 @@ from uuid import UUID
 from typing import Dict, Optional, List, Tuple
 from PyQt5.QtCore import QObject, QTimer, pyqtSignal
 from PyQt5.QtNetwork import QNetworkReply
-from PyQt5.QtWidgets import QMessageBox, QApplication
-from .provider_service import (get_provider_params, 
+from .provider_service import (get_provider_params,
                                setup_provider_info, 
                                validate_provider_params, 
                                duplicate_aoi_based_on_provider,
@@ -39,13 +38,12 @@ from ...schema.template import (
     ProcessingTemplateDTO,
     ProcessingTemplateDetails,
 )
-from ...infra.alert_service import alert, alert_info
+from ...infra.alert_service import (alert, alert_info, alert_warning, alert_confirm,
+                                    report_http_error)
 from ..app_context import AppContext
 from ...model.provider import ImagerySearchProvider
 from ...config import Config
 from ...functional.layer_utils import ResultsLoader, max_aoi_bbox_area
-from ...http import get_error_report_body
-from ...dialogs.error_message_widget import ErrorMessageWidget
 
 logger = logging.getLogger(__name__)
 
@@ -464,11 +462,10 @@ class ProcessingService(QObject):
             aoi_size=self.app_context.aoi_size,
             processing_cost=self.processing_cost
         ):
-            alert(
+            alert_warning(
                 self.tr('Processing limit exceeded. '
                     'Visit "<a href=\"https://app.mapflow.ai/account/balance\">Mapflow</a>" '
-                    'to top up your balance'),
-                icon=QMessageBox.Warning
+                    'to top up your balance')
             )
             return False
         return True
@@ -595,9 +592,8 @@ class ProcessingService(QObject):
 
     def start_processing_callback(self, response: QNetworkReply) -> None:
         """Display a success message and clear the processing name field."""
-        alert(
-            self.tr("Success! We'll notify you when the processing has finished."),
-            QMessageBox.Information
+        alert_info(
+            self.tr("Success! We'll notify you when the processing has finished.")
         )
         response_data = json.loads(response.readAll().data())
         self.processing_fetch_timer.start()  # start monitoring
@@ -639,21 +635,19 @@ class ProcessingService(QObject):
         response_body = response.readAll().data().decode()
         if error == QNetworkReply.ContentAccessDenied \
                 and "data provider" in response_body.lower():
-            alert(self.tr('The selected data provider is unavailable on your plan. \n '
-                          'Upgrade your subscription to get access to the data. \n'
-                          'See pricing at <a href=\"https://mapflow.ai/pricing\">mapflow.ai</a>'),
-                       QMessageBox.Information)
+            alert_info(self.tr('The selected data provider is unavailable on your plan. \n '
+                               'Upgrade your subscription to get access to the data. \n'
+                               'See pricing at <a href=\"https://mapflow.ai/pricing\">mapflow.ai</a>'))
             # provider ID is the last "word" in the message.
             # In this case, when "data provider" is in the message, there can't be index error
         else:
-            error_summary, email_body = get_error_report_body(response=response,
-                                                              response_body=response_body,
-                                                              plugin_version=self.app_context.plugin_version,
-                                                              error_message_parser=api_message_parser)
-            ErrorMessageWidget(parent=QApplication.activeWindow(),
-                               text= error_summary,
-                               title=self.tr('Processing creation failed'),
-                               email_body=email_body).show()
+            # The report tier builds and shows the dialog; the body was already read above, so it
+            # is handed over rather than re-read (`readAll` has drained the reply).
+            report_http_error(response=response,
+                              response_body=response_body,
+                              plugin_version=self.app_context.plugin_version,
+                              title=self.tr('Processing creation failed'),
+                              error_message_parser=api_message_parser)
         if False not in self.app_context.allow_enable_processing.values():
             self.submissionInFlight.emit(False)
 
@@ -1089,9 +1083,7 @@ class ProcessingService(QObject):
         # Filter to only items that exist (templates or processings)
         valid_ids = [pid for pid in selected_ids if pid in self.processings or pid in self.templates]
         # Ask for confirmation if there are selected rows
-        if valid_ids and alert(
-                self.tr('Delete selected items?'), QMessageBox.Question
-        ):
+        if valid_ids and alert_confirm(self.tr('Delete selected items?')):
             self.delete_processings(response=None, items=valid_ids, deleted=[], failed=[])
             
     def delete_processings(self, 

--- a/mapflow/infra/alert_service.py
+++ b/mapflow/infra/alert_service.py
@@ -66,13 +66,18 @@ class AlertService(QObject):
                           response,
                           plugin_version: str,
                           title: str = None,
-                          error_message_parser: Optional[Callable] = None) -> None:
+                          error_message_parser: Optional[Callable] = None,
+                          response_body: Optional[str] = None) -> None:
         """The *report* tier of `spec/006_error_reporting.md`: the dialog that offers to mail us
         the failure. Here for the same reason `alert` and `ask_text` are — a service that hits an
         HTTP error should not have to import a dialog to say so.
 
         `plugin_version` is passed in rather than read: this tier knows how to present a failure,
         not where the session state lives.
+
+        `response_body` lets a caller that has already read the reply hand it over: `readAll()`
+        drains the buffer, so a caller that inspected the body itself must pass it here or the
+        report would decode an empty one.
         """
         # Imported here, not at module scope, for the reason `error_guard.report_unexpected_error`
         # gives for the same import: the dialog pulls in the Qt widget tree, and keeping it lazy
@@ -80,7 +85,8 @@ class AlertService(QObject):
         # tier's job, so the dependency itself is not the thing being avoided.
         from ..dialogs.error_message_widget import ErrorMessageWidget
         from ..http import get_error_report_body
-        response_body = response.readAll().data().decode()
+        if response_body is None:
+            response_body = response.readAll().data().decode()
         error_summary, email_body = get_error_report_body(
             response=response,
             response_body=response_body,
@@ -123,6 +129,7 @@ def ask_text(title: str, label: str, default: str = "") -> Tuple[str, bool]:
     return AlertService.instance().ask_text(title, label, default)
 
 def report_http_error(response, plugin_version: str, title: str = None,
-                      error_message_parser: Optional[Callable] = None) -> None:
+                      error_message_parser: Optional[Callable] = None,
+                      response_body: Optional[str] = None) -> None:
     return AlertService.instance().report_http_error(
-        response, plugin_version, title, error_message_parser)
+        response, plugin_version, title, error_message_parser, response_body)

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -71,13 +71,11 @@ DIALOG_PARAMS = {"dlg", "dialog", "maindialog", "main_dialog"}
 ALLOWED = {
     # service/ and api/ still constructing the error-report widget or an alert. Cleared as the
     # error-reporting phase routes them through the infra reporter / message tier.
-    ("widget-import", "mapflow.functional.service.processing_service"),
     ("widget-import", "mapflow.functional.api.data_catalog_api"),
-    # The error-report widget (ErrorMessageWidget) still constructed inside a service/api. One
-    # entry per module, so it clears only when that module is clean. Cleared as the error-reporting
-    # phase routes each through the infra reporter.
+    # The error-report widget (ErrorMessageWidget) still constructed inside an api. One entry per
+    # module, so it clears only when that module is clean. Cleared as the error-reporting phase
+    # routes each through the infra reporter.
     ("api-imports-dialogs", "mapflow.functional.api.data_catalog_api"),
-    ("service-imports-dialogs", "mapflow.functional.service.processing_service"),
 }
 
 #: Cycles that exist today, as the set of modules involved so the entry survives a change of

--- a/tests/qgis/conftest.py
+++ b/tests/qgis/conftest.py
@@ -31,6 +31,14 @@ def pytest_configure(config):
     except Exception as error:  # pragma: no cover - environment capability probe
         print(f"QGIS Processing unavailable, geometry operations will not run: {error}")
 
+    # Initialise the message-tier singleton once. Service code calls `alert_info`/`alert_warning`/
+    # `alert_confirm` (module functions that go through `AlertService.instance()`), which raises if
+    # the singleton was never created. A unit test that triggers one without building the plugin
+    # would hit that RuntimeError; `_no_blocking_dialogs` already stops the dialog from opening, and
+    # this stops the lookup from failing — the same "make forgetting harmless" intent.
+    from mapflow.infra.alert_service import AlertService
+    AlertService("Mapflow")
+
 
 @pytest.fixture(autouse=True)
 def _no_blocking_dialogs(monkeypatch):

--- a/tests/qgis/test_processing_error_report.py
+++ b/tests/qgis/test_processing_error_report.py
@@ -1,0 +1,75 @@
+"""QGIS-tier tests: ProcessingService reports HTTP errors through the infra reporter, not by
+building the dialog itself (error-reporting phase, MR-2).
+
+`start_processing_error_handler` used to construct `ErrorMessageWidget` inline — a service reaching
+for a dialog. It now hands the failure to `report_http_error` in `mapflow.infra`. The subtlety this
+pins: the handler reads the reply body itself (to spot the "data provider" case), and `readAll`
+drains the buffer, so it must pass that body to the reporter rather than let it re-read an empty one.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtNetwork import QNetworkReply
+
+from mapflow.functional.service import processing_service as processing_service_module
+from mapflow.functional.service.processing_service import ProcessingService
+
+
+def _service():
+    service = ProcessingService.__new__(ProcessingService)
+    QObject.__init__(service)
+    service.tr = lambda text: text
+    service.app_context = SimpleNamespace(plugin_version="9.9.9",
+                                          allow_enable_processing={"aoi_loaded": True})
+    return service
+
+
+def _response(body: bytes, error=QNetworkReply.UnknownContentError):
+    response = MagicMock()
+    response.error.return_value = error
+    response.readAll.return_value.data.return_value = body
+    return response
+
+
+def test_a_generic_error_is_reported_through_the_infra_reporter():
+    service = _service()
+    response = _response(b'{"code": "BAD_REQUEST", "message": "no"}')
+
+    with patch.object(processing_service_module, "report_http_error") as report:
+        service.start_processing_error_handler(response)
+
+    report.assert_called_once()
+    kwargs = report.call_args.kwargs
+    assert kwargs["response"] is response
+    assert kwargs["plugin_version"] == "9.9.9"
+    # The body was read once by the handler and handed over, not re-read (readAll has drained it).
+    assert kwargs["response_body"] == '{"code": "BAD_REQUEST", "message": "no"}'
+    assert kwargs["error_message_parser"] is processing_service_module.api_message_parser
+
+
+def test_the_data_provider_case_alerts_and_does_not_report():
+    """An unavailable data provider is an expected, actionable message — an info alert, not a
+    'something went wrong, mail us' report."""
+    service = _service()
+    response = _response(b'the data provider is not on your plan',
+                         error=QNetworkReply.ContentAccessDenied)
+    alerts = []
+
+    with patch.object(processing_service_module, "report_http_error") as report, \
+            patch.object(processing_service_module, "alert_info", lambda *a, **k: alerts.append(a)):
+        service.start_processing_error_handler(response)
+
+    report.assert_not_called()
+    assert alerts  # the upgrade-your-plan message was shown
+
+
+def test_the_button_is_re_enabled_after_a_report():
+    service = _service()
+    in_flight = []
+    service.submissionInFlight.connect(in_flight.append)
+
+    with patch.object(processing_service_module, "report_http_error"):
+        service.start_processing_error_handler(_response(b"{}"))
+
+    assert in_flight == [False]

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -435,7 +435,7 @@ def test_start_processing_callback_refreshes_processings_for_regular_response():
     response.readAll.return_value.data.return_value = b'{"id": "proc-1", "name": "Run 1"}'
     mock_processing = SimpleNamespace(id="proc-1", name="Run 1", status=SimpleNamespace())
 
-    with patch.object(processing_service_module, "alert"), \
+    with patch.object(processing_service_module, "alert_info"), \
             patch.object(processing_service_module.ProcessingDTO, "from_dict", return_value=mock_processing):
         service.start_processing_callback(response)
 
@@ -459,7 +459,7 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
     response = MagicMock()
     response.readAll.return_value.data.return_value = b'{"template": {"id": "tpl-1"}, "searchResults": []}'
 
-    with patch.object(processing_service_module, "alert"):
+    with patch.object(processing_service_module, "alert_info"):
         service.start_processing_callback(response)
 
     assert asked == [True]
@@ -747,7 +747,7 @@ def test_confirm_delete_processings_deletes_templates():
     service.set_selected_ids(["tpl-1"])
     service._delete_state = {}
 
-    with patch.object(processing_service_module, "alert", return_value=True):
+    with patch.object(processing_service_module, "alert_confirm", return_value=True):
         service.confirm_delete_processings()
 
     # delete_processings should be called with the template ID

--- a/tests/qgis/test_template_start_processing_refresh.py
+++ b/tests/qgis/test_template_start_processing_refresh.py
@@ -76,7 +76,7 @@ def test_template_start_asks_for_a_rehydrate_and_skips_flat_add():
     added = _added(service)
     in_flight = _in_flight(service)
 
-    with patch.object(processing_service_module, "alert"):
+    with patch.object(processing_service_module, "alert_info"):
         service.start_processing_callback(_response(_PROCESSING))
 
     # A plain refresh would refetch the rows without rebinding the new processing to its AOI.
@@ -92,7 +92,7 @@ def test_regular_start_does_flat_add_and_asks_for_a_plain_refresh():
     added = _added(service)
     fake_dto = SimpleNamespace(id="p-1", name="Run 1", status="IN_PROGRESS")
 
-    with patch.object(processing_service_module, "alert"), \
+    with patch.object(processing_service_module, "alert_info"), \
             patch.object(processing_service_module.ProcessingDTO, "from_dict", return_value=fake_dto):
         service.start_processing_callback(_response(_PROCESSING))
 


### PR DESCRIPTION
The processing-create error handler built ErrorMessageWidget inline, and four alerts passed an
explicit QMessageBox icon — the last widget construction in the service. The handler now hands the
failure to report_http_error in mapflow.infra, and the alerts become alert_info / alert_warning /
alert_confirm. With the QtWidgets and ErrorMessageWidget imports gone, widget-import and
service-imports-dialogs clear for processing_service — two more allowlist entries.

report_http_error gained an optional response_body. The handler reads the reply itself to spot the
"data provider unavailable" case, and readAll() drains the buffer, so a reporter that re-read it
would decode an empty body and mail us a blank failure. The handler passes the body it already read.

## Manual test
none — no user-visible change. The same dialogs appear: an unavailable-data-provider start shows the
"upgrade your plan" info alert; any other start failure shows the mail-us error report with the
server's message; over-limit shows the top-up warning; deleting selected processings still asks to
confirm. Regression surface: the error report must still carry the server's message (not an empty
body — the readAll double-read this commit guards against), and a successful start still shows the
"we'll notify you" info alert.
