### PR TITLE
chore: drop the planned config split, keep the throttle startup shim

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -336,24 +336,6 @@ The expensive half is `spec/006` § "A guarded callback is interrupted, not comp
 converted is checked for cleanup placed after code that can raise — the bug that polled
 `/user/status` twice a second for a whole session.
 
-[ready-for-review] Fix E — connectivity errors use the message tier, not the report tier
-`Mapflow.default_error_handler` routes network/connectivity errors (offline, host-not-found,
-unknown-network, timeout, 503, proxy, 403 rights) to the report tier ("Let us know") and mislabels
-`UnknownNetworkError` as "Proxy error". Per spec/006 the report tier is unexpected (plugin-bug)
-failures only; a dropped connection is expected and user-actionable → message tier (plain `alert`,
-now throttled by step 5). **500 stays message-tier** ("try again") by user decision; only the final
-`else` (truly unclassified) stays report tier. No spec delta. Do after step 5 — the message tier had
-to be throttled before connectivity storms could land on it, which is why step 5 came first.
-
-[ ] Split `config.py` into a Qt-free `config.py` + `qt_config.py`
-config.py is imported everywhere but calls `QgsSettings()`/`QCoreApplication.translate` in its class
-body, so importing it needs QGIS — which blocks Qt-free/early modules (`report_throttle`, `http`)
-from reading it. Move the QGIS/settings-derived values (MAPFLOW_ENV, SERVER, PROJECT_ID,
-SHOW_RAW_ERROR, MAX_AOIS_PER_PROCESSING, AUTH_CONFIG_*, ConfigColumns) to `qt_config.py`; leave the
-static constants (incl. REPORT_THROTTLE_*) in a now-Qt-free config.py. ~25 sites across ~10 files;
-no behaviour change. Then `report_throttle` imports the throttle params directly, and step 5's
-`configure_throttle` startup plumbing plus report_throttle's fallback constants both go away.
-
 [fixed] A refused price (and any disable) is undone by the next selection
 `update_start_processing_button_state` re-enabled Start whenever there was no *planned-processing*
 gate error — knowing nothing about pricing, the AOI, the model or the provider. So a refused

--- a/mapflow/config.py
+++ b/mapflow/config.py
@@ -126,9 +126,11 @@ class Config:
 
     # ERROR REPORTING — the suppression budget (spec/006 § Volume limit). Tunable here without a
     # code change; the values match report_throttle.py's Qt-free fallback defaults. Mapflow.__init__
-    # pushes them into both budgets (report tier and message tier) at startup. (report_throttle
-    # cannot import config directly — config is QGIS-bound and the throttle is Qt-free by contract;
-    # the scheduled config split removes this indirection.)
+    # pushes them into both budgets (report tier and message tier) at startup, because
+    # report_throttle cannot import config directly — config is QGIS-bound (it reads QgsSettings in
+    # its class body) and the throttle is Qt-free by contract. Kept as a small startup push on
+    # purpose: making config itself Qt-free would mean splitting this pervasively-shared object,
+    # which fragments it for far less benefit than the shim costs.
     REPORT_THROTTLE_FIRST_WINDOW_SECONDS = 60.0
     REPORT_THROTTLE_MAX_WINDOW_SECONDS = 30 * 60.0
     REPORT_THROTTLE_GLOBAL_FLOOR_SECONDS = 10.0

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -178,8 +178,8 @@ class Mapflow(QObject):
         AlertService(self.plugin_name)
         # Push the throttle parameters (spec/006 § Volume limit) from config into both suppression
         # budgets at startup: config.py is the single tunable source, but report_throttle/reporter/
-        # alert_service stay Qt-free and cannot import the QGIS-bound config themselves. The
-        # scheduled config split lets report_throttle read them directly and drops this block.
+        # alert_service stay Qt-free and cannot import the QGIS-bound config themselves. This small
+        # push is deliberate — making config Qt-free would mean splitting a pervasively-shared object.
         from .infra import reporter as _reporter
         from .infra import alert_service as _alert_service
         for _module in (_reporter, _alert_service):


### PR DESCRIPTION
The scheduled config.py -> config.py + qt_config.py split was evaluated and dropped: it does not
make the codebase clearer. `config` is a single, pervasively-shared object — constructed once,
stored on app_context, and read at ~76 sites, with static values (intervals, page limits, columns)
and QGIS/settings-derived values (SERVER, MAPFLOW_ENV, MAX_AOIS, AUTH_CONFIG_*, ConfigColumns) read
off the same object throughout. Splitting it forces either two objects threaded through all of those
sites and every `config=` constructor, or a lazy/metaclass scheme on the most central class —
neither clearer than what exists. The only concrete payoff would be deleting step 5's ~15-line,
well-contained configure_throttle startup shim, which is a bad trade on clarity and risk.

So the shim stays as the right-sized bridge for the (permanent) Qt-free-vs-QGIS-bound tension. This
updates the two comments that had promised the split would remove it, drops the split's WAL entry,
and removes the merged Fix E WAL entry.

## Manual test
none (comments and WAL only).
