### PR TITLE
refactor: DataCatalogApi holds no widget — the layering allowlist is now empty

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -298,10 +298,13 @@ first because the reporter must be reachable from an `api` before the api can ca
     a `response_body` param so `readAll` is not called twice); the four `alert(…, QMessageBox.X)`
     calls become `alert_info`/`alert_warning`/`alert_confirm`. Clears `widget-import` +
     `service-imports-dialogs` for processing_service.
-[ ] MR-3a `data_catalog_api`'s 6 `ErrorMessageWidget` sites → infra reporter. Clears
-    `api-imports-dialogs·data_catalog_api`.
-[ ] MR-3b `data_catalog_api` upload-progress `QProgressBar` → `DataCatalogController`. Clears
-    `widget-import·data_catalog_api` → **`ALLOWED` empty**.
+[ready-for-review] MR-3 `data_catalog_api` holds no widget. Its 6 `ErrorMessageWidget` sites route
+    through a new `show_error_report` infra primitive (for pre-composed messages, unlike
+    `report_http_error` which parses a response); its upload `QProgressBar` moves to a view-layer
+    `UploadProgressReporter` injected into the api. Clears both `data_catalog_api` entries —
+    **`ALLOWED` is now empty**. (The progress reporter went to `view/`, not the controller: the api
+    is built by the service before any controller exists, so it takes a plain injected collaborator
+    that may hold widgets.)
 
 [ ] 1. Signature and throttle for the HTTP path
 `response_signature(response)` = Qt error code + endpoint path; `http._request_path` already

--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -5,13 +5,12 @@ from uuid import UUID
 
 from PyQt5.QtCore import QObject, pyqtSignal, QFile, QIODevice
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest, QHttpMultiPart, QHttpPart
-from PyQt5.QtWidgets import QApplication, QProgressBar
 from qgis.core import QgsMapLayer
 
 from ...schema.data_catalog import PreviewSize, MosaicCreateSchema, ImageReturnSchema, MosaicUpdateSchema
 from ...http import Http, get_error_report_body, data_catalog_message_parser
 from ...functional import layer_utils
-from ...dialogs.error_message_widget import ErrorMessageWidget
+from ...infra.alert_service import show_error_report
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +37,10 @@ class DataCatalogApi(QObject):
         self.iface = iface
         self.result_loader = result_loader
         self.plugin_version = plugin_version
+        #: The view-layer helper that shows upload progress in the message bar. Injected after
+        #: construction (the api is built by the service, the reporter needs iface and is wired in
+        #: `mapflow.py`). A no-op default so an upload without one still works, just unshown.
+        self.progress_reporter = None
 
     # Mosaics CRUD
     def create_mosaic(self, mosaic: MosaicCreateSchema, callback: Callable = lambda *args: None):
@@ -72,21 +75,9 @@ class DataCatalogApi(QObject):
                                   timeout=3600
                                  )
         body.setParent(response)
