### PR TITLE
feat: guard Qt entry points with guarded_connect, enforced by an AST test

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -325,16 +325,26 @@ refresh_status` (`/user/status` poll), `processing_api.get_processings` (process
 `tests/functional/test_silent_opt_outs.py` (AST) now allowlists exactly that one; a new silent
 request fails it.
 
-[ ] 4. Apply `guard_entry_point` at the entry points
-`guard_entry_point` is written and tested but applied nowhere; only `Http.response_dispatcher` is
-guarded. Everything entering plugin code from Qt without passing through `Http` still escapes to
-QGIS's raw unhandled-exception dialog: button clicks, selection changes, timer ticks,
-drag-and-drop, dialog accept/reject. 203 `.connect()` sites today, 109 still in `mapflow.py` —
-which is why this waits for Phase C, where a controller slot becomes the definition of an entry
-point (`spec/007_architecture.md` § Entry points).
-The decorator is the cheap half. The expensive half is `spec/006` § "A guarded callback is
-interrupted, not completed": every slot needs checking for cleanup placed after code that can
-raise. That is the bug that polled `/user/status` twice a second for a whole session.
+4. Guard the entry points — ~179 Qt-source connects (measured; the old "203/109" was stale). Split
+into PRs; mechanism + two spec deltas approved by the user (guarded-connect helper at connect sites,
+decorator for non-connect entries; new invariant 7 enforced by an AST test).
+
+[ready-for-review] 4-PR1 The mechanism + enforcement scaffold. `error_guard.guarded_connect` wraps a
+    slot in `call_guarded` at the connection site; `test_entry_points_guarded.py` (AST) fails any
+    raw `.connect` to a Qt-owned signal not in its only-shrinking `ALLOWED_UNGUARDED`. spec/007
+    § Entry points + § Invariants/Enforcement amended. `provider_controller` converted as the worked
+    example (its rows dropped from the allowlist). No behaviour change.
+[ ] 4-PR2 Cleanup-after-raise fixes (live bugs, independent of the wiring): `start_processing_callback`
+    + `submit_processing` leave Start disabled for the session if the payload drifts (RISK 1);
+    `preview_multiple_png` discards the in-flight id after a raise (RISK 2); `save_downloaded` wires
+    `reply.finished` past the guard (RISK 3 — route via `guarded_connect`); `unload` skips settings
+    persistence on a teardown raise (RISK 4).
+[ ] 4-PR3..6 Roll `guarded_connect` across the remaining regions (poll/submission controllers →
+    other controllers → `mapflow.py` + initGui/unload/main → views/dialogs), each PR deleting its
+    allowlist rows until `ALLOWED_UNGUARDED` holds only the response_dispatcher wiring.
+The expensive half is `spec/006` § "A guarded callback is interrupted, not completed": every slot
+converted is checked for cleanup placed after code that can raise — the bug that polled
+`/user/status` twice a second for a whole session.
 
 [ ] 5. Throttle the message tier too
 Decided with the above: the contract says *no failure* may produce unbounded dialogs, and

--- a/mapflow/error_guard.py
+++ b/mapflow/error_guard.py
@@ -87,3 +87,29 @@ def call_guarded(func: Callable,
     except Exception as exception:
         report_unexpected_error(exception, context, plugin_version)
         return None
+
+
+def guarded_connect(signal, slot: Callable, context: str = None, version_source: object = None):
+    """Connect `slot` to a Qt-owned `signal` so an unexpected failure becomes a report instead of
+    escaping to Qt's event loop.
+
+    Use this at every Qt-source connection — a widget/action/timer/layer/project/dialog signal —
+    which is where a fresh call stack enters plugin code (`spec/007_architecture.md` § Entry points).
+    A slot on a plugin `pyqtSignal` does NOT need it: that signal emits synchronously inside some
+    other entry point's stack, so it is already covered.
+
+    Returns whatever `signal.connect()` returns, so a caller that disconnects later can keep the
+    token. `context` names the failing operation for the report (defaults to the slot's name);
+    `version_source` is any object carrying `plugin_version`/`app_context.plugin_version` for the
+    report body, or None for 'unknown'.
+
+    PyQt keeps a strong reference to a connected Python callable for the connection's lifetime, so
+    the wrapper is not collected while connected (pinned by `test_guarded_connect`'s keep-alive test).
+    """
+    resolved_context = context or f"a UI action ({getattr(slot, '__name__', 'slot')})"
+
+    def _guarded(*args, **kwargs):
+        return call_guarded(slot, resolved_context, _resolve_plugin_version(version_source),
+                            *args, **kwargs)
+
+    return signal.connect(_guarded)

--- a/mapflow/functional/controller/provider_controller.py
+++ b/mapflow/functional/controller/provider_controller.py
@@ -8,6 +8,7 @@ would be controller-to-controller. It stays in the composition root, driving vie
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QMessageBox
 
+from ...error_guard import guarded_connect
 from ...infra.alert_service import alert, alert_warning
 from ..service.provider_service import ProviderService
 from ..view.provider_view import ProviderView
@@ -36,15 +37,17 @@ class ProviderController(QObject):
         self.processing_service = processing_service
 
         if add_button is not None:
-            add_button.clicked.connect(self.add_provider)
+            guarded_connect(add_button.clicked, self.add_provider, "adding a provider", app_context)
         if edit_button is not None:
-            edit_button.clicked.connect(self.edit_provider)
+            guarded_connect(edit_button.clicked, self.edit_provider, "editing a provider", app_context)
         if remove_button is not None:
-            remove_button.clicked.connect(self.remove_provider)
+            guarded_connect(remove_button.clicked, self.remove_provider, "removing a provider", app_context)
         if zoom_combo is not None:
-            zoom_combo.currentIndexChanged.connect(self.on_zoom_change)
+            guarded_connect(zoom_combo.currentIndexChanged, self.on_zoom_change,
+                            "changing the zoom", app_context)
         if provider_dialog is not None:
-            provider_dialog.accepted.connect(self.commit_provider)
+            guarded_connect(provider_dialog.accepted, self.commit_provider,
+                            "saving a provider", app_context)
 
     # ---------- the zoom ----------
 

--- a/spec/007_architecture.md
+++ b/spec/007_architecture.md
@@ -225,14 +225,26 @@ matching `.py` contains behaviour only.
 
 ### Entry points
 
-A controller method connected to a Qt signal is **the** definition of an entry point in
-this plugin. That matters beyond tidiness: `error_guard.guard_entry_point` is applied at
-entry points, and today "entry point" cannot be identified because `mapflow.py` mixes
-slots, callbacks and helpers in one class. Once controllers own the signal connections,
-the set of places needing the guard is enumerable rather than a judgement call.
+A slot connected to a **Qt-owned** signal — a widget, `QAction`, `QTimer`, `QgsVectorLayer`,
+`QgsProject`, or dialog — is an entry point: its invocation begins a fresh call stack from Qt's
+event loop, so an unexpected exception there escapes to QGIS's raw dialog unless it is guarded. A
+slot connected to a plugin `pyqtSignal` is **not** a separate entry point: that signal emits
+synchronously inside some other entry point's stack, so guarding every Qt-owned connection covers
+it transitively.
+
+The guard is applied two ways:
+
+* **At the connection site, `error_guard.guarded_connect(signal, slot, context, version_source)`** —
+  used instead of a raw `signal.connect(slot)` for every Qt-owned signal. It wraps the slot in
+  `call_guarded` and returns the connection token. This covers what a decorator cannot without
+  changing call semantics: lambdas, signal-to-signal forwards, and connections made directly to a
+  service or view method.
+* **`error_guard.guard_entry_point` (the decorator)** for entry points that are not `.connect`
+  sites — the Qt/QGIS event-handler overrides `initGui`, `unload`, `main`, `resizeEvent`.
 
 See `spec/006_error_reporting.md` for what the guard does and the constraint that a
-guarded callback is interrupted rather than completed.
+guarded callback is interrupted rather than completed — a slot that owns a state transition
+(stopping a timer, clearing an in-flight flag) must perform it before anything that can raise.
 
 ### The test surface that survives a move
 
@@ -290,12 +302,21 @@ restore the several hundred kilobytes the raw responses carry.
 4. One concept has one home. A type is defined once — no parallel copies across packages.
 5. `mapflow.py` contains no `self.dlg.<widget>` access.
 6. New and moved code adds nothing to the `.flake8` debt ledger. The ledger only shrinks.
+7. Every Qt-owned signal is connected through `error_guard.guarded_connect`, so no unexpected
+   failure at an entry point escapes to Qt's event loop. (Plugin-`pyqtSignal` connections are
+   exempt — they are covered transitively; see § Entry points.)
 
 ### Enforcement
 
 Invariants 1–3 are checked by a test, not by review. `tests/functional/test_layering.py`
 walks the import statements of each package and fails with the offending module and import
 when a rule is broken.
+
+Invariant 7 is checked the same way by `tests/functional/test_entry_points_guarded.py`: it walks
+every `.connect` call, and a connection to a Qt-owned signal made with a raw `.connect` (rather than
+`guarded_connect`) fails unless it is in that test's `ALLOWED_UNGUARDED` allowlist. The allowlist
+holds the connections not yet converted; it only shrinks, and a stale entry (a site now guarded)
+fails too — the same discipline as the layering allowlist and `test_silent_opt_outs.py`.
 
 This is deliberate, and `tests/functional/test_tier_layout.py` is the precedent: the
 stranded-test-file problem it now guards against had survived review for a long time

--- a/tests/functional/test_entry_points_guarded.py
+++ b/tests/functional/test_entry_points_guarded.py
@@ -1,0 +1,206 @@
+"""Every Qt-source entry point is guarded (spec/007 § Entry points, § Enforcement).
+
+A slot connected to a Qt-owned signal (a widget, action, timer, layer, project or dialog) begins a
+fresh call stack from Qt's event loop; an unexpected failure there escapes to QGIS's raw
+unhandled-exception dialog unless it is guarded. The guard is `error_guard.guarded_connect`, used at
+the connection site instead of a raw `signal.connect(slot)`.
+
+A slot on a plugin `pyqtSignal` is NOT an entry point of its own: it emits synchronously inside some
+other entry point's stack, so it is covered transitively and is not flagged here.
+
+`ALLOWED_UNGUARDED` records the Qt-source connections not yet routed through `guarded_connect`. It
+only shrinks — each entry-point PR removes its rows, and a row that no longer corresponds to a raw
+Qt-source connect fails the stale-entry test. Same discipline as `test_layering.py` /
+`test_silent_opt_outs.py`.
+"""
+import ast
+from pathlib import Path
+
+PLUGIN = Path(__file__).resolve().parents[2] / "mapflow"
+
+#: Signals owned by Qt/QGIS — a connection to one of these begins a fresh stack from the event loop
+#: (spec/007 § Entry points). Classified by attribute name, since AST cannot resolve the receiver's
+#: type. Plugin `pyqtSignal`s (domain signals like `refreshRequested`) are deliberately absent.
+QT_SIGNALS = {
+    # widgets
+    "clicked", "triggered", "itemSelectionChanged", "cellClicked", "cellDoubleClicked",
+    "doubleClicked", "currentIndexChanged", "currentTextChanged", "activated", "textChanged",
+    "textEdited", "stateChanged", "toggled", "valueChanged", "sectionClicked", "layerChanged",
+    "aboutToShow",
+    # QTimer
+    "timeout",
+    # QgsVectorLayer
+    "selectionChanged", "geometryChanged", "featureAdded", "featuresDeleted",
+    # QgsProject
+    "layersAdded", "readProject",
+    # QDialog / QNetworkReply completion
+    "finished", "accepted", "rejected",
+    # custom dialog signals emitted from inside a Qt event handler (fresh stack — see spec § Entry points)
+    "rasterSourceChanged", "metadataTableFilled",
+}
+
+#: (path relative to repo root, enclosing function, signal name) for each Qt-source connection still
+#: made with a raw `.connect`. Only shrinks — see the module docstring. Seeded with the set that
+#: existed when the guard rollout began (PR-1), minus `provider_controller`, converted as the worked
+#: example. Each later entry-point PR routes its region through `guarded_connect` and deletes its rows.
+ALLOWED_UNGUARDED = {
+    ('mapflow/dialogs/image_dialog.py', '__init__', 'textChanged'),
+    ('mapflow/dialogs/main_dialog.py', '__init__', 'clicked'),
+    ('mapflow/dialogs/main_dialog.py', '__init__', 'currentTextChanged'),
+    ('mapflow/dialogs/main_dialog.py', '_setup_off_nadir_filter', 'valueChanged'),
+    ('mapflow/dialogs/main_dialog.py', 'add_model_option', 'toggled'),
+    ('mapflow/dialogs/main_dialog.py', 'connect_processing_column_checkboxes', 'toggled'),
+    ('mapflow/dialogs/main_dialog.py', 'connect_search_column_checkboxes', 'toggled'),
+    ('mapflow/dialogs/main_dialog.py', 'set_raster_sources', 'currentTextChanged'),
+    ('mapflow/dialogs/main_dialog.py', 'set_state_from_settings', 'toggled'),
+    ('mapflow/dialogs/main_dialog.py', 'switch_provider_combo', 'currentTextChanged'),
+    ('mapflow/dialogs/main_dialog.py', 'switch_raster_combo', 'currentTextChanged'),
+    ('mapflow/dialogs/mosaic_dialog.py', '__init__', 'textChanged'),
+    ('mapflow/dialogs/processing_dialog.py', '__init__', 'textChanged'),
+    ('mapflow/dialogs/project_dialog.py', '__init__', 'textChanged'),
+    ('mapflow/dialogs/provider_dialog.py', '__init__', 'currentTextChanged'),
+    ('mapflow/dialogs/provider_dialog.py', '__init__', 'textChanged'),
+    ('mapflow/dialogs/provider_dialog.py', '__init__', 'toggled'),
+    ('mapflow/dialogs/review_dialog.py', 'setup', 'layerChanged'),
+    ('mapflow/dialogs/review_dialog.py', 'setup', 'textChanged'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_choose_raster_layer_paths', 'accepted'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'activated'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'cellDoubleClicked'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'clicked'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'textChanged'),
+    ('mapflow/functional/controller/data_catalog_controller.py', '_connect_buttons', 'triggered'),
+    ('mapflow/functional/controller/data_catalog_controller.py', 'create_mosaic', 'accepted'),
+    ('mapflow/functional/controller/data_catalog_controller.py', 'show_rename_image_dialog', 'accepted'),
+    ('mapflow/functional/controller/data_catalog_controller.py', 'update_mosaic', 'accepted'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'accepted'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'activated'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'cellClicked'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'clicked'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'currentIndexChanged'),
+    ('mapflow/functional/controller/processing_controller.py', '__init__', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_navigation', 'clicked'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_navigation', 'doubleClicked'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_navigation', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processing_bindings', 'aboutToShow'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processing_bindings', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processing_bindings', 'timeout'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processing_bindings', 'triggered'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processings_table_bindings', 'activated'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processings_table_bindings', 'clicked'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_processings_table_bindings', 'textEdited'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_project_bindings', 'activated'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_project_bindings', 'clicked'),
+    ('mapflow/functional/controller/project_processing_controller.py', '_setup_project_bindings', 'textEdited'),
+    ('mapflow/functional/controller/project_processing_controller.py', 'connect_projects', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/project_processing_controller.py', 'create_project', 'accepted'),
+    ('mapflow/functional/controller/project_processing_controller.py', 'show_details', 'clicked'),
+    ('mapflow/functional/controller/project_processing_controller.py', 'update_processing', 'accepted'),
+    ('mapflow/functional/controller/project_processing_controller.py', 'update_project', 'accepted'),
+    ('mapflow/functional/controller/search_controller.py', '__init__', 'cellDoubleClicked'),
+    ('mapflow/functional/controller/search_controller.py', '__init__', 'clicked'),
+    ('mapflow/functional/controller/search_controller.py', 'on_metadata_layer_ready', 'selectionChanged'),
+    ('mapflow/functional/controller/search_controller.py', 'sync_table_selection_with_layer', 'selectionChanged'),
+    ('mapflow/functional/controller/template_controller.py', '__init__', 'cellClicked'),
+    ('mapflow/functional/controller/template_controller.py', '__init__', 'clicked'),
+    ('mapflow/functional/controller/template_controller.py', '__init__', 'itemSelectionChanged'),
+    ('mapflow/functional/controller/template_controller.py', '__init__', 'triggered'),
+    ('mapflow/functional/service/account_service.py', '__init__', 'timeout'),
+    ('mapflow/functional/service/data_catalog.py', 'save_downloaded', 'finished'),
+    ('mapflow/functional/service/provider_service.py', 'duplicate_imagery_search', 'selectionChanged'),
+    ('mapflow/functional/view/aoi_view.py', 'enter_edit_session', 'clicked'),
+    ('mapflow/functional/view/processing_view.py', 'confirm_processing_start', 'accepted'),
+    ('mapflow/functional/view/processing_view.py', 'confirm_processing_start', 'toggled'),
+    ('mapflow/functional/view/processing_view.py', 'connect_header_sort', 'sectionClicked'),
+    ('mapflow/functional/view/search_view.py', 'connect_cell_preview', 'cellClicked'),
+    ('mapflow/functional/view/search_view.py', 'connect_table_selection', 'itemSelectionChanged'),
+    ('mapflow/functional/view/search_view.py', 'setup_search_mode_dropdown', 'triggered'),
+    ('mapflow/functional/view/search_view.py', 'setup_seen_dropdown', 'triggered'),
+    # `send_request` wires the finished signal to `response_dispatcher`, which IS the guard (it wraps
+    # every callback in `call_guarded`). It is the one `.connect` that need not go through the helper.
+    ('mapflow/http.py', 'send_request', 'finished'),
+    ('mapflow/mapflow.py', '__init__', 'cellClicked'),
+    ('mapflow/mapflow.py', '__init__', 'cellDoubleClicked'),
+    ('mapflow/mapflow.py', '__init__', 'clicked'),
+    ('mapflow/mapflow.py', '__init__', 'finished'),
+    ('mapflow/mapflow.py', '__init__', 'itemSelectionChanged'),
+    ('mapflow/mapflow.py', '__init__', 'layerChanged'),
+    ('mapflow/mapflow.py', '__init__', 'layersAdded'),
+    ('mapflow/mapflow.py', '__init__', 'metadataTableFilled'),
+    ('mapflow/mapflow.py', '__init__', 'rasterSourceChanged'),
+    ('mapflow/mapflow.py', '__init__', 'sectionClicked'),
+    ('mapflow/mapflow.py', '__init__', 'stateChanged'),
+    ('mapflow/mapflow.py', '__init__', 'triggered'),
+    ('mapflow/mapflow.py', 'initGui', 'readProject'),
+    ('mapflow/mapflow.py', 'initGui', 'triggered'),
+    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'featureAdded'),
+    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'featuresDeleted'),
+    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'geometryChanged'),
+    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'selectionChanged'),
+    ('mapflow/mapflow.py', 'set_up_login_dialog', 'clicked'),
+    ('mapflow/mapflow.py', 'set_up_login_dialog', 'toggled'),
+    ('mapflow/mapflow.py', 'setup_add_layer_menu', 'triggered'),
+    ('mapflow/mapflow.py', 'setup_options_menu_connections', 'triggered'),
+}
+
+
+def _signal_name(call: ast.Call):
+    """The signal a `.connect(...)` call attaches to, e.g. 'clicked' for `btn.clicked.connect(x)`.
+
+    Returns None when the receiver of `.connect` is not an attribute access (e.g. a bare `signal`
+    parameter inside the helper itself), which cannot be a Qt-source connection to classify.
+    """
+    if not (isinstance(call.func, ast.Attribute) and call.func.attr == "connect"):
+        return None
+    receiver = call.func.value
+    return receiver.attr if isinstance(receiver, ast.Attribute) else None
+
+
+class _ConnectVisitor(ast.NodeVisitor):
+    def __init__(self, rel_path: str):
+        self.rel_path = rel_path
+        self.func_stack = []
+        self.sites = set()
+
+    def visit_FunctionDef(self, node):
+        self.func_stack.append(node.name)
+        self.generic_visit(node)
+        self.func_stack.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node):
+        name = _signal_name(node)
+        if name in QT_SIGNALS:
+            func = self.func_stack[-1] if self.func_stack else "<module>"
+            self.sites.add((self.rel_path, func, name))
+        self.generic_visit(node)
+
+
+def _qt_source_connects():
+    sites = set()
+    for path in sorted(PLUGIN.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        visitor = _ConnectVisitor(path.relative_to(PLUGIN.parent).as_posix())
+        visitor.visit(tree)
+        sites |= visitor.sites
+    return sites
+
+
+def test_every_qt_source_connection_is_guarded_or_allowlisted():
+    sites = _qt_source_connects()
+    unguarded = sites - ALLOWED_UNGUARDED
+    assert not unguarded, (
+        "these Qt-source signals are connected with a raw `.connect` — route them through "
+        "`guarded_connect`, or (for a genuine Qt->Qt passthrough) add to ALLOWED_UNGUARDED with a "
+        f"reason:\n{chr(10).join(repr(s) for s in sorted(unguarded))}")
+
+
+def test_the_allowlist_has_no_stale_entries():
+    sites = _qt_source_connects()
+    stale = ALLOWED_UNGUARDED - sites
+    assert not stale, (
+        f"these are allowlisted but no longer raw Qt-source connects — drop them from "
+        f"ALLOWED_UNGUARDED:\n{chr(10).join(repr(s) for s in sorted(stale))}")

--- a/tests/functional/test_guarded_connect.py
+++ b/tests/functional/test_guarded_connect.py
@@ -1,0 +1,87 @@
+"""`error_guard.guarded_connect` — the mechanism that guards Qt-source entry points.
+
+It wraps a slot so an unexpected exception becomes a report (via `report_unexpected_error`) instead
+of escaping to Qt's event loop, and returns the connection token the caller may keep. These run in
+the no-QGIS functional tier with a fake signal; the keep-alive property (PyQt retaining the wrapper)
+is checked in the qgis tier with a real signal — see `tests/qgis/test_guarded_connect_keepalive.py`.
+"""
+from unittest.mock import patch
+
+from mapflow import error_guard
+
+
+class _FakeSignal:
+    """Records the slot connected and returns a token, like `pyqtSignal.connect`."""
+
+    def __init__(self):
+        self.connected = None
+        self.token = object()
+
+    def connect(self, slot):
+        self.connected = slot
+        return self.token
+
+
+class Boom(Exception):
+    pass
+
+
+def test_it_returns_the_connection_token():
+    signal = _FakeSignal()
+    token = error_guard.guarded_connect(signal, lambda: None, "doing a thing")
+    assert token is signal.token
+
+
+def test_a_raising_slot_is_reported_not_propagated():
+    signal = _FakeSignal()
+
+    def slot(*args):
+        raise Boom("kaboom")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        error_guard.guarded_connect(signal, slot, "doing a thing")
+        signal.connected("arg")  # fire it as Qt would — must not raise
+
+    reported.assert_called_once()
+    exception, context = reported.call_args.args[:2]
+    assert isinstance(exception, Boom)
+    assert context == "doing a thing"
+
+
+def test_a_successful_slot_runs_and_gets_its_arguments():
+    signal = _FakeSignal()
+    seen = []
+    error_guard.guarded_connect(signal, lambda *a: seen.append(a), "x")
+
+    signal.connected(1, 2)
+
+    assert seen == [(1, 2)]
+
+
+def test_the_context_defaults_to_the_slot_name():
+    signal = _FakeSignal()
+
+    def refresh_table(*args):
+        raise Boom("x")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        error_guard.guarded_connect(signal, refresh_table)
+        signal.connected()
+
+    assert "refresh_table" in reported.call_args.args[1]
+
+
+def test_the_plugin_version_comes_from_the_version_source():
+    signal = _FakeSignal()
+
+    class Owner:
+        plugin_version = "9.9.9"
+
+    def slot(*args):
+        raise Boom("x")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        error_guard.guarded_connect(signal, slot, "x", version_source=Owner())
+        signal.connected()
+
+    assert reported.call_args.args[2] == "9.9.9"

--- a/tests/qgis/test_guarded_connect_keepalive.py
+++ b/tests/qgis/test_guarded_connect_keepalive.py
@@ -1,0 +1,27 @@
+"""`guarded_connect`'s wrapper must survive GC while the connection is live (qgis tier: real signal).
+
+The helper connects a closure it does not itself retain. PyQt keeps a strong reference to a connected
+Python callable for the connection's lifetime, so the wrapper is not collected — this pins that, so
+the helper never needs a retention set of its own (unlike C3.4's widget). If PyQt's behaviour ever
+changed, a guarded slot would silently stop firing; this test would catch it.
+"""
+import gc
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from mapflow import error_guard
+
+
+class _Emitter(QObject):
+    fired = pyqtSignal(int)
+
+
+def test_the_wrapper_still_fires_after_collection():
+    emitter = _Emitter()
+    seen = []
+    error_guard.guarded_connect(emitter.fired, lambda value: seen.append(value), "x")
+
+    gc.collect()  # the wrapper closure has no local reference here — only the connection holds it
+    emitter.fired.emit(7)
+
+    assert seen == [7], "the guarded wrapper was collected before the signal fired"


### PR DESCRIPTION
An unexpected exception in a slot connected to a Qt-owned signal (a widget, action, timer, layer or
dialog) escapes to QGIS's raw unhandled-exception dialog — which names the plugin, offers no action,
and is dismissed without a report. Only network callbacks were guarded (Http.response_dispatcher);
every button, selection change and timer tick was not.

This adds the mechanism and the enforcement, and converts one region as the worked example — no
behaviour change yet, the rollout is later PRs.

- error_guard.guarded_connect(signal, slot, context, version_source) wraps a slot in call_guarded at
  the connection site and returns the connection token. It covers what the @guard_entry_point
  decorator cannot without changing call semantics: lambdas, signal-to-signal forwards, and
  connections made straight to a service/view method. The decorator stays for the non-.connect
  entries (initGui/unload/main/resizeEvent).
- test_entry_points_guarded.py (AST, functional tier) fails any raw `.connect` to a Qt-owned signal
  that is not routed through guarded_connect and not in ALLOWED_UNGUARDED — an only-shrinking
  allowlist seeded with today's ~90 unconverted sites. A stale entry (a site since guarded) fails
  too. Same enforce-don't-review discipline as test_layering / test_silent_opt_outs.
- provider_controller is converted (its 5 connects) and its rows removed from the allowlist, so the
  test proves both directions: the helper satisfies it, and conversion must drop the row.

Spec deltas (approved): spec/007 § Entry points now defines an entry point as a Qt-owned connection
and names guarded_connect (site) + the decorator (non-connect entries); § Invariants gains #7 "every
Qt-owned signal is connected through guarded_connect", enforced by the new test.

PyQt keeps a strong reference to a connected Python callable, so the wrapper is not collected while
connected — pinned by a qgis-tier keep-alive test, so the helper needs no retention set of its own.

## Manual test
none — no user-visible change. The provider add/edit/remove buttons, the zoom combo and the provider
dialog's OK still work exactly as before; they are now guarded, so a bug in one of those handlers
would show a "send a report" dialog instead of QGIS's raw crash dialog. Regression surface: adding,
editing, removing a provider, and changing zoom, all still function.
