### PR TITLE
fix: throttle the message tier, and source throttle params from config

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -329,16 +329,6 @@ request fails it.
 into PRs; mechanism + two spec deltas approved by the user (guarded-connect helper at connect sites,
 decorator for non-connect entries; new invariant 7 enforced by an AST test).
 
-[ready-for-review] 4-PR1 The mechanism + enforcement scaffold. `error_guard.guarded_connect` wraps a
-    slot in `call_guarded` at the connection site; `test_entry_points_guarded.py` (AST) fails any
-    raw `.connect` to a Qt-owned signal not in its only-shrinking `ALLOWED_UNGUARDED`. spec/007
-    § Entry points + § Invariants/Enforcement amended. `provider_controller` converted as the worked
-    example (its rows dropped from the allowlist). No behaviour change.
-[ready-for-review] 4-PR2 Cleanup-after-raise fixes (live bugs, independent of the wiring): `start_processing_callback`
-    + `submit_processing` leave Start disabled for the session if the payload drifts (RISK 1);
-    `preview_multiple_png` discards the in-flight id after a raise (RISK 2); `save_downloaded` wires
-    `reply.finished` past the guard (RISK 3 — route via `guarded_connect`); `unload` skips settings
-    persistence on a teardown raise (RISK 4).
 [ ] 4-PR3..6 Roll `guarded_connect` across the remaining regions (poll/submission controllers →
     other controllers → `mapflow.py` + initGui/unload/main → views/dialogs), each PR deleting its
     allowlist rows until `ALLOWED_UNGUARDED` holds only the response_dispatcher wiring.
@@ -346,13 +336,32 @@ The expensive half is `spec/006` § "A guarded callback is interrupted, not comp
 converted is checked for cleanup placed after code that can raise — the bug that polled
 `/user/status` twice a second for a whole session.
 
-[ ] 5. Throttle the message tier too
-Decided with the above: the contract says *no failure* may produce unbounded dialogs, and
-`alert()` is `exec()`-modal like the report dialog. It is reachable from polled paths (the
-template callbacks hang off the 6 s processing poll), so the same storm is possible there.
-Throttle parameters move into `config.py` so they can be tuned during live UX testing without a
-code change — the current values (60 s window, ×2 backoff, 30 min cap, 10 s global floor) were
-reasoned from poll intervals, not measured against users.
+[ready-for-review] 5. Throttle the message tier too
+`alert()` is `exec()`-modal like the report dialog and reachable from polled paths, so it stacks the
+same way. It now shares the report tier's mechanism — its own `ReportThrottle`, keyed on
+icon+message, with the suppressed count carried into the message; `Question`/`ask_text` are exempt
+(interactive dialogs must return a real answer). Throttle parameters (60 s window, ×2 backoff,
+30 min cap, 10 s global floor) now live in `config.py` and are pushed into BOTH budgets at startup
+via an interim `configure_throttle` call — because config.py is QGIS-bound and the throttles are
+Qt-free. The config split below removes that indirection.
+
+[ ] Fix E — connectivity errors use the message tier, not the report tier
+`Mapflow.default_error_handler` routes network/connectivity errors (offline, host-not-found,
+unknown-network, timeout, 503, proxy, 403 rights) to the report tier ("Let us know") and mislabels
+`UnknownNetworkError` as "Proxy error". Per spec/006 the report tier is unexpected (plugin-bug)
+failures only; a dropped connection is expected and user-actionable → message tier (plain `alert`,
+now throttled by step 5). **500 stays message-tier** ("try again") by user decision; only the final
+`else` (truly unclassified) stays report tier. No spec delta. Do after step 5 — the message tier had
+to be throttled before connectivity storms could land on it, which is why step 5 came first.
+
+[ ] Split `config.py` into a Qt-free `config.py` + `qt_config.py`
+config.py is imported everywhere but calls `QgsSettings()`/`QCoreApplication.translate` in its class
+body, so importing it needs QGIS — which blocks Qt-free/early modules (`report_throttle`, `http`)
+from reading it. Move the QGIS/settings-derived values (MAPFLOW_ENV, SERVER, PROJECT_ID,
+SHOW_RAW_ERROR, MAX_AOIS_PER_PROCESSING, AUTH_CONFIG_*, ConfigColumns) to `qt_config.py`; leave the
+static constants (incl. REPORT_THROTTLE_*) in a now-Qt-free config.py. ~25 sites across ~10 files;
+no behaviour change. Then `report_throttle` imports the throttle params directly, and step 5's
+`configure_throttle` startup plumbing plus report_throttle's fallback constants both go away.
 
 [fixed] A refused price (and any disable) is undone by the next selection
 `update_start_processing_button_state` re-enabled Start whenever there was no *planned-processing*

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -124,6 +124,16 @@ class Config:
     #: hiccup — but an unreachable server must not leave it retrying for the whole session.
     STARTUP_STATUS_MAX_ATTEMPTS = 20
 