-        # Disolay progress for first image
-        progressMessageBar = self.iface.messageBar().createMessage(f"Uploading image 1/{len(image_paths)}:")
-        progress = QProgressBar()
-        progressMessageBar.layout().addWidget(progress)
-        self.iface.messageBar().pushWidget(progressMessageBar)
-        def display_upload_progress(bytes_sent: int, bytes_total: int):
-            try:
-                progress.setValue(round(bytes_sent / bytes_total * 100))
-            except ZeroDivisionError:
-                return
-            if bytes_total > 0:
-                if bytes_sent == bytes_total:
-                    self.iface.messageBar().popWidget(progressMessageBar)
-        connection = response.uploadProgress.connect(display_upload_progress)
-        progressMessageBar.destroyed.connect(lambda: response.uploadProgress.disconnect(connection))
+        # Show progress for the first image; the view-layer reporter owns the widget.
+        if self.progress_reporter:
+            self.progress_reporter.track(response, f"Uploading image 1/{len(image_paths)}:")
 
     def get_mosaics(self, callback: Callable):
         self.http.get(url=f"{self.server}/rasters/mosaic",
@@ -131,10 +122,7 @@ class DataCatalogApi(QObject):
         else:
             title = self.tr("Error. Could not delete following imagery collections:")
             message = ', \n'.join(mosaics)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=message,
-                           title=title,
-                           email_body='').show()
+        show_error_report(text=message, title=title)
         
     def request_mosaic_extent(self,
                               tilejson_uri: str,
@@ -181,10 +169,7 @@ class DataCatalogApi(QObject):
             title = self.tr("Error")
             email_body = "Error while loading an imagery collection." \
                         f"Collection id: {mosaic_id}"
-            ErrorMessageWidget(parent=QApplication.activeWindow(),
-                               text=error_summary,
-                               title=title,
-                               email_body=email_body).show()
+            show_error_report(text=error_summary, title=title, email_body=email_body)
 
     # Images CRUD
     def upload_image(self,
@@ -208,23 +193,8 @@ class DataCatalogApi(QObject):
                                   timeout=3600
                                  )
         body.setParent(response)
-
-        progressMessageBar = self.iface.messageBar().createMessage(f"Uploading image {image_number}/{image_count}:")
-        progress = QProgressBar()
-        progressMessageBar.layout().addWidget(progress)
-        self.iface.messageBar().pushWidget(progressMessageBar)
-
-        def display_upload_progress(bytes_sent: int, bytes_total: int):
-            try:
-                progress.setValue(round(bytes_sent / bytes_total * 100))
-            except ZeroDivisionError:
-                return
-            if bytes_total > 0:
-                if bytes_sent == bytes_total:
-                    self.iface.messageBar().popWidget(progressMessageBar)
-
-        connection = response.uploadProgress.connect(display_upload_progress)
-        progressMessageBar.destroyed.connect(lambda: response.uploadProgress.disconnect(connection))
+        if self.progress_reporter:
+            self.progress_reporter.track(response, f"Uploading image {image_number}/{image_count}:")
 
     def upload_image_error_handler(self, response: QNetworkReply, mosaic_name: str, image_paths: list):
         response_body = response.readAll().data().decode()
@@ -249,10 +219,7 @@ class DataCatalogApi(QObject):
             message = self.tr("Could not upload '{image}' to imagery collection").format(image=image_paths[0])
         else:
             message = self.tr("Could not upload following images:\n{images}").format(images= ', \n'.join(image_paths))
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=error_summary,
-                           title=message,
-                           email_body=email_body).show()
+        show_error_report(text=error_summary, title=message, email_body=email_body)
 
     def get_mosaic_images(self, mosaic_id: UUID, callback: Callable):
         self.http.get(url=f"{self.server}/rasters/mosaic/{mosaic_id}/image",
@@ -288,10 +255,7 @@ class DataCatalogApi(QObject):
         else:
             title = self.tr("Error. Could not delete following images:")
             message = ', \n'.join(image_paths)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=message,
-                           title=title,
-                           email_body='').show()
+        show_error_report(text=message, title=title)
 
     def get_image_preview(self,
                           image: ImageReturnSchema,
@@ -324,10 +288,9 @@ class DataCatalogApi(QObject):
         error_summary, email_body = get_error_report_body(response=response,
                                                           response_body=response.readAll().data().decode(),
                                                           plugin_version=self.plugin_version)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=error_summary,
-                           title="Error. Could not display preview",
-                           email_body=email_body).show()
+        show_error_report(text=error_summary,
+                          title="Error. Could not display preview",
+                          email_body=email_body)
 
     # Legacy:
     def upload_to_new_mosaic(self,
@@ -380,10 +343,7 @@ class DataCatalogApi(QObject):
                                                      response_body=response_body,
                                                      plugin_version=self.plugin_version,
                                                      error_message_parser=data_catalog_message_parser)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=error_summary,
-                           title=self.tr("Download error"),
-                           email_body='').show()
+        show_error_report(text=error_summary, title=self.tr("Download error"))
 
     @staticmethod
     def create_upload_image_body(image_path):

