### PR TITLE
fix: throttle the HTTP error path, behind one reporter shared with the exception path

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -172,11 +172,10 @@ for every model that has options; see the note under C3.2.
     Emitted in `mapflow.py` and `project_view.py:195`; only `currentIndexChanged` is connected. The
     model refresh those emits intend happens by accident via `setCurrentText`. Either connect it or
     delete the emits — but decide, because the accident is load-bearing today.
-[ ] C3.4 Error-report widgets can be garbage-collected before they appear
-    `report_unexpected_error` and `report_http_error` build an `ErrorMessageWidget` into a local and
-    call `.show()`. With no parent — `parent=None`, or `QApplication.activeWindow()` returning None —
-    the widget can be collected before it is drawn, so the user sees nothing. Folds naturally into
-    the error-reporting item below, which already rewrites both.
+[fixed by error-reporting steps 1+2] C3.4 Error-report widgets can be garbage-collected before they
+    appear. Fixed at `ErrorMessageWidget`: it retains itself in a class-level set until closed
+    (`WA_DeleteOnClose` + `destroyed`→discard), covering all five construction sites at once. Pinned
+    by `tests/qgis/test_error_widget_gc.py` (nothing pinned it before).
 [ ] C3.5a An account with no projects re-requests the list forever
     `ProjectService.get_projects_callback` treats "no projects and no filter" as a stale page and
     re-requests without parameters — which returns the same empty result, and asks again. It is
@@ -306,17 +305,17 @@ first because the reporter must be reachable from an `api` before the api can ca
     is built by the service before any controller exists, so it takes a plain injected collaborator
     that may hold widgets.)
 
-[ ] 1. Signature and throttle for the HTTP path
-`response_signature(response)` = Qt error code + endpoint path; `http._request_path` already
-computes that path, query-free, because it lands in a mail body. Carry `suppressed_count` into
-the dialog text and report body the way the exception path does.
-
-[ ] 2. One reporter, in `infra/`
-Both entry points behind one module (`infra/reporter.py`) owning the throttle, the dialog and the
-suppressed-count wording. This folds `report_http_error` in next to `report_unexpected_error`;
-`report_http_error` currently lives in the moved `alert_service` (message tier) and comes out into
-the reporter here. Both tiers are in `infra/` (the reclassification above), so this is a move within
-`infra/`, not across a layer boundary.
+[ready-for-review] Steps 1+2 (unified, user-approved) — Signature, throttle, and one reporter.
+`mapflow/infra/reporter.py` now owns BOTH report entry points behind one shared `_throttle`:
+`report_unexpected_error` (moved from `error_guard`, which keeps the guards and re-exports it) and
+`report_http_error` (moved from `alert_service`, now throttled). `http.response_signature` = Qt code
++ query-free path (`_request_path`); `get_error_report_body` carries `suppressed_count` into the
+body, the dialog text gets it too. One throttle across both paths because the 10s global floor must
+hold between an HTTP and an exception report rotating through the same poll tick. Also: the report
+body now carries the query-free path, not the full URL (code catching up to spec/006 + privacy — a
+query carries ids/tokens); `Mapflow.report_http_error` (the default-handler path) folded onto the
+reporter; and C3.4 fixed at `ErrorMessageWidget` (self-retains until closed) so a report cannot be
+GC'd before it is painted. No spec delta needed — spec/006 § Volume limit already specifies all of it.
 
 [ ] 3. Restore the six silent request paths
 With the throttle covering them, opting out has no remaining justification — `spec/006` already

--- a/mapflow/dialogs/error_message_widget.py
+++ b/mapflow/dialogs/error_message_widget.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 from PyQt5 import uic
+from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QApplication
 
 
@@ -10,10 +11,20 @@ ui_path = Path(__file__).parent/'static'/'ui'
 logger = logging.getLogger(__name__)
 
 class ErrorMessageWidget(*uic.loadUiType(ui_path / 'error_message.ui')):
+    #: Every open dialog holds a reference to itself here. This dialog is often shown parentless
+    #: (`QApplication.activeWindow()` can be None while a report fires from a network callback),
+    #: and a top-level widget shown with `.show()` is then owned only by the local that built it —
+    #: the reporter returns, the local goes out of scope, and Qt can collect it before it is ever
+    #: painted. Self-retention until close is what keeps a reported error actually visible.
+    _alive = set()
+
     def __init__(self, parent: QWidget, text: str, title: str = None, email_body: str = '') -> None:
         """A message box notifying user about a plugin error, with a 'Send a report' button."""
         super().__init__(parent)
         self.setupUi(self)
+        type(self)._alive.add(self)
+        self.setAttribute(Qt.WA_DeleteOnClose)
+        self.destroyed.connect(lambda: type(self)._alive.discard(self))
         try:
             self.setWindowIcon(QApplication.activeWindow().windowIcon())
             self.setWindowTitle(QApplication.activeWindow().windowTitle())

--- a/mapflow/error_guard.py
+++ b/mapflow/error_guard.py
@@ -21,25 +21,13 @@ import functools
 import logging
 from typing import Callable, Optional
 
-from .report_throttle import ReportThrottle, exception_signature
+# The reporting itself lives in the infra report tier, behind a single throttle shared with the
+# HTTP report path (spec/006 § Where each tier lives). This module keeps only the entry-point
+# guards below; `report_unexpected_error` is re-exported so both the guards here and any
+# `from mapflow.error_guard import report_unexpected_error` caller keep resolving the bare name.
+from .infra.reporter import report_unexpected_error
 
 logger = logging.getLogger(__name__)
-
-#: Shown above the traceback in the dialog. Deliberately plain: the user did nothing
-#: wrong, and the only useful action is sending the report.
-DEFAULT_USER_TEXT = (
-    "Mapflow hit an unexpected error and could not finish that action.\n\n"
-    "The plugin is still running — you can keep working. Sending the report below helps "
-    "us fix it."
-)
-
-#: Appended when the same failure recurred while suppressed. A single dialog reads as a
-#: one-off glitch; the count is what tells the user (and us) it is systematic.
-REPEATED_USER_TEXT = "\n\nThis has happened {count} more time(s) since the last message."
-
-#: Process-wide, because the storm it prevents is process-wide: every guarded call site
-#: shares one budget. Tests substitute their own instance rather than reaching in here.
-_throttle = ReportThrottle()
 
 
 def _resolve_plugin_version(obj: object) -> str:
@@ -57,49 +45,6 @@ def _resolve_plugin_version(obj: object) -> str:
         if isinstance(target, str) and target:
             return target
     return 'unknown'