+    # ERROR REPORTING — the suppression budget (spec/006 § Volume limit). Tunable here without a
+    # code change; the values match report_throttle.py's Qt-free fallback defaults. Mapflow.__init__
+    # pushes them into both budgets (report tier and message tier) at startup. (report_throttle
+    # cannot import config directly — config is QGIS-bound and the throttle is Qt-free by contract;
+    # the scheduled config split removes this indirection.)
+    REPORT_THROTTLE_FIRST_WINDOW_SECONDS = 60.0
+    REPORT_THROTTLE_MAX_WINDOW_SECONDS = 30 * 60.0
+    REPORT_THROTTLE_GLOBAL_FLOOR_SECONDS = 10.0
+    REPORT_THROTTLE_BACKOFF_FACTOR = 2.0
+
     MAX_FILE_SIZE_PIXELS = 30_000
     MAX_FILE_SIZE_BYTES = 2*(1024**3)
 

--- a/mapflow/infra/alert_service.py
+++ b/mapflow/infra/alert_service.py
@@ -2,6 +2,25 @@ from typing import Optional, Tuple
 from PyQt5.QtWidgets import QApplication, QInputDialog, QMessageBox
 from PyQt5.QtCore import Qt, QObject
 
+from ..report_throttle import ReportThrottle
+
+#: Message-tier suppression budget (spec/006 § Volume limit). A separate instance from the report
+#: tier's: a dialog storm is same-tier repetition, which each budget bounds on its own. Tests
+#: substitute a fresh one; configure_throttle() rebuilds it from config at startup.
+_throttle = ReportThrottle()
+
+#: Appended to a message the throttle lets through after hiding repeats of it, so a recurring
+#: failure reads as systematic rather than a one-off.
+REPEATED_MESSAGE_SUFFIX = "\n\n(Repeated {count} more time(s) since this was last shown.)"
+
+
+def configure_throttle(first_window: float, max_window: float,
+                       global_floor: float, backoff: float) -> None:
+    """Rebuild the message-tier budget from config values; called once at startup."""
+    global _throttle
+    _throttle = ReportThrottle(first_window=first_window, max_window=max_window,
+                               global_floor=global_floor, backoff=backoff)
+
 
 class AlertService(QObject):
     """Singleton service for displaying alerts and notifications."""
