### PR TITLE
fix: restore the silent request paths now that the throttle bounds repeat dialogs

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -317,9 +317,13 @@ query carries ids/tokens); `Mapflow.report_http_error` (the default-handler path
 reporter; and C3.4 fixed at `ErrorMessageWidget` (self-retains until closed) so a report cannot be
 GC'd before it is painted. No spec delta needed — spec/006 § Volume limit already specifies all of it.
 
-[ ] 3. Restore the six silent request paths
-With the throttle covering them, opting out has no remaining justification — `spec/006` already
-says so. Each site takes the default handler back, or states in a comment why not.
+[ready-for-review] 3. Restore the silent request paths — FIVE, not six (the old count had stale
+pre-Phase-C line numbers). Four restored to the default (throttled) handler: `account_service.
+refresh_status` (`/user/status` poll), `processing_api.get_processings` (processings page poll),
+`data_catalog_api.get_mosaic` and `.get_mosaic_images`. One kept opted out with a WHY comment:
+`mapflow.main`'s `/version` probe, which fails open so a report on an offline start would be noise.
+`tests/functional/test_silent_opt_outs.py` (AST) now allowlists exactly that one; a new silent
+request fails it.
 
 [ ] 4. Apply `guard_entry_point` at the entry points
 `guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher` is

--- a/mapflow/functional/api/data_catalog_api.py
+++ b/mapflow/functional/api/data_catalog_api.py
@@ -89,7 +89,7 @@ class DataCatalogApi(QObject):
     def get_mosaic(self, mosaic_id: UUID, callback: Callable):
         self.http.get(url=f"{self.server}/rasters/mosaic/{mosaic_id}",
                       callback=callback,
-                      use_default_error_handler=False
+                      use_default_error_handler=True
                      )
     
     def update_mosaic(self, mosaic_id, mosaic: MosaicUpdateSchema, callback: Callable, callback_kwargs: Optional[dict] = None):
@@ -225,7 +225,7 @@ class DataCatalogApi(QObject):
     def get_mosaic_images(self, mosaic_id: UUID, callback: Callable):
         self.http.get(url=f"{self.server}/rasters/mosaic/{mosaic_id}/image",
                       callback=callback,
-                      use_default_error_handler=False
+                      use_default_error_handler=True
                      )
 
     def get_image(self, image_id: UUID, callback: Callable, error_handler: Callable):

--- a/mapflow/functional/api/processing_api.py
+++ b/mapflow/functional/api/processing_api.py
@@ -131,7 +131,7 @@ class ProcessingApi(QObject):
         self.http.post(path=f"projects/{project_id}/processings/v2/page",
                        body=request_body.as_json().encode(),
                        callback=callback,
-                       use_default_error_handler=False,
+                       use_default_error_handler=True,
                        timeout=5)
 
 

--- a/mapflow/functional/service/account_service.py
+++ b/mapflow/functional/service/account_service.py
@@ -75,7 +75,7 @@ class AccountService(QObject):
         self.http.get(
             url=f'{self.server}/user/status',
             callback=self.apply_status,
-            use_default_error_handler=False  # driven by a timer, so errors would stack up alerts
+            use_default_error_handler=True,  # the report throttle bounds the timer's repeats now
         )
 
     def request_status(self) -> None:

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1259,7 +1259,11 @@ class Mapflow(QObject):
         self.http.get(
             url=f'{self.server}/version',
             callback=self.check_plugin_version_callback,
-            use_default_error_handler=False  # ignore errors
+            # Best-effort probe: version_ok fails open (stays True unless the callback clears it),
+            # so an unreachable /version must NOT report — a report modal on every offline start is
+            # a non-bug the user cannot act on. This is the one path that stays opted out (spec/006
+            # § Consequences: an opt-out states why).
+            use_default_error_handler=False,
         )
         if not self.version_ok:
             self.dlg.close()

--- a/tests/functional/test_silent_opt_outs.py
+++ b/tests/functional/test_silent_opt_outs.py
@@ -1,0 +1,79 @@
+"""Which HTTP requests are allowed to fail silently.
+
+A request made with `use_default_error_handler=False` and no `error_handler=` reports its server
+errors to nobody. Before the report throttle, several paths opted out that way to avoid a dialog
+every poll tick — the throttle now bounds that, so opting out to dodge repeat alerts has no
+justification left (`spec/006_error_reporting.md` § Consequences: "Opting out to dodge repeat alerts
+is superseded by the throttle").
+
+This enforces the one path that may still opt out: the `/version` probe, which fails open (the
+plugin still starts when it is unreachable) and so must NOT pop a report on an offline start. Any
+new silent request fails this test — restore the default handler, or add it to the allowlist with a
+reason, the same discipline as `test_layering.py`.
+"""
+import ast
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[2] / "mapflow"
+
+#: `Http` request methods. The `use_default_error_handler` keyword is unique to them, so matching on
+#: it (below) cannot collide with an unrelated `.get`/`.put` such as `dict.get`.
+HTTP_METHODS = {"get", "post", "put", "delete"}
+
+#: (path relative to repo root, enclosing function) allowed to make a silent request. Only the
+#: version probe: it fails open, so a report on an unreachable /version would be noise the user
+#: cannot act on.
+ALLOWED_SILENT = {("mapflow/mapflow.py", "main")}
+
+
+def _is_silent_http_call(node: ast.Call) -> bool:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr not in HTTP_METHODS:
+        return False
+    if any(kw.arg == "error_handler" for kw in node.keywords):
+        return False  # supplies its own handler — not silent
+    return any(kw.arg == "use_default_error_handler"
+               and isinstance(kw.value, ast.Constant) and kw.value.value is False
+               for kw in node.keywords)
+
+
+class _SilentSiteVisitor(ast.NodeVisitor):
+    def __init__(self, rel_path: str):
+        self.rel_path = rel_path
+        self.func_stack = []
+        self.sites = set()
+
+    def visit_FunctionDef(self, node):
+        self.func_stack.append(node.name)
+        self.generic_visit(node)
+        self.func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node):
+        if _is_silent_http_call(node):
+            self.sites.add((self.rel_path, self.func_stack[-1] if self.func_stack else "<module>"))
+        self.generic_visit(node)
+
+
+def _silent_sites():
+    sites = set()
+    for path in sorted(PLUGIN.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _SilentSiteVisitor(path.relative_to(PLUGIN.parent).as_posix())
+        visitor.visit(tree)
+        sites |= visitor.sites
+    return sites
+
+
+def test_only_the_version_probe_makes_a_silent_request():
+    sites = _silent_sites()
+    unexpected = sites - ALLOWED_SILENT
+    assert not unexpected, (
+        f"these requests fail silently — restore use_default_error_handler=True (the throttle now "
+        f"bounds repeat dialogs), or allowlist with a reason: {sorted(unexpected)}")
+    stale = ALLOWED_SILENT - sites
+    assert not stale, (
+        f"these are allowlisted as silent but no longer are — drop them from ALLOWED_SILENT: "
+        f"{sorted(stale)}")

--- a/tests/qgis/test_silent_paths_restored.py
+++ b/tests/qgis/test_silent_paths_restored.py
@@ -1,0 +1,56 @@
+"""The four restored request paths now use the default (throttled) error handler.
+
+Before the report throttle these polled/fetched silently — a server error reached nobody. The
+throttle bounds repeat dialogs, so they take the default handler back (error-reporting step 3). The
+"handler fires on error" logic lives in the unchanged `Http.response_dispatcher`; what step 3
+changed is only the flag these calls pass, so that is what is asserted.
+"""
+from unittest.mock import MagicMock
+
+from mapflow.functional.service.account_service import AccountService
+from mapflow.functional.api.processing_api import ProcessingApi
+from mapflow.functional.api.data_catalog_api import DataCatalogApi
+from mapflow.schema.processing import ProcessingsRequest
+
+
+def _kwargs(mock_method):
+    mock_method.assert_called_once()
+    return mock_method.call_args.kwargs
+
+
+def _assert_reports(kwargs):
+    assert kwargs.get("use_default_error_handler") is True, "the path must report its errors"
+    assert "error_handler" not in kwargs, "it uses the default handler, not its own"
+
+
+def test_the_status_poll_reports_its_errors():
+    service = AccountService.__new__(AccountService)
+    service.http = MagicMock()
+    service.server = "https://example.com/rest"
+    service.apply_status = MagicMock()
+
+    service.refresh_status()
+
+    _assert_reports(_kwargs(service.http.get))
+
+
+def test_the_processings_page_reports_its_errors():
+    api = ProcessingApi.__new__(ProcessingApi)
+    api.http = MagicMock()
+
+    api.get_processings(project_id="p-1", request_body=ProcessingsRequest(), callback=MagicMock())
+
+    _assert_reports(_kwargs(api.http.post))
+
+
+def test_loading_a_mosaic_and_its_images_reports_errors():
+    api = DataCatalogApi.__new__(DataCatalogApi)
+    api.http = MagicMock()
+    api.server = "https://example.com/rest"
+
+    api.get_mosaic(mosaic_id="m-1", callback=MagicMock())
+    _assert_reports(_kwargs(api.http.get))
+
+    api.http.get.reset_mock()
+    api.get_mosaic_images(mosaic_id="m-1", callback=MagicMock())
+    _assert_reports(_kwargs(api.http.get))


### PR DESCRIPTION
Five requests opted out of error handling with no handler of their own, so their server errors
reached nobody. Most opted out to dodge the dialog storm a failing poll would cause — which the
report throttle now prevents, so the reason is gone (spec/006 § Consequences: "Opting out to dodge
repeat alerts is superseded by the throttle").

Four take the default (throttled) handler back: the /user/status poll (its own comment said "errors
would stack up alerts" — exactly what the throttle removes), the processings-page poll, and loading
a mosaic and its images (a selected mosaic failing to load silently is unexpected — its sibling
get_mosaics already reported). One stays opted out, now with a reason instead of "# ignore errors":
the /version probe fails open (version_ok stays True unless the callback clears it), so an
unreachable /version must not pop a report on every offline start.

test_silent_opt_outs.py (AST, functional tier) now allowlists exactly that one probe: any other
request made with use_default_error_handler=False and no error_handler fails the test, the same
enforce-don't-review discipline as test_layering.py. The WAL said "six" silent paths from stale
pre-Phase-C line numbers; the real count in the current tree is five.

## Manual test
Hard to force without a server error. To exercise a restore: while a project is open, make the
processings-page or /user/status request fail (block the endpoint) — a throttled "send a report"
dialog now appears where nothing did before, and does not repeat every poll tick. Select a My
Imagery mosaic whose load fails: the same report appears instead of a blank panel. Regression
surface: a normal offline start (no network) must STILL open the plugin silently — the /version
probe stays opted out; and none of the restored polls may open a dialog on every tick (the throttle
from the previous commit is what guarantees that).