-
-
-def report_unexpected_error(exception: BaseException,
-                            context: str,
-                            plugin_version: str = 'unknown',
-                            parent=None) -> None:
-    """Log with traceback, then offer the user a pre-filled report.
-
-    Never raises. A reporting path that can fail is worse than none: it would replace the
-    original exception with its own, losing the very thing being reported.
-
-    Logging happens for every occurrence; only the *dialog* is throttled. The log is where
-    a developer reconstructs how often something fired, so thinning it would trade the one
-    complete record for nothing the user benefits from.
-    """
-    logger.error("Unexpected error during %s", context, exc_info=exception)
-
-    suppressed_count = _throttle.should_report(exception_signature(exception))
-    if suppressed_count is None:
-        return
-
-    try:
-        # Imported here, not at module scope: this module is imported early, and the
-        # dialog pulls in the Qt widget tree. Keeping it lazy also means a headless
-        # context (tests) can call the logging half without a QApplication.
-        from PyQt5.QtWidgets import QApplication
-        from .dialogs.error_message_widget import ErrorMessageWidget
-        from .http import get_exception_report_body
-
-        summary, email_body = get_exception_report_body(exception, plugin_version, context,
-                                                        suppressed_count=suppressed_count)
-        text = DEFAULT_USER_TEXT
-        if suppressed_count:
-            text += REPEATED_USER_TEXT.format(count=suppressed_count)
-        widget = ErrorMessageWidget(parent=parent or QApplication.activeWindow(),
-                                    text=text,
-                                    title=summary,
-                                    email_body=email_body)
-        widget.show()
-    except Exception:
-        # The original failure is already in the log above; this only records that the
-        # user was not shown it.
-        logger.exception("Could not present the error report dialog for: %s", context)
 
 
 def guard_entry_point(context: str, reraise: bool = False) -> Callable:

--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -8,7 +8,8 @@ from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest, QHttpMultiPart, QHtt
 from qgis.core import QgsMapLayer
 
 from ...schema.data_catalog import PreviewSize, MosaicCreateSchema, ImageReturnSchema, MosaicUpdateSchema
-from ...http import Http, get_error_report_body, data_catalog_message_parser
+from ...http import Http, data_catalog_message_parser
+from ...infra.report_body import get_error_report_body
 from ...functional import layer_utils
 from ...infra.alert_service import show_error_report
 

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -10,7 +10,8 @@ from qgis.core import (QgsCoordinateReferenceSystem, QgsFeature, QgsGeometry,
 from .. import helpers
 from .. import layer_utils
 from ..app_context import AppContext
-from ...infra.alert_service import alert, alert_info, alert_warning, report_http_error
+from ...infra.alert_service import alert, alert_info, alert_warning
+from ...infra.reporter import report_http_error
 from ...config import OSM
 from ...errors import ImageIdRequired
 from ...schema.catalog import MultiPreviewList, PreviewType

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -38,8 +38,8 @@ from ...schema.template import (
     ProcessingTemplateDTO,
     ProcessingTemplateDetails,
 )
-from ...infra.alert_service import (alert, alert_info, alert_warning, alert_confirm,
-                                    report_http_error)
+from ...infra.alert_service import alert, alert_info, alert_warning, alert_confirm
+from ...infra.reporter import report_http_error
 from ..app_context import AppContext
 from ...model.provider import ImagerySearchProvider
 from ...config import Config

--- a/mapflow/functional/service/search_service.py
+++ b/mapflow/functional/service/search_service.py
@@ -13,7 +13,7 @@ from ...http import api_message_parser
 from ...model.provider import ImagerySearchProvider, ProviderInterface
 from ...schema import ImageCatalogRequestSchema, ImageCatalogResponseSchema
 from ...schema.catalog import ProductType
-from ...infra.alert_service import report_http_error
+from ...infra.reporter import report_http_error
 
 logger = logging.getLogger(__name__)
 

--- a/mapflow/functional/service/template_service.py
+++ b/mapflow/functional/service/template_service.py
@@ -40,7 +40,8 @@ from ...config import Config
 from ..geometry import geometry_from_geojson
 from ..helpers import utc_date_from_iso
 from ...infra.alert_service import (alert, alert_confirm, alert_info, alert_warning,
-                            ask_text, report_http_error)
+                            ask_text)
+from ...infra.reporter import report_http_error
 from ...errors import ErrorMessage
 from ...http import api_message_parser
 from ...schema import ImageCatalogResponseSchema

--- a/mapflow/http.py
+++ b/mapflow/http.py
@@ -29,6 +29,19 @@ def _request_path(response: QNetworkReply) -> str:
         return 'the server'
 
 
+def response_signature(response: QNetworkReply) -> str:
+    """Suppression identity for an HTTP failure (spec/006 § Volume limit): the Qt error code plus
+    the query-free endpoint path. There is no raising frame to key on, as there is for an
+    exception. Reuses `_request_path` so the signature and the report body carry the same string,
+    and no id or token from a query makes each occurrence of one failure look distinct.
+    """
+    try:
+        code = response.error()
+    except (AttributeError, RuntimeError):
+        code = 'unknown'
+    return f'{code}@{_request_path(response)}'
+
+
 class Http(QObject):
     """"""
 
@@ -280,7 +293,8 @@ def _format_email_body(report: dict) -> str:
 def get_error_report_body(response: QNetworkReply,
                           response_body: str,
                           plugin_version: str,
-                          error_message_parser: Optional[Callable] = None):
+                          error_message_parser: Optional[Callable] = None,
+                          suppressed_count: int = 0):
     if error_message_parser is None:
         error_message_parser = default_message_parser
     if response.error() == QNetworkReply.OperationCanceledError:
@@ -298,11 +312,17 @@ def get_error_report_body(response: QNetworkReply,
     report = {
         # escape in case the error text is HTML
         'Error summary': html.escape(send_error_text),
-        'URL': response.request().url().toDisplayString(),
+        # The path only, never the full URL: the signature keys on this same string, and a query
+        # would carry ids and tokens into a mail body the user sends us (see `_request_path`).
+        'URL': _request_path(response),
         'HTTP code': response.attribute(QNetworkRequest.HttpStatusCodeAttribute),
         'Qt code': response.error(),
-        **_environment_report(plugin_version),
     }
+    # Same wording as the exception path: a failure that fired 200 times sits on a timer, which a
+    # single dialog cannot reveal.
+    if suppressed_count:
+        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
+    report.update(_environment_report(plugin_version))
     return show_error_text, _format_email_body(report)
 
 

--- a/mapflow/http.py
+++ b/mapflow/http.py
@@ -1,13 +1,10 @@
-import html
 import json
 import logging
-import traceback
 from typing import Callable, Union, Optional
-from urllib.parse import quote
 
-from PyQt5.QtCore import QBuffer, QByteArray, QObject, QTimer, QUrl, qVersion
+from PyQt5.QtCore import QBuffer, QByteArray, QObject, QTimer, QUrl
 from PyQt5.QtNetwork import QHttpMultiPart, QNetworkReply, QNetworkRequest
-from qgis.core import QgsNetworkAccessManager, Qgis, QgsApplication, QgsAuthMethodConfig
+from qgis.core import QgsNetworkAccessManager, QgsApplication, QgsAuthMethodConfig
 
 from .config import DEFAULT_HTTP_TIMEOUT_SECONDS
 from .errors import ErrorMessage, ProxyIsAlreadySet
@@ -264,100 +261,6 @@ def api_message_parser(response_body: str) -> str:
         return None
 
 
-#: Cap on the traceback carried in a mailto body. Mail clients truncate long URLs (some
-#: around 2 KB), and a silently cut report is worse than a deliberately shortened one:
-#: the tail frames are where the failure actually happened, so keep those.
-MAX_TRACEBACK_LINES = 40
-
-
-def _environment_report(plugin_version: str) -> dict:
-    """Version fields every report carries, regardless of what failed."""
-    return {
-        'Plugin version': plugin_version,
-        'QGIS version': Qgis.QGIS_VERSION,
-        'Qt version': qVersion(),
-    }
-
-
-def _format_email_body(report: dict) -> str:
-    """Render a report dict into a percent-encoded mailto body.
-
-    The result is interpolated into a `mailto:...&body=` href, so it must be
-    percent-encoded: a raw `&` or `#` in a traceback or response body would terminate the
-    body parameter and silently truncate the report.
-    """
-    body = '\n'.join(f'{key}: {value}' for key, value in report.items())
-    return quote(body)
-
-
-def get_error_report_body(response: QNetworkReply,
-                          response_body: str,
-                          plugin_version: str,
-                          error_message_parser: Optional[Callable] = None,
-                          suppressed_count: int = 0):
-    if error_message_parser is None:
-        error_message_parser = default_message_parser
-    if response.error() == QNetworkReply.OperationCanceledError:
-        send_error_text = show_error_text = 'Request timed out'
-    else:
-        try:  # handled standardized backend exception ({"code": <int>, "message": <str>})
-            show_error_text = error_message_parser(response_body=response_body)
-        except Exception:
-            # error_message_parser is caller-supplied, so there is no meaningful set of
-            # expected exceptions to narrow to — but a parser that raises is a bug worth
-            # seeing rather than silently degrading every error to 'Unknown error'.
-            logger.exception("Error message parser raised, falling back to plain text")
-            show_error_text = 'Unknown error'
-        send_error_text = response_body
-    report = {
-        # escape in case the error text is HTML
-        'Error summary': html.escape(send_error_text),
-        # The path only, never the full URL: the signature keys on this same string, and a query
-        # would carry ids and tokens into a mail body the user sends us (see `_request_path`).
-        'URL': _request_path(response),
-        'HTTP code': response.attribute(QNetworkRequest.HttpStatusCodeAttribute),
-        'Qt code': response.error(),
-    }
-    # Same wording as the exception path: a failure that fired 200 times sits on a timer, which a
-    # single dialog cannot reveal.
-    if suppressed_count:
-        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
-    report.update(_environment_report(plugin_version))
-    return show_error_text, _format_email_body(report)
-
-
-def get_exception_report_body(exception: BaseException,
-                              plugin_version: str,
-                              context: str = '',
-                              suppressed_count: int = 0):
-    """Build (user-facing text, mailto body) for an unexpected internal exception.
-
-    The counterpart of get_error_report_body for failures that never reached the network.
-    Without it, a bug in plugin code either surfaces as QGIS's raw "unhandled exception"
-    dialog — which users dismiss and never report — or is logged to a panel nobody opens.
-    Routing it here gives the same "send a report" path an HTTP 500 already has.
-
-    `context` names the operation that failed, in user-facing terms, because the exception
-    type alone rarely tells the user what they were doing when it happened.
-
-    `suppressed_count` is how many identical failures were hidden since the last report
-    (see report_throttle). It changes the triage completely — a failure that fired 200
-    times sits on a timer-driven path, which the single traceback cannot reveal.
-    """
-    summary = f'{type(exception).__name__}: {exception}'
-    traceback_lines = traceback.format_exception(type(exception), exception, exception.__traceback__)
-    traceback_text = ''.join(traceback_lines).rstrip().splitlines()
-    if len(traceback_text) > MAX_TRACEBACK_LINES:
-        omitted = len(traceback_text) - MAX_TRACEBACK_LINES
-        traceback_text = ([f'... {omitted} earlier frame(s) omitted ...']
-                          + traceback_text[-MAX_TRACEBACK_LINES:])
-
-    report = {
-        'Error summary': html.escape(summary),
-        'Operation': context or 'unspecified',
-    }
-    if suppressed_count:
-        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
-    report.update(_environment_report(plugin_version))
-    report['Traceback'] = '\n' + '\n'.join(traceback_text)
-    return summary, _format_email_body(report)
+#: Report-body formatting moved to `infra/report_body.py` — only one of the two builders was ever
+#: about an HTTP response, and neither belongs in the network module. `_request_path`,
+#: `response_signature` and the message parsers above stay here: they ARE about a response.

--- a/mapflow/infra/alert_service.py
+++ b/mapflow/infra/alert_service.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 from PyQt5.QtWidgets import QApplication, QInputDialog, QMessageBox
 from PyQt5.QtCore import Qt, QObject
 
@@ -62,41 +62,6 @@ class AlertService(QObject):
         """Display a confirmation dialog. Returns True if user confirms."""
         return self.alert(message, QMessageBox.Question, blocking=True)
 
-    def report_http_error(self,
-                          response,
-                          plugin_version: str,
-                          title: str = None,
-                          error_message_parser: Optional[Callable] = None,
-                          response_body: Optional[str] = None) -> None:
-        """The *report* tier of `spec/006_error_reporting.md`: the dialog that offers to mail us
-        the failure. Here for the same reason `alert` and `ask_text` are — a service that hits an
-        HTTP error should not have to import a dialog to say so.
-
-        `plugin_version` is passed in rather than read: this tier knows how to present a failure,
-        not where the session state lives.
-
-        `response_body` lets a caller that has already read the reply hand it over: `readAll()`
-        drains the buffer, so a caller that inspected the body itself must pass it here or the
-        report would decode an empty one.
-        """
-        # Imported here, not at module scope, for the reason `error_guard.report_unexpected_error`
-        # gives for the same import: the dialog pulls in the Qt widget tree, and keeping it lazy
-        # lets a headless context construct this service without one. Showing dialogs is this
-        # tier's job, so the dependency itself is not the thing being avoided.
-        from ..dialogs.error_message_widget import ErrorMessageWidget
-        from ..http import get_error_report_body
-        if response_body is None:
-            response_body = response.readAll().data().decode()
-        error_summary, email_body = get_error_report_body(
-            response=response,
-            response_body=response_body,
-            plugin_version=plugin_version,
-            error_message_parser=error_message_parser)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text=error_summary,
-                           title=title,
-                           email_body=email_body).show()
-
     def show_error_report(self, text: str, title: str = None, email_body: str = "") -> None:
         """The *report* tier, for a caller that has already composed the failure text itself (an
         expected error with a bespoke message, or one it parsed its own way). `report_http_error`
@@ -139,12 +104,6 @@ def alert_confirm(message: str) -> bool:
 
 def ask_text(title: str, label: str, default: str = "") -> Tuple[str, bool]:
     return AlertService.instance().ask_text(title, label, default)
-
-def report_http_error(response, plugin_version: str, title: str = None,
-                      error_message_parser: Optional[Callable] = None,
-                      response_body: Optional[str] = None) -> None:
-    return AlertService.instance().report_http_error(
-        response, plugin_version, title, error_message_parser, response_body)
 
 def show_error_report(text: str, title: str = None, email_body: str = "") -> None:
     return AlertService.instance().show_error_report(text, title, email_body)

--- a/mapflow/infra/report_body.py
+++ b/mapflow/infra/report_body.py
@@ -1,0 +1,119 @@
+"""Formatting a failure into a report body (`spec/006_error_reporting.md`, the report tier).
+
+Both builders live here, next to the reporter that uses them, rather than in `http`: only one of
+them is about an HTTP response, and the other — an internal exception with a traceback — has nothing
+to do with the network. What they share is turning a failure into the percent-encoded mailto body
+the "send a report" dialog carries. `http` keeps the pieces that ARE about a response (`_request_path`,
+`response_signature`, the message parsers); this imports the two it needs from there.
+"""
+import html
+import logging
+import traceback
+from typing import Callable, Optional
+from urllib.parse import quote
+
+from PyQt5.QtCore import qVersion
+from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
+from qgis.core import Qgis
+
+from ..http import _request_path, default_message_parser
+
+logger = logging.getLogger(__name__)
+
+#: Cap on the traceback carried in a mailto body. Mail clients truncate long URLs (some around
+#: 2 KB), and a silently cut report is worse than a deliberately shortened one: the tail frames are
+#: where the failure actually happened, so keep those.
+MAX_TRACEBACK_LINES = 40
+
+
+def _environment_report(plugin_version: str) -> dict:
+    """Version fields every report carries, regardless of what failed."""
+    return {
+        'Plugin version': plugin_version,
+        'QGIS version': Qgis.QGIS_VERSION,
+        'Qt version': qVersion(),
+    }
+
+
+def _format_email_body(report: dict) -> str:
+    """Render a report dict into a percent-encoded mailto body.
+
+    The result is interpolated into a `mailto:...&body=` href, so it must be percent-encoded: a raw
+    `&` or `#` in a traceback or response body would terminate the body parameter and silently
+    truncate the report.
+    """
+    body = '\n'.join(f'{key}: {value}' for key, value in report.items())
+    return quote(body)
+
+
+def get_error_report_body(response: QNetworkReply,
+                          response_body: str,
+                          plugin_version: str,
+                          error_message_parser: Optional[Callable] = None,
+                          suppressed_count: int = 0):
+    if error_message_parser is None:
+        error_message_parser = default_message_parser
+    if response.error() == QNetworkReply.OperationCanceledError:
+        send_error_text = show_error_text = 'Request timed out'
+    else:
+        try:  # handled standardized backend exception ({"code": <int>, "message": <str>})
+            show_error_text = error_message_parser(response_body=response_body)
+        except Exception:
+            # error_message_parser is caller-supplied, so there is no meaningful set of
+            # expected exceptions to narrow to — but a parser that raises is a bug worth
+            # seeing rather than silently degrading every error to 'Unknown error'.
+            logger.exception("Error message parser raised, falling back to plain text")
+            show_error_text = 'Unknown error'
+        send_error_text = response_body
+    report = {
+        # escape in case the error text is HTML
+        'Error summary': html.escape(send_error_text),
+        # The path only, never the full URL: the signature keys on this same string, and a query
+        # would carry ids and tokens into a mail body the user sends us (see `_request_path`).
+        'URL': _request_path(response),
+        'HTTP code': response.attribute(QNetworkRequest.HttpStatusCodeAttribute),
+        'Qt code': response.error(),
+    }
+    # Same wording as the exception path: a failure that fired 200 times sits on a timer, which a
+    # single dialog cannot reveal.
+    if suppressed_count:
+        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
+    report.update(_environment_report(plugin_version))
+    return show_error_text, _format_email_body(report)
+
+
+def get_exception_report_body(exception: BaseException,
+                              plugin_version: str,
+                              context: str = '',
+                              suppressed_count: int = 0):
+    """Build (user-facing text, mailto body) for an unexpected internal exception.
+
+    The counterpart of get_error_report_body for failures that never reached the network. Without
+    it, a bug in plugin code either surfaces as QGIS's raw "unhandled exception" dialog — which
+    users dismiss and never report — or is logged to a panel nobody opens. Routing it here gives the
+    same "send a report" path an HTTP 500 already has.
+
+    `context` names the operation that failed, in user-facing terms, because the exception type
+    alone rarely tells the user what they were doing when it happened.
+
+    `suppressed_count` is how many identical failures were hidden since the last report (see
+    report_throttle). It changes the triage completely — a failure that fired 200 times sits on a
+    timer-driven path, which the single traceback cannot reveal.
+    """
+    summary = f'{type(exception).__name__}: {exception}'
+    traceback_lines = traceback.format_exception(type(exception), exception, exception.__traceback__)
+    traceback_text = ''.join(traceback_lines).rstrip().splitlines()
+    if len(traceback_text) > MAX_TRACEBACK_LINES:
+        omitted = len(traceback_text) - MAX_TRACEBACK_LINES
+        traceback_text = ([f'... {omitted} earlier frame(s) omitted ...']
+                          + traceback_text[-MAX_TRACEBACK_LINES:])
+
+    report = {
+        'Error summary': html.escape(summary),
+        'Operation': context or 'unspecified',
+    }
+    if suppressed_count:
+        report['Repeated'] = f'{suppressed_count} further occurrence(s) suppressed since the last report'
+    report.update(_environment_report(plugin_version))
+    report['Traceback'] = '\n' + '\n'.join(traceback_text)
+    return summary, _format_email_body(report)

--- a/mapflow/infra/reporter.py
+++ b/mapflow/infra/reporter.py
@@ -15,6 +15,8 @@ import logging
 from typing import Callable, Optional
 
 from ..report_throttle import ReportThrottle, exception_signature
+from ..http import response_signature
+from .report_body import get_error_report_body, get_exception_report_body
 
 logger = logging.getLogger(__name__)
 
@@ -39,8 +41,10 @@ def _present(text: str, title: str = None, email_body: str = '', parent=None) ->
     """Show the report dialog. Never raises — it runs while already handling a failure, so an
     exception escaping here would replace the failure being reported with its own.
 