@@ -40,6 +59,19 @@ class AlertService(QObject):
         :param blocking: Opened as modal - code below will only be executed when the alert is closed
         :return: True if user clicked OK (for Question dialogs), False otherwise
         """
+        # Volume limit (spec/006 § Volume limit): an informational modal on a polled path stacks
+        # exactly like a report dialog — exec() runs a nested event loop, so QTimer keeps firing and
+        # dialogs pile up. Suppress a repeat of the same message within the throttle window and carry
+        # the hidden count into the next one that gets through. Question is exempt: an interactive
+        # prompt must return a real answer, never a suppressed default. The signature is icon+message
+        # text — the only stable key a message alert has; a fixed poll message keys stably, while an
+        # id-bearing one-off never suppresses, which is fine because it does not storm.
+        if icon != QMessageBox.Question:
+            suppressed = _throttle.should_report(f"{int(icon)}:{message}")
+            if suppressed is None:
+                return False
+            if suppressed:
+                message += REPEATED_MESSAGE_SUFFIX.format(count=suppressed)
         box = QMessageBox(icon, self._plugin_name, message, parent=QApplication.activeWindow())
         box.setTextFormat(Qt.RichText)
         if icon == QMessageBox.Question:

--- a/mapflow/infra/reporter.py
+++ b/mapflow/infra/reporter.py
@@ -37,6 +37,17 @@ REPEATED_USER_TEXT = "\n\nThis has happened {count} more time(s) since the last 
 _throttle = ReportThrottle()
 
 
+def configure_throttle(first_window: float, max_window: float,
+                       global_floor: float, backoff: float) -> None:
+    """Rebuild the report-tier budget from config values; called once at startup by the composition
+    root. Qt-free like the rest of this module — it only constructs a ReportThrottle, and the caller
+    passes the numbers because this module cannot import the QGIS-bound config itself.
+    """
+    global _throttle
+    _throttle = ReportThrottle(first_window=first_window, max_window=max_window,
+                               global_floor=global_floor, backoff=backoff)
+
+
 def _present(text: str, title: str = None, email_body: str = '', parent=None) -> None:
     """Show the report dialog. Never raises — it runs while already handling a failure, so an
     exception escaping here would replace the failure being reported with its own.

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -176,6 +176,19 @@ class Mapflow(QObject):
         # AlertService must exist before setup_tempdir: an unavailable working directory below (and
         # select_output_directory on a bad pick) shows a modal, and both run before section 6.
         AlertService(self.plugin_name)