--- a/mapflow/functional/view/upload_progress.py
+++ b/mapflow/functional/view/upload_progress.py
@@ -1,0 +1,32 @@
+from PyQt5.QtWidgets import QProgressBar
+
+
+class UploadProgressReporter:
+    """Shows a raster upload's progress in the QGIS message bar.
+
+    This is the widget half of `DataCatalogApi`'s uploads. It lives in the view layer, which may
+    hold Qt widgets, and is injected into the api (which may not) as a plain collaborator — the api
+    hands over the reply and a label, and this attaches a progress bar to it. Uploads run one at a
+    time (the service recurses through the images), so one bar is tracked at a time.
+    """
+
+    def __init__(self, iface):
+        self.iface = iface
+
+    def track(self, response, message: str) -> None:
+        """Attach a progress bar to `response`'s upload, labelled `message`."""
+        message_bar = self.iface.messageBar().createMessage(message)
+        progress = QProgressBar()
+        message_bar.layout().addWidget(progress)
+        self.iface.messageBar().pushWidget(message_bar)
+
+        def on_progress(bytes_sent: int, bytes_total: int):
+            try:
+                progress.setValue(round(bytes_sent / bytes_total * 100))
+            except ZeroDivisionError:
+                return
+            if bytes_total > 0 and bytes_sent == bytes_total:
+                self.iface.messageBar().popWidget(message_bar)
+
+        connection = response.uploadProgress.connect(on_progress)
+        message_bar.destroyed.connect(lambda: response.uploadProgress.disconnect(connection))

--- a/mapflow/infra/alert_service.py
+++ b/mapflow/infra/alert_service.py
@@ -97,6 +97,18 @@ class AlertService(QObject):
                            title=title,
                            email_body=email_body).show()
 
