### PR TITLE
fix: connectivity errors use the message tier, not a crash report

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -336,16 +336,7 @@ The expensive half is `spec/006` § "A guarded callback is interrupted, not comp
 converted is checked for cleanup placed after code that can raise — the bug that polled
 `/user/status` twice a second for a whole session.
 
-[ready-for-review] 5. Throttle the message tier too
-`alert()` is `exec()`-modal like the report dialog and reachable from polled paths, so it stacks the
-same way. It now shares the report tier's mechanism — its own `ReportThrottle`, keyed on
-icon+message, with the suppressed count carried into the message; `Question`/`ask_text` are exempt
-(interactive dialogs must return a real answer). Throttle parameters (60 s window, ×2 backoff,
-30 min cap, 10 s global floor) now live in `config.py` and are pushed into BOTH budgets at startup
-via an interim `configure_throttle` call — because config.py is QGIS-bound and the throttles are
-Qt-free. The config split below removes that indirection.
-
-[ ] Fix E — connectivity errors use the message tier, not the report tier
+[ready-for-review] Fix E — connectivity errors use the message tier, not the report tier
 `Mapflow.default_error_handler` routes network/connectivity errors (offline, host-not-found,
 unknown-network, timeout, 503, proxy, 403 rights) to the report tier ("Let us know") and mislabels
 `UnknownNetworkError` as "Proxy error". Per spec/006 the report tier is unexpected (plugin-bug)

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -1052,13 +1052,21 @@ class Mapflow(QObject):
                               ) -> bool:
         """Handle general networking errors: offline, timeout, server errors.
 
+        Connectivity and server-availability failures are *expected* and user-actionable, so they
+        use the message tier (a plain, throttled alert), never the report tier's "Send a report":
+        spec/006 reserves reports for unexpected failures — the plugin being wrong — and a dropped
+        connection or an unreachable server is neither. Only a genuinely unclassified error (the
+        final branch) still offers a report.
+
         :param response: The HTTP response.
-        :param: error_message_parser: function to parse the message from the particular API
         Returns True if the error has been handled, otherwise returns False.
         """
         error = response.error()
         service = 'Mapflow'
         parser = api_message_parser
+        # The message tier does not log; log every handled network error here so the record survives
+        # (the report-tier branch logs again in the reporter, with a signature — acceptable overlap).
+        logger.warning("Network error %s: %s", error, response.errorString())
         if error == QNetworkReply.AuthenticationRequiredError:  # invalid/empty credentials
             # Prevent deadlocks
             if self.app_context.logged_in:  # token re-issued during a plugin session
@@ -1071,40 +1079,48 @@ class Mapflow(QObject):
         elif error in (
                 QNetworkReply.OperationCanceledError,  # timeout
                 QNetworkReply.ServiceUnavailableError,  # HTTP 503
-                QNetworkReply.InternalServerError,  # HTTP 500
+                QNetworkReply.InternalServerError,  # HTTP 500 — a server problem, not the plugin's:
+                                                    # message tier, "try again" (user decision)
                 QNetworkReply.ConnectionRefusedError,
                 QNetworkReply.RemoteHostClosedError,
                 QNetworkReply.NetworkSessionFailedError,
         ):