-    The widget retains itself until closed (see `ErrorMessageWidget`), so nothing here needs to
-    keep a reference alive.
+    The widget import stays local: it is the reporter's one true Qt-widget-tree dependency, and
+    keeping it here lets the report logic above (throttle, signature, body) be imported and
+    unit-tested with no widget/.ui machinery — the tests patch this function. The widget retains
+    itself until closed (see `ErrorMessageWidget`), so nothing here keeps a reference.
     """
     try:
         from PyQt5.QtWidgets import QApplication
@@ -70,7 +74,6 @@ def report_unexpected_error(exception: BaseException,
         return
 
     try:
-        from ..http import get_exception_report_body
         summary, email_body = get_exception_report_body(exception, plugin_version, context,
                                                         suppressed_count=suppressed_count)
         text = DEFAULT_USER_TEXT
@@ -94,7 +97,6 @@ def report_http_error(response,
     the buffer, so a caller that inspected the body itself must pass it here or the report would
     decode an empty one.
     """
-    from ..http import get_error_report_body, response_signature
     signature = response_signature(response)
     # Log every occurrence, before the throttle — suppression governs the dialog, never the log.
     logger.error("HTTP error: %s", signature)

--- a/mapflow/infra/reporter.py
+++ b/mapflow/infra/reporter.py
@@ -1,0 +1,118 @@
+"""The report tier of `spec/006_error_reporting.md`: the single place that turns a failure — an
+unexpected exception, or an HTTP error response — into a "Send a report" dialog, under one
+suppression budget.
+
+Both report paths live here, behind one `_throttle`, because the volume contract's global floor
+holds "between any two reports regardless of signature": an HTTP error and an exception can rotate
+through the same poll callback, and two separate throttles would let both fire inside the floor.
+One budget needs one owner.
+
+Qt-free at import time on purpose (only `report_throttle` + typing): it is imported early and by
+`error_guard`, and the dialog it eventually shows is pulled in lazily inside the functions, so a
+headless context can call the logging/throttle half without a QApplication.
+"""
+import logging
+from typing import Callable, Optional
+
+from ..report_throttle import ReportThrottle, exception_signature
+
+logger = logging.getLogger(__name__)
+
+#: Shown above the traceback in the dialog. Deliberately plain: the user did nothing wrong, and the
+#: only useful action is sending the report.
+DEFAULT_USER_TEXT = (
+    "Mapflow hit an unexpected error and could not finish that action.\n\n"
+    "The plugin is still running — you can keep working. Sending the report below helps "
+    "us fix it."
+)
+
+#: Appended when the same failure recurred while suppressed. A single dialog reads as a one-off
+#: glitch; the count is what tells the user (and us) it is systematic.
+REPEATED_USER_TEXT = "\n\nThis has happened {count} more time(s) since the last message."
+
+#: Process-wide, shared by BOTH report paths — that is what makes the global floor hold across
+#: tiers. Tests substitute their own instance rather than reaching in here.
+_throttle = ReportThrottle()
+
+
+def _present(text: str, title: str = None, email_body: str = '', parent=None) -> None:
+    """Show the report dialog. Never raises — it runs while already handling a failure, so an
+    exception escaping here would replace the failure being reported with its own.
+
+    The widget retains itself until closed (see `ErrorMessageWidget`), so nothing here needs to
+    keep a reference alive.
+    """
+    try:
+        from PyQt5.QtWidgets import QApplication
+        from ..dialogs.error_message_widget import ErrorMessageWidget
+        ErrorMessageWidget(parent=parent or QApplication.activeWindow(),
+                           text=text,
+                           title=title,
+                           email_body=email_body).show()
+    except Exception:
+        logger.exception("Could not present the error report dialog")
+
+
+def report_unexpected_error(exception: BaseException,
+                            context: str,
+                            plugin_version: str = 'unknown',
+                            parent=None) -> None:
+    """Log with traceback, then offer the user a pre-filled report.
+
+    Logging happens for every occurrence; only the *dialog* is throttled. The log is where a
+    developer reconstructs how often something fired, so thinning it would trade the one complete
+    record for nothing the user benefits from.
+    """
+    logger.error("Unexpected error during %s", context, exc_info=exception)
+
+    suppressed_count = _throttle.should_report(exception_signature(exception))
+    if suppressed_count is None:
+        return
+
+    try:
+        from ..http import get_exception_report_body
+        summary, email_body = get_exception_report_body(exception, plugin_version, context,
+                                                        suppressed_count=suppressed_count)
+        text = DEFAULT_USER_TEXT
+        if suppressed_count:
+            text += REPEATED_USER_TEXT.format(count=suppressed_count)
+        _present(text=text, title=summary, email_body=email_body, parent=parent)
+    except Exception:
+        # The original failure is already in the log above; this only records that the user was
+        # not shown it.
+        logger.exception("Could not build the error report for: %s", context)
+
+
+def report_http_error(response,
+                      plugin_version: str,
+                      title: str = None,
+                      error_message_parser: Optional[Callable] = None,
+                      response_body: Optional[str] = None) -> None:
+    """Report an HTTP error response, throttled by the same budget as the exception path.
+
+    `response_body` lets a caller that has already read the reply hand it over: `readAll()` drains
+    the buffer, so a caller that inspected the body itself must pass it here or the report would
+    decode an empty one.
+    """
+    from ..http import get_error_report_body, response_signature
+    signature = response_signature(response)
+    # Log every occurrence, before the throttle — suppression governs the dialog, never the log.
+    logger.error("HTTP error: %s", signature)
+
+    suppressed_count = _throttle.should_report(signature)
+    if suppressed_count is None:
+        return
+
+    try:
+        body = response.readAll().data().decode() if response_body is None else response_body
+        error_summary, email_body = get_error_report_body(
+            response=response,
+            response_body=body,
+            plugin_version=plugin_version,
+            error_message_parser=error_message_parser,
+            suppressed_count=suppressed_count)
+        if suppressed_count:
+            error_summary += REPEATED_USER_TEXT.format(count=suppressed_count)
+        _present(text=error_summary, title=title, email_body=email_body)
+    except Exception:
+        logger.exception("Could not present the HTTP error report: %s", signature)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -51,14 +51,12 @@ from .infra.alert_service import AlertService, alert
 from .functional.service.area_calculator_service import AreaCalculatorService
 # HTTP
 from .http import (Http,
-                   api_message_parser,
-                   get_error_report_body)
+                   api_message_parser)
 # Schema
 from .schema import ProviderReturnSchema
 from .schema.project import MapflowProject
 # Dialogs