+    def show_error_report(self, text: str, title: str = None, email_body: str = "") -> None:
+        """The *report* tier, for a caller that has already composed the failure text itself (an
+        expected error with a bespoke message, or one it parsed its own way). `report_http_error`
+        is the variant that parses a raw response; this one just shows what it is given, so a
+        service or api never has to import the report widget to raise it.
+        """
+        from ..dialogs.error_message_widget import ErrorMessageWidget
+        ErrorMessageWidget(parent=QApplication.activeWindow(),
+                           text=text,
+                           title=title,
+                           email_body=email_body).show()
+
     def ask_text(self, title: str, label: str, default: str = "") -> Tuple[str, bool]:
         """Ask the user for a line of text. Returns (text, accepted).
 
@@ -133,3 +145,6 @@ def report_http_error(response, plugin_version: str, title: str = None,
                       response_body: Optional[str] = None) -> None:
     return AlertService.instance().report_http_error(
         response, plugin_version, title, error_message_parser, response_body)
+
+def show_error_report(text: str, title: str = None, email_body: str = "") -> None:
+    return AlertService.instance().show_error_report(text, title, email_body)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -38,6 +38,7 @@ from .functional.view.aoi_view import AoiView
 from .functional.view.search_view import SearchView
 from .functional.view.processing_view import ProcessingView
 from .functional.view.data_catalog_view import DataCatalogView
+from .functional.view.upload_progress import UploadProgressReporter
 from .functional.service import (DataCatalogService,
                                  ProcessingService,
                                  ProjectService,
@@ -213,6 +214,9 @@ class Mapflow(QObject):
         # A failed preview used to be written to the pane by the api; it announces now, the view draws.
         self.data_catalog_service.api.previewUnavailable.connect(
             self.data_catalog_view.set_preview_unavailable)
+        # Upload progress is a message-bar widget; the api holds none, so the view-layer reporter
+        # (which may) is injected here, where iface is available.
+        self.data_catalog_service.api.progress_reporter = UploadProgressReporter(self.iface)
         # The catalog tables' selection is resolved by the service (into mosaics/images) and by
         # AreaCalculatorService (for the AOI area) — both told the ids, neither reading the table.
         # The push runs before those handlers, so it is connected here, above them, in the raw

--- a/tests/functional/test_layering.py
+++ b/tests/functional/test_layering.py
@@ -68,15 +68,9 @@ MAY_IMPORT = {
 #: anything a dependency check would notice.
 DIALOG_PARAMS = {"dlg", "dialog", "maindialog", "main_dialog"}
 
-ALLOWED = {
-    # service/ and api/ still constructing the error-report widget or an alert. Cleared as the
-    # error-reporting phase routes them through the infra reporter / message tier.
-    ("widget-import", "mapflow.functional.api.data_catalog_api"),
-    # The error-report widget (ErrorMessageWidget) still constructed inside an api. One entry per
-    # module, so it clears only when that module is clean. Cleared as the error-reporting phase
-    # routes each through the infra reporter.
-    ("api-imports-dialogs", "mapflow.functional.api.data_catalog_api"),
-}
+# Empty. Every service and api is free of widget and dialog imports — the goal of Phase C2 and the
+# error-reporting phase. An entry added here now records a real regression; fix the code instead.
+ALLOWED = set()
 
 #: Cycles that exist today, as the set of modules involved so the entry survives a change of
 #: traversal order. All three are the same shape: a package `__init__` imports its submodules

--- a/tests/qgis/test_data_catalog_api_error_report.py
+++ b/tests/qgis/test_data_catalog_api_error_report.py
@@ -1,0 +1,95 @@
+"""QGIS-tier tests: DataCatalogApi reports and shows progress without holding a widget (error-
+reporting phase, MR-3).
+
+The api built `ErrorMessageWidget` in six places and a `QProgressBar` in two — the last widget
+construction below the controller layer. The error handlers now call `show_error_report` in
+`mapflow.infra`; the upload progress is delegated to an injected view-layer reporter. With no
+QtWidgets or dialog imports left, the api's two allowlist entries clear and `ALLOWED` is empty.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PyQt5.QtCore import QObject
+from PyQt5.QtNetwork import QNetworkRequest
+
+from mapflow.functional.api import data_catalog_api as api_module
+from mapflow.functional.api.data_catalog_api import DataCatalogApi
+
+
+def _api():
+    api = DataCatalogApi.__new__(DataCatalogApi)
+    QObject.__init__(api)
+    api.tr = lambda text: text
+    api.plugin_version = "9.9.9"
+    api.progress_reporter = None
+    return api
+
+
+# ---------- the error handlers report through infra, not a dialog ----------
+
+def test_a_delete_failure_is_reported_with_its_message():
+    api = _api()
+
+    with patch.object(api_module, "show_error_report") as report:
+        api.delete_mosaic_error_handler(["North field"])
+
+    report.assert_called_once()
+    assert "North field" in report.call_args.kwargs["text"]
+
+
+def test_a_download_404_reports_the_not_found_message():
+    api = _api()
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = b"{}"
+    response.attribute.return_value = 404  # HttpStatusCodeAttribute
+
+    with patch.object(api_module, "show_error_report") as report:
+        api.download_image_error_handler(response)
+
+    assert "don't have access" in report.call_args.kwargs["text"]
+    assert report.call_args.kwargs["title"] == "Download error"
+
+
+def test_a_mosaic_extent_failure_reports_and_carries_the_collection_id():
+    api = _api()
+    api.iface = MagicMock()
+    api.result_loader = MagicMock()
+    response = MagicMock()
+    response.error.return_value = 99  # not NoError
+
+    with patch.object(api_module, "show_error_report") as report:
+        api.add_mosaic_with_extent(response, layer=MagicMock(), errors=False, mosaic_id="m-1")
+
+    assert "m-1" in report.call_args.kwargs["email_body"]
+
+
+# ---------- upload progress is delegated to the injected reporter ----------
+
+def test_an_upload_delegates_progress_to_the_reporter():
+    api = _api()
+    api.server = "https://example.com/rest"
+    response = MagicMock()
+    api.http = MagicMock()
+    api.http.post.return_value = response
+    api.progress_reporter = MagicMock()
+
+    with patch.object(api_module.DataCatalogApi, "create_upload_image_body", return_value=MagicMock()):
+        api.upload_image(mosaic_id="m-1", image_path="/tmp/x.tif",
+                         image_number=2, image_count=5)
+
+    api.progress_reporter.track.assert_called_once()
+    assert api.progress_reporter.track.call_args.args[0] is response
+    assert "2/5" in api.progress_reporter.track.call_args.args[1]
+
+
+def test_an_upload_without_a_reporter_still_uploads():
+    """The reporter is injected after construction; an upload before it exists must not crash."""
+    api = _api()
+    api.server = "https://example.com/rest"
+    api.http = MagicMock()
+    api.progress_reporter = None
+
+    with patch.object(api_module.DataCatalogApi, "create_upload_image_body", return_value=MagicMock()):
+        api.upload_image(mosaic_id="m-1", image_path="/tmp/x.tif")
+
+    api.http.post.assert_called_once()

