### PR TITLE
fix: selecting a processing no longer force-enables Start

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -354,23 +354,16 @@ Throttle parameters move into `config.py` so they can be tuned during live UX te
 code change — the current values (60 s window, ×2 backoff, 30 min cap, 10 s global floor) were
 reasoned from poll intervals, not measured against users.
 
-[ ] A refused price is undone by the next UI refresh
-When `/processing/cost/v2` refuses, `ProcessingService.disable_processing_start` correctly
-disables Start and formats the server's reason — and then both effects are thrown away.
-`update_start_processing_button_state` (`mapflow.py:700`) re-enables the button whenever there
-is no *planned-processing* gate error; it knows nothing about pricing. The label goes the same
-way: the user ends up reading "Set AOI to start processing" with the AOI plainly set and the
-area showing a real figure (3.12 sq.km in the behavioral run).
-Two consequences, the second serious:
-- the actual cause is invisible — in the captured case a workflow-def the backend does not
-  recognise;
-- **Start becomes clickable again for a processing the backend refused to price**, so the user
-  can submit it.
-Reproduced behaviourally: price one AOI successfully (Start enabled), then switch to an AOI
-whose pricing is refused — Start stays enabled.
-The fix is for the enable/disable decision to have one owner rather than several writers, which
-is what the Phase C extraction is for. `tests/qgis/behavioral/test_cost_estimate.py` asserts
-only that changing the AOI re-prices, and says why it stops there.
+[fixed] A refused price (and any disable) is undone by the next selection
+`update_start_processing_button_state` re-enabled Start whenever there was no *planned-processing*
+gate error — knowing nothing about pricing, the AOI, the model or the provider. So a refused
+`/processing/cost/v2`, or a "Set AOI" disable, was thrown away by the next processings- or
+metadata-table selection: Start became clickable again (submittable) and the real reason label was
+lost. Also the user-reported case: double-clicking a processing to load its results turned Start on
+with no AOI set.
+Fixed by giving the enable one owner: the method now only *disables* on the planned-image gate and
+never force-enables — the enabled state is the validation's (`update_processing_cost`), which runs on
+every change that affects it. `test_without_a_template_selection_does_not_force_start_on` pins it.
 
 [ ] Check whether the behavioral tier reaches the real backend
 The fake network replaces `QgsNetworkAccessManager` for everything the plugin requests through

--- a/mapflow/functional/controller/processing_controller.py
+++ b/mapflow/functional/controller/processing_controller.py
@@ -178,16 +178,23 @@ class ProcessingController(QObject):
             on_accept=lambda: self.processing_service.submit_processing(processing_params))
 
     def update_start_processing_button_state(self, *args) -> None:
-        """Render start button text and enforce planned-processing image selection gate."""
+        """Update the start button text, and block a planned start with no images selected.
+
+        Connected to the processings- and metadata-table selection. This method owns exactly one
+        input to the Start button: the planned-processing image gate. When a template would run but
+        no search images are selected, Start is disabled here with that reason.
+
+        It does NOT enable the button. Whether Start may be pressed depends on the AOI, the model,
+        the provider and billing — validated as one by `update_processing_cost`, which runs on every
+        change that affects them (a new AOI, a provider or model switch, an image selection). Forcing
+        Start on here would override that: selecting a finished processing to load its results would
+        turn Start on with no AOI set, and a refused price would be undone by the next selection. So
+        the enable is left to the validation, which is the single source of truth for it.
+        """
         self.update_start_processing_button_text()
         error = self.processing_service.planned_processing_selection_error()
         if error:
             self.processing_view.disable_processing_start(reason=error, clear_area=False)
-            return
-        # No gate error: re-enable the button and clear any planned-processing reason label.
-        self.processing_view.enable_processing_start(
-            clear_reason=self.tr("Select one or more images in search results "
-                                 "to start planned processing"))
 
     def update_start_processing_button_text(self, *args) -> None:
         # Mirror what the start action actually does: "Start planned processing" only when a

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -283,6 +283,10 @@ class ProcessingService(QObject):
             return error, disable_start
         
         try:
+            # The name is the one precondition that does not block pricing: update_processing_cost
+            # validates with allow_empty_name=True, so the cost is computed and shown before the
+            # processing is named. It is therefore prompted at commit — a modal, with Start left
+            # enabled (disable_start=False) — rather than disabling Start the way a missing AOI does.
             if not processing_params.name and not allow_empty_name:
                 error = self.tr('Please, specify a name for your processing')
                 alert(error)

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -132,21 +132,25 @@ def test_selecting_a_template_row_offers_a_planned_start():
     dlg.disable_processing_start.assert_called_once()
 
 
-def test_without_a_template_the_button_returns_to_a_plain_start():
+def test_without_a_template_selection_does_not_force_start_on():
+    """The gate only DISABLES a planned start; enabling Start is the validation's job. A non-template
+    selection (e.g. double-clicking a finished processing to load its results) must not turn Start on
+    — otherwise Start would enable with no AOI set, and a refused price would be undone by the next
+    selection."""
     controller = _start_button_controller(template_to_run=None, gate_error=None)
 
     controller.update_start_processing_button_state()
 
     dlg = controller.processing_view.dlg
     dlg.startProcessing.setText.assert_called_with("Start processing")
-    dlg.startProcessing.setEnabled.assert_called_with(True)
-    dlg.processingProblemsLabel.clear.assert_called_once()
-    dlg.disable_processing_start.assert_not_called()
+    dlg.disable_processing_start.assert_not_called()      # the gate passed, so nothing is disabled
+    dlg.startProcessing.setEnabled.assert_not_called()    # but it does not force-enable either
+    dlg.processingProblemsLabel.clear.assert_not_called()  # and does not touch the reason label
 
 
-def test_a_reason_from_another_check_is_not_cleared():
-    """Only the planned-start reason is this gate's to clear. Blanking anything else would hide
-    a live reason the processing cannot start — the AOI being too large, say."""
+def test_a_reason_from_another_check_survives_a_gate_ok_selection():
+    """A reason set by another check — the AOI being too large, say — must not be wiped by a
+    selection whose planned gate happens to pass. This method leaves the label to the validation."""
     controller = _start_button_controller(template_to_run=None, gate_error=None)
     controller.processing_view.dlg.processingProblemsLabel.text.return_value = "AOI is too large"
 


### PR DESCRIPTION
Double-clicking a processing to load its results turned the Start button on even with no AOI or name
set. `update_start_processing_button_state` — connected to the processings- and metadata-table
selection — checked only the planned-processing image gate, and when that passed (which it always
does for a normal, non-template processing) it called `enable_processing_start()`, an unconditional
`setEnabled(True)`. That clobbered the "Set AOI to start processing" disable that area-calculation
had set. The same override also undid a refused `/processing/cost/v2` (the WAL "refused price is
undone by the next UI refresh" defect): Start became clickable again for a processing the backend
refused to price, and the real reason label was lost.

The Start button's enabled state depends on the AOI, the model, the provider and billing, validated
as one by `update_processing_cost`, which already runs on every change that affects them (a new AOI,
a provider or model switch, an image selection). So this method now owns only the planned-image
*disable* and never force-enables — the enable is the validation's, its single source of truth.

This fixes every case rather than the reported one alone: with no AOI Start stays disabled; with a
valid AOI it stays enabled; selecting a finished processing to load its results changes neither. Two
tests that pinned the buggy force-enable are rewritten to assert the button is left to the validation.

## Manual test
Open a project with processings but no AOI/name set: Start reads "Set AOI to start processing" and is
disabled. Double-click a processing to load its results (ok or failed) — Start stays disabled. Now
set a valid AOI: Start enables. Switch to an AOI whose price the server refuses: Start stays disabled
with the server's reason (no longer re-enabled by the next click). Planned processing still works:
open a template, select search images — Start enables (the area/cost validation does it), and with no
images selected it is blocked with "Select one or more images in search results".