-from .dialogs import (ErrorMessageWidget,
-                      MainDialog,
+from .dialogs import (MainDialog,
                       MapflowLoginDialog,
                       ProviderDialog,
                       ReviewDialog)
@@ -1103,16 +1101,13 @@ class Mapflow(QObject):
         :param title: The error message's title.
         :param error_message_parser: function to parse error message, depends on server which is requested.
             Default parser (if None) searches for 'message' section in response json
+
+        This is the default error handler's path — the highest-volume one — so it goes through the
+        throttled infra reporter like every other report; showing the dialog straight from here would
+        stack one per poll tick.
         """
-        response_body = response.readAll().data().decode()
-        error_summary, email_body = get_error_report_body(response=response,
-                                                          response_body=response_body,
-                                                          plugin_version=self.app_context.plugin_version,
-                                                          error_message_parser=error_message_parser)
-        ErrorMessageWidget(parent=QApplication.activeWindow(),
-                           text= error_summary,
-                           title=title,
-                           email_body=email_body).show()
+        from .infra.reporter import report_http_error
+        report_http_error(response, self.app_context.plugin_version, title, error_message_parser)
 
 
     def find_project(self, projects: List[MapflowProject], project_id: str):

--- a/tests/functional/test_error_guard.py
+++ b/tests/functional/test_error_guard.py
@@ -11,8 +11,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mapflow import error_guard
+from mapflow.infra import reporter
 from mapflow.http import MAX_TRACEBACK_LINES, get_exception_report_body
 from mapflow.report_throttle import ReportThrottle
+
+#: `report_unexpected_error` and the throttle moved to `infra.reporter`; `error_guard` re-exports the
+#: function and keeps only the entry-point guards. Its reporting now logs under the reporter's logger.
+REPORTER_LOGGER = "mapflow.infra.reporter"
 
 
 class Boom(Exception):
@@ -31,13 +36,13 @@ def fresh_throttle(monkeypatch):
     error would push every later one inside the global floor and silently turn its dialog
     assertions vacuous.
     """
-    monkeypatch.setattr(error_guard, "_throttle", ReportThrottle())
+    monkeypatch.setattr(reporter, "_throttle", ReportThrottle())
 
 
 # ---------- report_unexpected_error ----------
 
 def test_logs_with_traceback(caplog):
-    with caplog.at_level(logging.ERROR, logger="mapflow.error_guard"), \
+    with caplog.at_level(logging.ERROR, logger=REPORTER_LOGGER), \
             patch.object(error_guard, "report_unexpected_error",
                          wraps=error_guard.report_unexpected_error):
         try:
@@ -59,7 +64,7 @@ def test_never_raises_even_if_the_dialog_fails(caplog):
         _raise_boom()
     except Boom as exc:
         with patch("mapflow.http.get_exception_report_body", side_effect=RuntimeError("nope")), \
-                caplog.at_level(logging.ERROR, logger="mapflow.error_guard"):
+                caplog.at_level(logging.ERROR, logger=REPORTER_LOGGER):
             # Must not raise RuntimeError.
             error_guard.report_unexpected_error(exc, "doing the thing", "1.2.3")
 
@@ -70,7 +75,7 @@ def test_never_raises_even_if_the_dialog_fails(caplog):
 def test_a_repeated_failure_shows_one_dialog(caplog):
     """The whole point: a bug on a 6-second poll must not open a dialog every 6 seconds."""
     with patch("mapflow.dialogs.error_message_widget.ErrorMessageWidget") as widget, \
-            caplog.at_level(logging.ERROR, logger="mapflow.error_guard"):
+            caplog.at_level(logging.ERROR, logger=REPORTER_LOGGER):
         for _ in range(20):
             try:
                 _raise_boom()
@@ -94,7 +99,7 @@ def test_the_next_dialog_reports_how_many_were_hidden(monkeypatch):
     clock = _FakeClock()
     # The floor is irrelevant with a single signature; the per-signature window is the
     # mechanism under test.
-    monkeypatch.setattr(error_guard, "_throttle",
+    monkeypatch.setattr(reporter, "_throttle",
                         ReportThrottle(first_window=60.0, global_floor=0.0, clock=clock))
 
     with patch("mapflow.dialogs.error_message_widget.ErrorMessageWidget") as widget:

--- a/tests/functional/test_error_guard.py
+++ b/tests/functional/test_error_guard.py
@@ -12,7 +12,7 @@ import pytest
 
 from mapflow import error_guard
 from mapflow.infra import reporter
-from mapflow.http import MAX_TRACEBACK_LINES, get_exception_report_body
+from mapflow.infra.report_body import MAX_TRACEBACK_LINES, get_exception_report_body
 from mapflow.report_throttle import ReportThrottle
 
 #: `report_unexpected_error` and the throttle moved to `infra.reporter`; `error_guard` re-exports the
@@ -63,7 +63,7 @@ def test_never_raises_even_if_the_dialog_fails(caplog):
     try:
         _raise_boom()
     except Boom as exc:
-        with patch("mapflow.http.get_exception_report_body", side_effect=RuntimeError("nope")), \
+        with patch("mapflow.infra.reporter.get_exception_report_body", side_effect=RuntimeError("nope")), \
                 caplog.at_level(logging.ERROR, logger=REPORTER_LOGGER):
             # Must not raise RuntimeError.
             error_guard.report_unexpected_error(exc, "doing the thing", "1.2.3")
@@ -213,7 +213,7 @@ def test_long_traceback_is_truncated_from_the_front():
     try:
         _raise_boom()
     except Boom as exc:
-        with patch("mapflow.http.MAX_TRACEBACK_LINES", 2):
+        with patch("mapflow.infra.report_body.MAX_TRACEBACK_LINES", 2):
             _summary, body = get_exception_report_body(exc, "1.0", "ctx")
 
     decoded = unquote(body)

--- a/tests/functional/test_infra_alert_service.py
+++ b/tests/functional/test_infra_alert_service.py
@@ -15,8 +15,15 @@ def test_the_message_tier_is_importable_from_infra():
     # Safe in the no-QGIS functional tier: alert_service imports only PyQt5, not qgis.core.
     module = importlib.import_module("mapflow.infra.alert_service")
     for name in ("AlertService", "alert", "alert_info", "alert_warning", "alert_error",
-                 "alert_confirm", "ask_text", "report_http_error"):
+                 "alert_confirm", "ask_text", "show_error_report"):
         assert hasattr(module, name), f"infra.alert_service is missing {name}"
+
+
+def test_the_report_tier_is_importable_from_infra():
+    """The report tier (both entry points) lives in `infra.reporter`, behind one throttle."""
+    module = importlib.import_module("mapflow.infra.reporter")
+    for name in ("report_http_error", "report_unexpected_error", "_throttle"):
+        assert hasattr(module, name), f"infra.reporter is missing {name}"
 
 
 def test_the_old_service_path_is_gone():

--- a/tests/functional/test_reporter.py
+++ b/tests/functional/test_reporter.py
@@ -1,0 +1,128 @@
+"""The report tier (`mapflow/infra/reporter.py`): one throttle for both report paths.
+
+Step 1 of the error-reporting phase's behaviour half. The HTTP report path used to be unthrottled —
+a recurring poll error could stack a dialog every few seconds. It now shares the exception path's
+suppression budget, keyed on a per-failure signature, with the suppressed count carried into both
+the dialog text and the report body. These run in the no-QGIS functional tier: the throttle and the
+signature are Qt-free; the dialog itself is patched out.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mapflow.infra import reporter
+from mapflow.http import response_signature, get_error_report_body
+from mapflow.report_throttle import ReportThrottle
+
+
+def _response(path="/rasters/mosaic", code=299, http_code=400):
+    response = MagicMock()
+    response.error.return_value = code
+    response.request.return_value.url.return_value.path.return_value = path
+    response.attribute.return_value = http_code
+    return response
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+@pytest.fixture(autouse=True)
+def fresh_throttle(monkeypatch):
+    """A private budget per test — the production throttle is process-wide."""
+    monkeypatch.setattr(reporter, "_throttle", ReportThrottle())
+
+
+# ---------- the signature (spec/006 § Volume limit) ----------
+
+def test_the_signature_is_the_qt_code_and_the_query_free_path():
+    assert response_signature(_response("/rasters/mosaic", code=299)) == "299@/rasters/mosaic"
+
+
+def test_a_different_path_or_code_is_a_different_signature():
+    base = response_signature(_response("/rasters/mosaic", code=299))
+    assert response_signature(_response("/rasters/image", code=299)) != base
+    assert response_signature(_response("/rasters/mosaic", code=203)) != base
+
+
+# ---------- the HTTP path is now throttled ----------
+
+def test_a_repeated_http_error_shows_one_dialog():
+    """The whole point of step 1: a poll error must not open a dialog every tick."""
+    with patch.object(reporter, "_present") as present:
+        for _ in range(20):
+            reporter.report_http_error(_response(), "1.0", response_body="{}")
+    assert present.call_count == 1
+
+
+def test_the_dialog_returns_after_the_window():
+    clock = _FakeClock()
+    reporter._throttle = ReportThrottle(first_window=60.0, global_floor=0.0, clock=clock)
+    with patch.object(reporter, "_present") as present:
+        reporter.report_http_error(_response(), "1.0", response_body="{}")
+        for _ in range(5):
+            reporter.report_http_error(_response(), "1.0", response_body="{}")
+        clock.now += 61.0
+        reporter.report_http_error(_response(), "1.0", response_body="{}")
+    assert present.call_count == 2
+
+
+def test_the_suppressed_count_reaches_the_dialog_text():
+    clock = _FakeClock()
+    reporter._throttle = ReportThrottle(first_window=60.0, global_floor=0.0, clock=clock)
+    with patch.object(reporter, "_present") as present, \
+            patch("mapflow.http.get_error_report_body", return_value=("Server said no", "body")):
+        for _ in range(5):  # one shown, four suppressed
+            reporter.report_http_error(_response(), "1.0", response_body="{}")
+        clock.now += 61.0
+        reporter.report_http_error(_response(), "1.0", response_body="{}")
+
+    second_text = present.call_args.kwargs["text"]
+    assert "4 more time(s)" in second_text
+
+
+def test_the_log_records_every_occurrence_even_when_suppressed(caplog):
+    import logging
+    with patch.object(reporter, "_present"), \
+            caplog.at_level(logging.ERROR, logger="mapflow.infra.reporter"):
+        for _ in range(20):
+            reporter.report_http_error(_response(), "1.0", response_body="{}")
+    # 20 logged, 1 shown: suppression governs the dialog, never the log.
+    assert sum("HTTP error:" in r.message for r in caplog.records) == 20
+
+
+# ---------- the global floor spans BOTH report paths (the shared-throttle proof) ----------
+
+def test_an_http_report_and_an_exception_report_share_the_10s_floor():
+    """The decisive reason both paths live behind one throttle: a floor that held per-tier would
+    let an HTTP error and an exception both fire inside the 10s floor through the same poll tick."""
+    clock = _FakeClock()
+    reporter._throttle = ReportThrottle(global_floor=10.0, clock=clock)
+    with patch.object(reporter, "_present") as present:
+        reporter.report_http_error(_response(), "1.0", response_body="{}")   # shown
+        try:
+            raise ValueError("a different failure entirely")
+        except ValueError as exc:
+            reporter.report_unexpected_error(exc, "polling", "1.0")          # within the floor
+    assert present.call_count == 1  # the second is suppressed by the shared floor
+
+
+# ---------- the report body carries the query-free path (spec + privacy) ----------
+
+def test_the_report_body_carries_the_query_free_path():
+    from urllib.parse import unquote
+    response = _response(path="/rasters/mosaic", http_code=400)
+    _summary, body = get_error_report_body(response, '{"message": "no"}', "1.0")
+    decoded = unquote(body)
+    assert "/rasters/mosaic" in decoded
+
+
+def test_the_report_body_states_how_many_http_repeats_were_suppressed():
+    from urllib.parse import unquote
+    _summary, body = get_error_report_body(_response(), '{"message": "no"}', "1.0",
+                                           suppressed_count=41)
+    assert "41" in unquote(body) and "suppressed" in unquote(body)

--- a/tests/functional/test_reporter.py
+++ b/tests/functional/test_reporter.py
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from mapflow.infra import reporter
-from mapflow.http import response_signature, get_error_report_body
+from mapflow.http import response_signature
+from mapflow.infra.report_body import get_error_report_body
 from mapflow.report_throttle import ReportThrottle
 
 
@@ -75,7 +76,7 @@ def test_the_suppressed_count_reaches_the_dialog_text():
     clock = _FakeClock()
     reporter._throttle = ReportThrottle(first_window=60.0, global_floor=0.0, clock=clock)
     with patch.object(reporter, "_present") as present, \
-            patch("mapflow.http.get_error_report_body", return_value=("Server said no", "body")):
+            patch("mapflow.infra.reporter.get_error_report_body", return_value=("Server said no", "body")):
         for _ in range(5):  # one shown, four suppressed
             reporter.report_http_error(_response(), "1.0", response_body="{}")
         clock.now += 61.0

--- a/tests/qgis/test_error_widget_gc.py
+++ b/tests/qgis/test_error_widget_gc.py
@@ -1,0 +1,41 @@
+"""C3.4: the error-report dialog must outlive the callback that built it.
+
+`ErrorMessageWidget` is often shown parentless (a report can fire from a network callback while
+`QApplication.activeWindow()` is None), and a top-level widget shown with `.show()` is then owned
+only by the local that built it. The reporter returns, the local goes out of scope, and Qt could
+collect the dialog before it was ever painted. The widget now retains itself in a class-level set
+until closed; this pins that it survives collection while open and leaves the set once closed.
+"""
+import gc
+import weakref
+
+from PyQt5.QtCore import QEvent
+from PyQt5.QtWidgets import QApplication
+
+from mapflow.dialogs.error_message_widget import ErrorMessageWidget
+
+
+def test_the_dialog_is_not_collected_while_open():
+    """Without the self-retention, dropping the last local and collecting would take the dialog
+    with it — the C3.4 bug. With it, the class holds a reference and the dialog survives."""
+    ref = weakref.ref(ErrorMessageWidget(parent=None, text="something failed"))
+
+    gc.collect()
+
+    assert ref() is not None, "the dialog was collected before it could be shown (C3.4)"
+
+
+def test_closing_the_dialog_releases_it_from_the_retention_set():
+    """The other half of the mechanism: retention must end on close, or every reported error would
+    leak for the session. Asserted on set membership (what the code controls) rather than Python GC
+    of the wrapper."""
+    baseline = len(ErrorMessageWidget._alive)
+    widget = ErrorMessageWidget(parent=None, text="something failed")
+    assert len(ErrorMessageWidget._alive) == baseline + 1, "an open dialog must be retained"
+
+    widget.close()
+    # WA_DeleteOnClose posts a deferred-delete; flush it so `destroyed` fires and discards the
+    # dialog from the set (processEvents does not reliably run DeferredDelete in a headless test).
+    QApplication.sendPostedEvents(None, QEvent.DeferredDelete)
+
+    assert len(ErrorMessageWidget._alive) == baseline, "a closed dialog must leave the retention set"


### PR DESCRIPTION
Two report paths did the same job with different plumbing, and only the exception one was throttled:
the HTTP/response path could stack a "send a report" dialog every few seconds while a poll kept
failing — exactly the unbounded-dialog storm spec/006 § Volume limit forbids. A third path, the
default error handler on the god object, was the highest-volume of all and also unthrottled.

All three now go through mapflow/infra/reporter.py, which owns both entry points behind ONE shared
throttle. report_unexpected_error moves here from error_guard (which keeps the entry-point guards and
re-exports the name); report_http_error moves here from the message tier (alert_service) and gains
the throttle; Mapflow.report_http_error is folded onto it. One throttle across both paths is not
tidiness — the 10s global floor must hold between an HTTP report and an exception report rotating
through the same 6-second poll callback, which two separate throttles could not guarantee.

An HTTP failure is identified by http.response_signature = the Qt error code plus the query-free
endpoint path, the same string the report body now carries. The suppressed-occurrence count reaches
both the dialog text and the report body, the way the exception path already did — a failure that
fired 200 times is a timer bug a single dialog cannot reveal.

Two smaller corrections ride along, both spec-driven:
- The report body carried the full URL (query included); spec/006 and _request_path's own docstring
  say the path only, and a query carries ids and tokens into a mail body the user sends us. Changed
  to the query-free path, so body and signature agree. Report emails no longer include query params.
- C3.4: the report dialog could be garbage-collected before it was painted — built into a local and
  shown parentless, it was owned by nothing once the reporter returned. ErrorMessageWidget now
  retains itself until closed (a class-level set + WA_DeleteOnClose), fixing all five construction
  sites at once. Nothing pinned this before; a GC test does now.

No spec delta: spec/006 § Volume limit already specifies the signature, the window, the global floor
and the suppressed-count wording verbatim.

## Manual test
Hard to force naturally — the throttle only shows under a repeating failure. To exercise it: point
the plugin at an unreachable server (or block a polled endpoint) so a request fails every poll; the
"send a report" dialog appears ONCE, then stays quiet, and when it reappears (after the window) its
text says how many times the failure recurred. A one-off failure (e.g. a single bad action) still
reports immediately with no repeat line. The report email's URL line shows the path only, no query.

Regression surface: a normal one-off HTTP error must still open the report dialog with the server's
message; an unexpected internal exception must still report (the exception path moved modules);
guard_entry_point / call_guarded still swallow-and-report; and the dialog must actually appear and
stay up (the GC fix) rather than flashing and vanishing.