--- a/tests/qgis/test_upload_progress.py
+++ b/tests/qgis/test_upload_progress.py
@@ -1,0 +1,44 @@
+"""QGIS-tier test for the upload-progress reporter that left DataCatalogApi (error-reporting MR-3).
+
+The api may hold no widget, so the message-bar progress bar moved to this view-layer helper, injected
+into the api. It shows a bar for an upload and removes it when the bytes complete.
+"""
+from unittest.mock import MagicMock
+
+from mapflow.functional.view.upload_progress import UploadProgressReporter
+
+
+def test_track_pushes_a_progress_bar_and_wires_the_reply():
+    iface = MagicMock()
+    reporter = UploadProgressReporter(iface)
+    response = MagicMock()
+
+    reporter.track(response, "Uploading image 1/3:")
+
+    iface.messageBar().createMessage.assert_called_once_with("Uploading image 1/3:")
+    iface.messageBar().pushWidget.assert_called_once()
+    response.uploadProgress.connect.assert_called_once()
+
+
+def test_the_bar_is_removed_when_the_upload_completes():
+    iface = MagicMock()
+    reporter = UploadProgressReporter(iface)
+    response = MagicMock()
+
+    reporter.track(response, "Uploading image 1/1:")
+    on_progress = response.uploadProgress.connect.call_args.args[0]
+
+    on_progress(50, 100)     # mid-upload: bar stays
+    iface.messageBar().popWidget.assert_not_called()
+
+    on_progress(100, 100)    # complete: bar removed
+    iface.messageBar().popWidget.assert_called_once()
+
+
+def test_zero_total_does_not_divide_by_zero():
+    reporter = UploadProgressReporter(MagicMock())
+    response = MagicMock()
+    reporter.track(response, "Uploading:")
+    on_progress = response.uploadProgress.connect.call_args.args[0]
+
+    on_progress(0, 0)  # must not raise


### PR DESCRIPTION
The catalog api built ErrorMessageWidget in six error handlers and a QProgressBar in two uploads —
the last widget construction below the controller layer.

The six error handlers now call show_error_report, a new primitive in the infra report tier. It sits
beside report_http_error but for a caller that has already composed its own message (an expected
failure with bespoke wording, or one parsed a particular way) — so it shows the text it is given
rather than parsing a raw response. Several of these sites compute a custom summary per error code,
which is exactly why report_http_error alone did not fit.

The upload progress bar moved to a view-layer UploadProgressReporter, injected into the api after
construction. It went to view/ rather than the controller because the api is built by the service,
before any controller exists; the api holds it as a plain collaborator (a view may hold widgets, an
api may not) and calls track(response, message). Uploads run one at a time — the service recurses
through the images — so a single tracked bar is correct. An api built without a reporter still
uploads, just unshown.

With the QtWidgets, QApplication and ErrorMessageWidget imports gone, both data_catalog_api entries
clear and ALLOWED is empty. Every service and api in the plugin is now free of widget and dialog
imports — the goal of Phase C2 and the error-reporting phase. test_the_allowlist_has_no_stale_entries
now guards an empty set, so a new widget import in a service or api fails the build instead of being
quietly exempted.

## Manual test
none — no user-visible change. Force each path: delete a collection/image that fails (the error
report appears), load a collection whose tiles 404 (the "failed to load" report), upload an image
that the server rejects (the upload-error report), open an image whose large preview 404s (the
"could not display preview" report), download an image you lack access to (the "download error"
report). Upload a valid image: the message-bar progress bar appears and clears at 100%. Regression
surface: the progress bar must still show and remove itself, and each error report must carry the
same text/title it did before.