-            self.report_http_error(response, self.tr(
+            self.alert(self.tr(
                 service + ' is not responding. Please, try again.\n\n'
                           'If you are behind a proxy or firewall,\ncheck your QGIS proxy settings.\n'),
-                                   error_message_parser=parser)
+                       QMessageBox.Warning)
             return True
         elif error == QNetworkReply.HostNotFoundError:  # offline
-            self.alert(self.tr(service + ' not found. Check your Internet connection'))
+            self.alert(self.tr(service + ' not found. Check your Internet connection'),
+                       QMessageBox.Warning)
+            return True
+        elif error == QNetworkReply.UnknownNetworkError:
+            # Qt's catch-all for a connection dropped mid-request. It is NOT a proxy problem —
+            # reporting it as one (as this branch used to, lumped in with the proxy errors) misled
+            # every user who has no proxy configured.
+            self.alert(self.tr('Connection to ' + service + ' was lost. '
+                               'Check your Internet connection and try again.'),
+                       QMessageBox.Warning)
             return True
         elif error in (
-                QNetworkReply.UnknownNetworkError,
                 QNetworkReply.ProxyConnectionRefusedError,
                 QNetworkReply.ProxyConnectionClosedError,
                 QNetworkReply.ProxyNotFoundError,
                 QNetworkReply.ProxyTimeoutError,
                 QNetworkReply.ProxyAuthenticationRequiredError,
         ):
-            self.report_http_error(response, self.tr('Proxy error. Please, check your proxy settings.'))
+            self.alert(self.tr('Proxy error. Please, check your proxy settings.'), QMessageBox.Warning)
             return True
         elif error == QNetworkReply.ContentAccessDenied:
             if not self.app_context.user_role.can_delete_rename_project:
-                self.report_http_error(response,
-                                       self.tr("Not enough rights for this action\n"+
-                                                "in a shared project '{project_name}' ({user_role})").format(project_name=self.app_context.current_project.name, 
-                                                                                                            user_role=self.app_context.user_role.value),
-                                       error_message_parser=parser)
+                self.alert(self.tr("Not enough rights for this action\n"
+                                   "in a shared project '{project_name}' ({user_role})").format(
+                                       project_name=self.app_context.current_project.name,
+                                       user_role=self.app_context.user_role.value),
+                           QMessageBox.Warning)
             else:
-                self.report_http_error(response,
-                                       self.tr("This operation is forbidden for your account, contact us"),
-                                       error_message_parser=parser)
+                self.alert(self.tr("This operation is forbidden for your account, contact us"),
+                           QMessageBox.Warning)
             return True
         else:
             self.report_http_error(response, self.tr("Error"), error_message_parser=parser)

--- a/tests/qgis/test_default_error_handler.py
+++ b/tests/qgis/test_default_error_handler.py
@@ -1,0 +1,89 @@
+"""`Mapflow.default_error_handler` sorts a network error into a tier (error-reporting Fix E).
+
+spec/006 reserves the report tier ("Send a report") for unexpected failures — the plugin being
+wrong. A dropped connection, an unreachable server, a proxy misconfiguration or a rights refusal is
+expected and user-actionable, so it belongs in the message tier (a plain, throttled alert). Before
+this, most of them opened a report dialog, and `UnknownNetworkError` — Qt's catch-all for a
+connection lost mid-request — was mislabelled "Proxy error" for users who had no proxy at all.
+
+Only a genuinely unclassified error still offers a report.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PyQt5.QtNetwork import QNetworkReply
+
+from mapflow.mapflow import Mapflow
+
+
+def _plugin():
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.tr = lambda text: text
+    plugin.alert = MagicMock()
+    plugin.report_http_error = MagicMock()
+    return plugin
+
+
+def _response(error):
+    response = MagicMock()
+    response.error.return_value = error
+    response.errorString.return_value = "network error"
+    return response
+
+
+CONNECTIVITY_ERRORS = [
+    QNetworkReply.OperationCanceledError,     # timeout
+    QNetworkReply.ServiceUnavailableError,    # 503
+    QNetworkReply.InternalServerError,        # 500 — message tier by user decision, not a report
+    QNetworkReply.ConnectionRefusedError,
+    QNetworkReply.RemoteHostClosedError,
+    QNetworkReply.NetworkSessionFailedError,
+    QNetworkReply.HostNotFoundError,          # offline
+    QNetworkReply.UnknownNetworkError,        # connection lost mid-request
+    QNetworkReply.ProxyConnectionRefusedError,
+    QNetworkReply.ProxyAuthenticationRequiredError,
+]
+
+
+@pytest.mark.parametrize("error", CONNECTIVITY_ERRORS)
+def test_connectivity_errors_use_the_message_tier_not_a_report(error):
+    plugin = _plugin()
+
+    handled = plugin.default_error_handler(_response(error))
+
+    assert handled is True
+    plugin.alert.assert_called_once()             # message tier — a plain alert
+    plugin.report_http_error.assert_not_called()  # never the report tier's "Send a report"
+
+
+def test_unknown_network_error_does_not_blame_the_proxy():
+    plugin = _plugin()
+
+    plugin.default_error_handler(_response(QNetworkReply.UnknownNetworkError))
+
+    message = plugin.alert.call_args.args[0]
+    assert "proxy" not in message.lower()  # it is a lost connection, not a proxy problem
+
+
+def test_content_access_denied_uses_the_message_tier():
+    plugin = _plugin()
+    plugin.app_context = SimpleNamespace(
+        user_role=SimpleNamespace(can_delete_rename_project=True, value="viewer"),
+        current_project=SimpleNamespace(name="Shared project"))
+
+    handled = plugin.default_error_handler(_response(QNetworkReply.ContentAccessDenied))
+
+    assert handled is True
+    plugin.alert.assert_called_once()
+    plugin.report_http_error.assert_not_called()
+
+
+def test_an_unclassified_error_still_offers_a_report():
+    plugin = _plugin()
+
+    handled = plugin.default_error_handler(_response(QNetworkReply.UnknownContentError))
+
+    assert handled is False                          # unhandled -> the request's own handler runs
+    plugin.report_http_error.assert_called_once()    # genuinely unexpected -> report tier
+    plugin.alert.assert_not_called()


### PR DESCRIPTION
spec/006 reserves the report tier ("Send a report") for unexpected failures — the plugin being
wrong. `default_error_handler` was sending connectivity and server-availability errors there
instead: a dropped connection, a timeout, a 500/503, a proxy misconfiguration, even a 403 rights
refusal all opened the report dialog. None of those is the plugin being wrong; they are expected,
user-actionable conditions, and inviting a bug report for them is what trains users (and us) to
ignore the real ones.

Worse, `UnknownNetworkError` — Qt's catch-all for a connection dropped mid-request — was lumped in
with the proxy errors and rendered as "Proxy error. Please, check your proxy settings." for users
who have no proxy at all. That is the case the screenshots showed: killing the network mid-work
produced a proxy warning with a "Let us know" link.

Every connectivity/server/proxy/rights branch now uses the message tier (a plain, throttled alert),
and UnknownNetworkError is split out with its own "connection was lost" message. 500 stays
message-tier ("try again") by decision — a server 500 is the server's problem, not the plugin's.
Only a genuinely unclassified error still offers a report (and returns False, so the request's own
handler can also run). A log line is added at the top so the log tier survives the move off the
reporter, which had been doing the logging.

This is safe only now that the message tier is throttled (previous change): these errors are
reachable from the polled paths, where an unthrottled modal would stack. Icons are unified to
Warning across the family — recoverable conditions, not the red-octagon Critical.

## Manual test
Go offline mid-work (kill wifi while the plugin is polling): you now get a plain "connection was
lost / not responding" warning, no "Send a report" link and no false proxy claim; repeats are
throttled. Start while already offline: "Mapflow not found. Check your Internet connection", same
tier. A genuinely unexpected error (an unclassified reply) still shows the report dialog. Regression
surface: a 403 in a shared project still explains the rights problem, and a normal successful
request is unaffected.
