### PR TITLE
fix: guarded callbacks clear their own state before code that can raise

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -334,7 +334,7 @@ decorator for non-connect entries; new invariant 7 enforced by an AST test).
     raw `.connect` to a Qt-owned signal not in its only-shrinking `ALLOWED_UNGUARDED`. spec/007
     § Entry points + § Invariants/Enforcement amended. `provider_controller` converted as the worked
     example (its rows dropped from the allowlist). No behaviour change.
-[ ] 4-PR2 Cleanup-after-raise fixes (live bugs, independent of the wiring): `start_processing_callback`
+[ready-for-review] 4-PR2 Cleanup-after-raise fixes (live bugs, independent of the wiring): `start_processing_callback`
     + `submit_processing` leave Start disabled for the session if the payload drifts (RISK 1);
     `preview_multiple_png` discards the in-flight id after a raise (RISK 2); `save_downloaded` wires
     `reply.finished` past the guard (RISK 3 — route via `guarded_connect`); `unload` skips settings

--- a/mapflow/functional/service/data_catalog.py
+++ b/mapflow/functional/service/data_catalog.py
@@ -12,6 +12,7 @@ from ...schema.data_catalog import PreviewSize, MosaicReturnSchema, ImageReturnS
 from ...schema import MyImageryParams
 from ..api.data_catalog_api import DataCatalogApi
 from ...infra.alert_service import alert
+from ...error_guard import guarded_connect
 from ...http import Http
 from ...functional import helpers
 from ...functional.app_context import AppContext
@@ -406,7 +407,12 @@ class DataCatalogService(QObject):
         request = QNetworkRequest(QUrl(url))
         nam = self.api.http.nam
         reply = nam.get(request)
-        reply.finished.connect(lambda: self._save_downloaded_file(reply, save_path))
+        # Route the reply through the guard: `finished` is a Qt-owned signal and an unexpected
+        # raise in the slot would otherwise reach the event loop unguarded (spec/007 invariant 7).
+        guarded_connect(reply.finished,
+                        lambda: self._save_downloaded_file(reply, save_path),
+                        "saving a downloaded image",
+                        self.app_context)
 
     def _save_downloaded_file(self, reply: QNetworkReply, save_path: str):
         if reply.error() != QNetworkReply.NoError:

--- a/mapflow/functional/service/preview_service.py
+++ b/mapflow/functional/service/preview_service.py
@@ -312,12 +312,16 @@ class PreviewService(QObject):
             georeferenced_previews_list.append(georeferenced_preview)
         # Final part: merge all collected images into one VRT
         if len(previews) == 0:
+            # The multi-part download is finished the moment we reach this branch, so clear the
+            # in-flight guard first: building the VRT below can raise, and the callback is
+            # guard-wrapped, so a discard left at the tail would strand the id and block every
+            # later preview of this image (spec/006 § a guarded callback is interrupted).
+            self._pending_preview_ids.discard(image_id)  # multi-part download finished
             vrt_path = os.path.join(self.app_context.temp_dir, os.urandom(32).hex())
             vrt = gdal.BuildVRT(vrt_path, georeferenced_previews_list)
             vrt.FlushCache()
             vrt = None
             vrt_layer = QgsRasterLayer(vrt_path, f"{image_id} preview", 'gdal')
-            self._pending_preview_ids.discard(image_id)  # multi-part download finished
             self.result_loader.add_layer(vrt_layer)
             self._add_aoi_to_preview_if_needed()
             self._relocate_to_template_group(vrt_layer)

--- a/mapflow/functional/service/processing_service.py
+++ b/mapflow/functional/service/processing_service.py
@@ -521,6 +521,10 @@ class ProcessingService(QObject):
                     self.start_processing_error_handler
                 )
         except Exception as e:
+            # The run never left, so re-enable Start (undo the emit(True) above). Not a `finally`:
+            # on success the request is genuinely in flight and the flag must stay set until the
+            # async callback returns and clears it.
+            self.submissionInFlight.emit(False)
             alert(self.tr("Could not launch processing! Error: {}.").format(str(e)))
 
     def _build_run_template_processing_schema(
@@ -596,39 +600,44 @@ class ProcessingService(QObject):
 
     def start_processing_callback(self, response: QNetworkReply) -> None:
         """Display a success message and clear the processing name field."""
-        alert_info(
-            self.tr("Success! We'll notify you when the processing has finished.")
-        )
-        response_data = json.loads(response.readAll().data())
-        self.processing_fetch_timer.start()  # start monitoring
-        if self._open_template is not None:
-            # In a template the new processing is shown grouped UNDER its AOI. That binding
-            # lives in the template's aoiDetails, which the run response does not carry, so a
-            # flat optimistic add would place the processing under the "No AOI" separator until
-            # the user re-entered the template (feedback 8.2). Re-hydrating is what binds it, so
-            # ask for that rather than a plain refresh. Template run responses also may not be a
-            # full ProcessingDTO, so we do not parse one here.
-            if isinstance(response_data, dict) and response_data.get("name"):
-                self.processingNameCleared.emit(response_data["name"])
-            self.templateRehydrateRequested.emit()
+        try:
+            alert_info(
+                self.tr("Success! We'll notify you when the processing has finished.")
+            )
+            response_data = json.loads(response.readAll().data())
+            self.processing_fetch_timer.start()  # start monitoring
+            if self._open_template is not None:
+                # In a template the new processing is shown grouped UNDER its AOI. That binding
+                # lives in the template's aoiDetails, which the run response does not carry, so a
+                # flat optimistic add would place the processing under the "No AOI" separator until
+                # the user re-entered the template (feedback 8.2). Re-hydrating is what binds it, so
+                # ask for that rather than a plain refresh. Template run responses also may not be a
+                # full ProcessingDTO, so we do not parse one here.
+                if isinstance(response_data, dict) and response_data.get("name"):
+                    self.processingNameCleared.emit(response_data["name"])
+                self.templateRehydrateRequested.emit()
+                return
+            new_processing = None
+            # Template start responses may differ from processing-create responses.
+            # Try optimistic local update only when payload looks like a Processing DTO.
+            if isinstance(response_data, dict) and response_data.get("id") and response_data.get("name"):
+                new_processing = ProcessingDTO.from_dict(response_data)
+                self.processingNameCleared.emit(new_processing.name)
+            if new_processing is not None:
+                # Add to history
+                self.processings[new_processing.id] = new_processing
+                self.processings_history.add(new_processing.id, new_processing.status)
+                # display
+                self.processingAdded.emit(new_processing)
+            # Always refresh full list because template-started processings can affect
+            # both processings and template status/counts in table.
+            self.refreshRequested.emit()
+        finally:
+            # Clearing the in-flight flag is this callback's own state transition, so it goes in
+            # `finally`: the response is guard-wrapped (http.call_guarded), so a parse error on a
+            # drifted payload is swallowed and a tail emit would never run — leaving Start disabled
+            # for the rest of the session (spec/006 § a guarded callback is interrupted).
             self.submissionInFlight.emit(False)
-            return
-        new_processing = None
-        # Template start responses may differ from processing-create responses.
-        # Try optimistic local update only when payload looks like a Processing DTO.
-        if isinstance(response_data, dict) and response_data.get("id") and response_data.get("name"):
-            new_processing = ProcessingDTO.from_dict(response_data)
-            self.processingNameCleared.emit(new_processing.name)
-        if new_processing is not None:
-            # Add to history
-            self.processings[new_processing.id] = new_processing
-            self.processings_history.add(new_processing.id, new_processing.status)
-            # display
-            self.processingAdded.emit(new_processing)
-        # Always refresh full list because template-started processings can affect
-        # both processings and template status/counts in table.
-        self.refreshRequested.emit()
-        self.submissionInFlight.emit(False)
 
     def start_processing_error_handler(self, response: QNetworkReply) -> None:        
         """Error handler for processing creation requests.

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1012,6 +1012,19 @@ class Mapflow(QObject):
 
     def unload(self) -> None:
         """Remove the plugin icon & toolbar from QGIS GUI."""
+        # Persist the metadata filter the user set BEFORE any teardown. unload is reached from QGIS
+        # at plugin removal, and the teardown below can raise (a service stop, a dialog close); with
+        # these writes left at the tail a raise would strand them and lose the filter on the next
+        # start (spec/006 § a guarded callback is interrupted). Reading the values before close() is
+        # equivalent — close() hides the dialog, it does not destroy it.
+        if self.dlg:
+            self.app_context.settings.setValue('metadataMinIntersection', self.dlg.minIntersection.value())
+            self.app_context.settings.setValue('metadataMaxCloudCover', self.dlg.maxCloudCover.value())
+            off_nadir_min, off_nadir_max = self.dlg.off_nadir_range()
+            self.app_context.settings.setValue('metadataMinOffNadir', off_nadir_min)
+            self.app_context.settings.setValue('metadataMaxOffNadir', off_nadir_max)
+            self.app_context.settings.setValue('metadataFrom', self.dlg.metadataFrom.date())
+            self.app_context.settings.setValue('metadataTo', self.dlg.metadataTo.date())
         self.processing_service.stop()
         self.account_service.stop_refreshing()
         self.iface.removeCustomActionForLayerType(self.add_layer_action)
@@ -1020,13 +1033,6 @@ class Mapflow(QObject):
             if dlg:
                 dlg.close()
         del self.toolbar
-        self.app_context.settings.setValue('metadataMinIntersection', self.dlg.minIntersection.value())
-        self.app_context.settings.setValue('metadataMaxCloudCover', self.dlg.maxCloudCover.value())
-        off_nadir_min, off_nadir_max = self.dlg.off_nadir_range()
-        self.app_context.settings.setValue('metadataMinOffNadir', off_nadir_min)
-        self.app_context.settings.setValue('metadataMaxOffNadir', off_nadir_max)
-        self.app_context.settings.setValue('metadataFrom', self.dlg.metadataFrom.date())
-        self.app_context.settings.setValue('metadataTo', self.dlg.metadataTo.date())
 
     def default_error_handler(self,
                               response: QNetworkReply,

--- a/tests/functional/test_entry_points_guarded.py
+++ b/tests/functional/test_entry_points_guarded.py
@@ -106,7 +106,6 @@ ALLOWED_UNGUARDED = {
     ('mapflow/functional/controller/template_controller.py', '__init__', 'itemSelectionChanged'),
     ('mapflow/functional/controller/template_controller.py', '__init__', 'triggered'),
     ('mapflow/functional/service/account_service.py', '__init__', 'timeout'),
-    ('mapflow/functional/service/data_catalog.py', 'save_downloaded', 'finished'),
     ('mapflow/functional/service/provider_service.py', 'duplicate_imagery_search', 'selectionChanged'),
     ('mapflow/functional/view/aoi_view.py', 'enter_edit_session', 'clicked'),
     ('mapflow/functional/view/processing_view.py', 'confirm_processing_start', 'accepted'),

--- a/tests/qgis/test_data_catalog_save.py
+++ b/tests/qgis/test_data_catalog_save.py
@@ -1,0 +1,31 @@
+"""QGIS-tier test: a downloaded-image save routes its reply through the guard (4-PR2, RISK 3).
+
+`save_downloaded` wires `reply.finished` to write the fetched bytes to disk. `finished` is a
+Qt-owned signal, so an unexpected raise in the slot would reach the event loop unguarded
+(spec/007 invariant 7). The connection goes through `guarded_connect`, never a raw `.connect`.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from mapflow.functional.service import data_catalog as data_catalog_module
+from mapflow.functional.service.data_catalog import DataCatalogService
+
+
+def test_save_downloaded_routes_the_reply_through_the_guard(monkeypatch):
+    service = DataCatalogService.__new__(DataCatalogService)
+    service.app_context = SimpleNamespace(plugin_version="1.2.3")
+    reply = MagicMock()
+    nam = MagicMock()
+    nam.get.return_value = reply
+    service.api = SimpleNamespace(http=SimpleNamespace(nam=nam))
+
+    connected = []
+    monkeypatch.setattr(data_catalog_module, "guarded_connect",
+                        lambda signal, slot, *a, **k: connected.append((signal, slot)))
+
+    service.save_downloaded("https://example.com/img.tif", "/tmp/out.tif")
+
+    assert connected, "save_downloaded must connect the reply's finished signal"
+    signal, _slot = connected[0]
+    assert signal is reply.finished             # guarded, not a raw reply.finished.connect
+    reply.finished.connect.assert_not_called()  # the raw connect path is gone

--- a/tests/qgis/test_preview_dedup.py
+++ b/tests/qgis/test_preview_dedup.py
@@ -62,3 +62,20 @@ def test_error_handler_clears_in_flight_flag(service, monkeypatch):
 
     assert "IMG-1" not in service._pending_preview_ids
     reported.assert_called_once()
+
+
+def test_final_merge_clears_in_flight_flag_even_if_vrt_build_raises(service, monkeypatch):
+    # The multi-part download is complete once the final merge runs (previews empty). If BuildVRT
+    # then raises, the in-flight id must already be cleared: the callback is guard-wrapped, so a
+    # discard left at the tail would strand the id and block every later preview of this image.
+    service.app_context.temp_dir = "/tmp"
+    service._pending_preview_ids = {"IMG-1"}
+    monkeypatch.setattr("mapflow.functional.service.preview_service.gdal.BuildVRT",
+                        MagicMock(side_effect=RuntimeError("corrupt part")))
+
+    with pytest.raises(RuntimeError):
+        service.preview_multiple_png(response=None, previews=[], footprint=MagicMock(),
+                                     image_id="IMG-1",
+                                     georeferenced_previews_list=["/tmp/part.tif"])
+
+    assert "IMG-1" not in service._pending_preview_ids  # cleared before the raise

--- a/tests/qgis/test_template_start_processing.py
+++ b/tests/qgis/test_template_start_processing.py
@@ -3,6 +3,8 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from PyQt5.QtCore import QObject
 
 from mapflow.functional.controller.template_controller import TemplateController
@@ -469,6 +471,51 @@ def test_start_processing_callback_refreshes_processings_for_template_response_s
     assert asked == [True]
     assert added == []
     assert in_flight[-1] is False
+
+
+def test_start_processing_callback_clears_in_flight_even_when_the_body_is_malformed():
+    # A drifted run response (not JSON) makes json.loads raise. The callback is guard-wrapped in
+    # production, so that raise is swallowed; the button must still be re-enabled, or Start stays
+    # disabled for the rest of the session (spec/006 § a guarded callback is interrupted).
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    service.processing_fetch_timer = MagicMock()
+    service.processings = {}
+    service.processings_history = MagicMock()
+    service._open_template = None
+    QObject.__init__(service)
+    in_flight = []
+    service.submissionInFlight.connect(in_flight.append)
+
+    response = MagicMock()
+    response.readAll.return_value.data.return_value = b'<html>not json</html>'
+
+    with patch.object(processing_service_module, "alert_info"):
+        with pytest.raises(json.JSONDecodeError):
+            service.start_processing_callback(response)
+
+    assert in_flight[-1] is False  # the finally re-enabled Start despite the parse error
+
+
+def test_submit_processing_reenables_start_when_request_setup_raises():
+    # If building/sending the request raises, the async callback never fires, so the emit(True)
+    # that disabled Start would never be undone. The except must re-enable it.
+    service = ProcessingService.__new__(ProcessingService)
+    service.tr = lambda text: text
+    service.iface = MagicMock()
+    service.app_context = SimpleNamespace(plugin_name="Mapflow")
+    service.api = MagicMock()
+    service.api.create_processing.side_effect = RuntimeError("boom")
+    service.template_to_run = MagicMock(return_value=None)  # take the create_processing branch
+    QObject.__init__(service)
+    in_flight = []
+    service.submissionInFlight.connect(in_flight.append)
+
+    with patch.object(processing_service_module, "alert"):
+        service.submit_processing(MagicMock())
+
+    assert in_flight[0] is True     # disabled while the run is being sent
+    assert in_flight[-1] is False   # re-enabled after setup failed
 
 
 def test_disable_processing_start_uses_fallback_when_api_message_is_none():

--- a/tests/qgis/test_unload_persists_settings.py
+++ b/tests/qgis/test_unload_persists_settings.py
@@ -1,0 +1,58 @@
+"""QGIS-tier test: unload persists the metadata filter before teardown (4-PR2, RISK 4).
+
+The metadata filter the user set is written to QgsSettings in `unload`. Those writes used to sit at
+the tail of unload, after service stops and dialog closes that can raise; a raise there stranded
+them and lost the filter on the next start. They now run first, so a teardown failure cannot drop
+them (spec/006 § a guarded callback is interrupted).
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from mapflow.mapflow import Mapflow
+
+
+def _plugin_with_dialog():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.processing_service = MagicMock()
+    plugin.account_service = MagicMock()
+    plugin.iface = MagicMock()
+    plugin.add_layer_action = MagicMock()
+    plugin.remove_layer_action = MagicMock()
+    plugin.toolbar = MagicMock()
+    plugin.dlg_login = None
+    plugin.dlg_provider = None
+    plugin.app_context = SimpleNamespace(settings=MagicMock())
+    dlg = MagicMock()
+    dlg.minIntersection.value.return_value = 5
+    dlg.maxCloudCover.value.return_value = 20
+    dlg.off_nadir_range.return_value = (0, 45)
+    plugin.dlg = dlg
+    return plugin
+
+
+def _persisted_keys(settings):
+    return [c.args[0] for c in settings.setValue.call_args_list]
+
+
+def test_unload_persists_metadata_settings():
+    plugin = _plugin_with_dialog()
+
+    plugin.unload()
+
+    keys = _persisted_keys(plugin.app_context.settings)
+    assert 'metadataMinIntersection' in keys
+    assert 'metadataTo' in keys
+
+
+def test_unload_still_persists_settings_when_teardown_raises():
+    plugin = _plugin_with_dialog()
+    plugin.processing_service.stop.side_effect = RuntimeError("stop failed")
+
+    with pytest.raises(RuntimeError):
+        plugin.unload()
+
+    keys = _persisted_keys(plugin.app_context.settings)
+    assert 'metadataMinIntersection' in keys  # written before the teardown that raised
+    assert 'metadataTo' in keys


### PR DESCRIPTION
Four callbacks reached through error_guard left cleanup after a line that can raise. The response
callbacks run inside http.call_guarded, so the raise is swallowed and the callback returns — and
the stranded cleanup never runs, invisibly (spec/006 § a guarded callback is interrupted, not
completed). Each callback owns a state transition and now performs it before the raise-prone code,
or in a finally.

- start_processing_callback: json.loads on a drifted run payload raised before the tail
  submissionInFlight.emit(False), leaving Start disabled for the rest of the session. The in-flight
  clear moves into a finally.
- submit_processing: if building/sending the request raised, the except alerted but never undid the
  emit(True) that disabled Start — the same stuck button by the synchronous path. The except now
  re-enables (not a finally: on success the flag must stay set until the async callback clears it).
- preview_multiple_png: the in-flight-id discard sat after gdal.BuildVRT / QgsRasterLayer in the
  final-merge branch; a raise there stranded the id and blocked every later preview of that image.
  The discard moves to the top of the branch — the multi-part download is finished the moment we
  reach it.
- save_downloaded: reply.finished was a raw Qt connect, so an unexpected raise in the write-to-disk
  slot would reach the event loop unguarded (spec/007 invariant 7). Routed through guarded_connect,
  and its ALLOWED_UNGUARDED row deleted.
- unload: the metadata-filter settings writes ran last, after service stops and dialog closes that
  can raise; a teardown raise dropped them and lost the user's filter on the next start. They move
  to the top of unload, before any teardown.

## Manual test
- Start a processing, then kill the network so the run response arrives malformed (or never parses):
  the Start button must return to enabled, not stay greyed for the rest of the session.
- Trigger a run whose request build fails: Start re-enables and the error alert shows.
- Preview a multi-part image (e.g. Roscosmos) whose parts are corrupt so the VRT build fails: the
  image can still be previewed again afterwards, not permanently blocked.
- Download a catalog image to disk: it still saves (regression surface — guarded_connect must not
  change the happy path).
- Set the metadata filter (cloud cover, off-nadir, dates), then reload the plugin: the values come
  back. Regression surface: a normal unload with no teardown error still persists them.