+        # Push the throttle parameters (spec/006 § Volume limit) from config into both suppression
+        # budgets at startup: config.py is the single tunable source, but report_throttle/reporter/
+        # alert_service stay Qt-free and cannot import the QGIS-bound config themselves. The
+        # scheduled config split lets report_throttle read them directly and drops this block.
+        from .infra import reporter as _reporter
+        from .infra import alert_service as _alert_service
+        for _module in (_reporter, _alert_service):
+            _module.configure_throttle(
+                first_window=self.config.REPORT_THROTTLE_FIRST_WINDOW_SECONDS,
+                max_window=self.config.REPORT_THROTTLE_MAX_WINDOW_SECONDS,
+                global_floor=self.config.REPORT_THROTTLE_GLOBAL_FLOOR_SECONDS,
+                backoff=self.config.REPORT_THROTTLE_BACKOFF_FACTOR,
+            )
         self.workdir_service = WorkdirService(app_context=self.app_context)
         self.workdir_view = WorkdirView(dlg=self.dlg,
                                         main_window=self.main_window,

--- a/mapflow/report_throttle.py
+++ b/mapflow/report_throttle.py
@@ -31,6 +31,10 @@ MAX_WINDOW_SECONDS = 30 * 60.0
 #: dialog every 6 seconds while each individual signature stayed within its window.
 GLOBAL_FLOOR_SECONDS = 10.0
 
+#: Factor the per-signature window grows by on each further report (2.0 = doubling). A fallback
+#: default: config.py holds the tunable value, pushed in at startup (see config REPORT_THROTTLE_*).
+BACKOFF_FACTOR = 2.0
+
 
 def exception_signature(exception: BaseException) -> str:
     """Identity of a failure for suppression purposes: type plus the line it failed on.
@@ -82,10 +86,12 @@ class ReportThrottle:
                  first_window: float = FIRST_WINDOW_SECONDS,
                  max_window: float = MAX_WINDOW_SECONDS,
                  global_floor: float = GLOBAL_FLOOR_SECONDS,
+                 backoff: float = BACKOFF_FACTOR,
                  clock: Callable[[], float] = time.monotonic) -> None:
         self._first_window = first_window
         self._max_window = max_window
         self._global_floor = global_floor
+        self._backoff = backoff
         self._clock = clock
         self._states: Dict[str, _SignatureState] = {}
         self._last_shown_at: Optional[float] = None
@@ -111,9 +117,9 @@ class ReportThrottle:
             return None
 
         if state.shown_at is not None:
-            # Doubling starts only from the second report: the first one defines the
+            # Backoff starts only from the second report: the first one defines the
             # baseline window rather than consuming it.
-            state.window = min(state.window * 2, self._max_window)
+            state.window = min(state.window * self._backoff, self._max_window)
         state.shown_at = now
         self._last_shown_at = now
 

--- a/tests/functional/test_alert_throttle.py
+++ b/tests/functional/test_alert_throttle.py
@@ -1,0 +1,94 @@
+"""The message tier (`mapflow/infra/alert_service.py`) is throttled too (error-reporting step 5).
+
+`alert()` opens a modal `exec()` — a nested event loop — so an informational alert on a polled path
+stacks exactly like an unthrottled report dialog and locks QGIS (spec/006 § Volume limit). It now
+shares the same suppression mechanism as the report tier, keyed on the icon + message text, with the
+hidden-occurrence count carried into the next message it lets through. Interactive dialogs
+(`Question`) are never suppressed — they must return a real answer.
+
+Runs in the no-QGIS functional tier: the throttle is Qt-free and the dialog is patched out.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtWidgets import QMessageBox
+
+from mapflow.infra import alert_service
+from mapflow.report_throttle import ReportThrottle
+
+
+class _Clock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+@pytest.fixture
+def clock():
+    return _Clock()
+
+
+@pytest.fixture(autouse=True)
+def fresh_throttle(monkeypatch, clock):
+    """A private budget per test — the production throttle is process-wide. Global floor 0 so these
+    tests exercise the per-signature window without the cross-signature floor getting in the way."""
+    monkeypatch.setattr(alert_service, "_throttle",
+                        ReportThrottle(global_floor=0.0, clock=clock))
+
+
+@pytest.fixture(autouse=True)
+def no_real_dialog(monkeypatch):
+    """Replace the dialog class so nothing tries to build a QMessageBox without a QApplication. The
+    fake keeps the real `Question` enum so alert()'s exemption check still compares correctly."""
+    fake = MagicMock()
+    fake.Question = QMessageBox.Question
+    monkeypatch.setattr(alert_service, "QMessageBox", fake)
+    monkeypatch.setattr(alert_service, "QApplication", MagicMock())
+    return fake
+
+
+@pytest.fixture
+def service():
+    return alert_service.AlertService("Mapflow")
+
+
+def test_a_repeated_message_shows_once(service, no_real_dialog):
+    service.alert("Mapflow is not responding")
+    service.alert("Mapflow is not responding")
+
+    assert no_real_dialog.call_count == 1  # the second is suppressed within the window
+
+
+def test_a_different_message_is_not_suppressed(service, no_real_dialog):
+    service.alert("Mapflow is not responding")
+    service.alert("Something else failed")
+
+    assert no_real_dialog.call_count == 2  # a different signature always shows
+
+
+def test_a_question_is_never_suppressed(service, no_real_dialog):
+    service.alert("Delete this project?", QMessageBox.Question)
+    service.alert("Delete this project?", QMessageBox.Question)
+
+    assert no_real_dialog.call_count == 2  # interactive: both must ask for a real answer
+
+
+def test_the_suppressed_count_is_carried_into_the_next_message(service, no_real_dialog, clock):
+    service.alert("Mapflow is not responding")   # shown
+    service.alert("Mapflow is not responding")   # suppressed -> counted
+    clock.now += 61.0                            # the 60s window elapses
+    service.alert("Mapflow is not responding")   # shown again, now with the count
+
+    shown_message = no_real_dialog.call_args.args[2]  # QMessageBox(icon, name, message, ...)
+    assert "Repeated" in shown_message and "1" in shown_message
+
+
+def test_configure_throttle_replaces_the_message_budget():
+    alert_service.configure_throttle(first_window=5.0, max_window=50.0,
+                                     global_floor=1.0, backoff=3.0)
+    budget = alert_service._throttle
+
+    assert (budget._first_window, budget._max_window,
+            budget._global_floor, budget._backoff) == (5.0, 50.0, 1.0, 3.0)

--- a/tests/functional/test_reporter.py
+++ b/tests/functional/test_reporter.py
@@ -127,3 +127,13 @@ def test_the_report_body_states_how_many_http_repeats_were_suppressed():
     _summary, body = get_error_report_body(_response(), '{"message": "no"}', "1.0",
                                            suppressed_count=41)
     assert "41" in unquote(body) and "suppressed" in unquote(body)
+
+
+# ---------- the budget is configured from config at startup (error-reporting step 5) ----------
+
+def test_configure_throttle_replaces_the_report_budget():
+    reporter.configure_throttle(first_window=5.0, max_window=50.0, global_floor=1.0, backoff=3.0)
+    budget = reporter._throttle
+
+    assert (budget._first_window, budget._max_window,
+            budget._global_floor, budget._backoff) == (5.0, 50.0, 1.0, 3.0)

--- a/tests/qgis/conftest.py
+++ b/tests/qgis/conftest.py
@@ -63,6 +63,17 @@ def _no_blocking_dialogs(monkeypatch):
                         raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _fresh_alert_throttle(monkeypatch):
+    """A private message-tier budget per test. `alert_service._throttle` is process-wide, so without
+    this a message shown in one test would suppress the same message in a later one (the 60 s window
+    outlasts a whole test run), failing an unrelated test. Mirrors test_reporter.py's fresh_throttle.
+    """
+    from mapflow.infra import alert_service
+    from mapflow.report_throttle import ReportThrottle
+    monkeypatch.setattr(alert_service, "_throttle", ReportThrottle())
+
+
 @pytest.fixture()
 def iface():
     """Mock QgisInterface for tests that need a plugin iface reference."""


### PR DESCRIPTION
spec/006's volume limit covers "every dialog tier — report and message alike", but only the report
tier was throttled. `alert()` opens a modal `exec()` — a nested event loop — so an informational
alert on a polled path (the template callbacks hang off the 6 s processing poll; the restored
silent polls hit it too) stacks exactly like an unthrottled report dialog and locks QGIS.

The message tier now shares the report tier's mechanism: its own `ReportThrottle`, keyed on the
icon + message text, with the suppressed count carried into the next message it lets through. A
separate instance from the report tier's — a dialog storm is same-tier repetition, which each
budget bounds on its own. `Question` and `ask_text` are exempt: an interactive prompt must return a
real answer, never a suppressed default. The signature is the message text because it is the only
stable key a message alert has — a fixed poll message keys stably, and an id-bearing one-off never
suppresses, which is fine because it does not storm.

The throttle parameters (60 s window, ×2 backoff, 30 min cap, 10 s global floor) move to
`config.py`, the single tunable source, and are pushed into BOTH budgets at startup. This is an
interim `configure_throttle` call rather than a direct import: config.py is QGIS-bound (it reads
QgsSettings in its class body) and `report_throttle`/`reporter` are Qt-free by contract, so they
cannot import it. `report_throttle` keeps the same numbers as fallback defaults meanwhile. The
scheduled config.py split (WAL) makes config.py Qt-free and drops both the startup plumbing and the
fallback constants.

Also tidies the WAL: the merged 4-PR1 and 4-PR2 entries are removed (their WHY is in commits
b8c57bc and b5a2b4b), and the next steps — Fix E (connectivity errors to the message tier) and the
config split — are recorded as planned.

## Manual test
Go offline and let a poll fail repeatedly (or trigger any repeating informational alert): the alert
shows once, not on every tick, and when it reappears after the window it notes how many occurrences
were hidden. A confirmation dialog (delete a project, "start processing?") still appears every time
it is asked — interactive prompts are never suppressed. Regression surface: a normal one-off alert
(bad AOI, "specify a name") must still appear immediately the first time.
