### PR TITLE
fix: guard the composition root's entry points, and start the refresh timer first

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -329,12 +329,19 @@ request fails it.
 into PRs; mechanism + two spec deltas approved by the user (guarded-connect helper at connect sites,
 decorator for non-connect entries; new invariant 7 enforced by an AST test).
 
-[ready-for-review] 4-PR4 The remaining controllers: `data_catalog_controller`, `search_controller`,
-    `template_controller` and `provider_service`'s selection sync — 19 allowlist rows removed. The
-    audit found nothing this time: the selection-sync slots already reconnect in `finally`.
-[ ] 4-PR5..6 Roll `guarded_connect` across the rest (`mapflow.py` + initGui/unload/main →
-    views/dialogs), each PR deleting its allowlist rows until `ALLOWED_UNGUARDED` holds only the
-    response_dispatcher wiring.
+[ready-for-review] 4-PR5 The composition root: every Qt-source connection in `mapflow.py`
+    (`__init__`, `initGui`, `main`, the menus, the login dialog, the per-layer AOI monitoring) —
+    22 allowlist rows removed, plus the local-filter loop the AST test cannot see. The audit found
+    one live bug: `main` started the periodic status refresh *after* the one-off request, so a
+    failed immediate refresh cost the session every later one.
+[ ] 4-PR6 Views and dialogs — the last regions. When they land, `ALLOWED_UNGUARDED` holds only
+    the `response_dispatcher` wiring, which IS the guard, and Phase 4 is complete.
+[ ] Close the entry-point enforcement gap the rollout exposed
+    `test_entry_points_guarded` classifies a connection by the attribute the `.connect` hangs off,
+    so `for signal in (...): signal.connect(...)` is invisible to it — the receiver is a bare name.
+    `mapflow.py`'s local-filter block was exactly that shape (nine Qt widget signals) and was
+    guarded only because the rollout read the code. Either resolve simple loop variables in the
+    visitor, or fail on a `.connect` whose receiver cannot be classified.
 The expensive half is `spec/006` § "A guarded callback is interrupted, not completed": every slot
 converted is checked for cleanup placed after code that can raise — the bug that polled
 `/user/status` twice a second for a whole session.

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -17,6 +17,7 @@ from qgis.core import (
 )
 
 from .config import Config, ConfigColumns
+from .error_guard import guarded_connect
 # Functional
 from .functional import helpers, layer_utils
 from .functional.app_context import AppContext
@@ -232,8 +233,12 @@ class Mapflow(QObject):
         # AreaCalculatorService (for the AOI area) — both told the ids, neither reading the table.
         # The push runs before those handlers, so it is connected here, above them, in the raw
         # signal's connection order (same rule as the processings/search tables).
-        self.dlg.mosaicTable.itemSelectionChanged.connect(self.push_catalog_mosaic_selection)
-        self.dlg.imageTable.itemSelectionChanged.connect(self.push_catalog_image_selection)
+        guarded_connect(self.dlg.mosaicTable.itemSelectionChanged,
+                        self.push_catalog_mosaic_selection,
+                        "pushing the mosaic selection", self.app_context)
+        guarded_connect(self.dlg.imageTable.itemSelectionChanged,
+                        self.push_catalog_image_selection,
+                        "pushing the image selection", self.app_context)
         # DataCatalogController is built after PreviewService (below): its two preview buttons
         # wire to that service, which in turn needs processing_service for the in-template
         # placement rules.
@@ -356,11 +361,14 @@ class Mapflow(QObject):
         # that selection into objects through ProcessingService — which is told the ids rather
         # than reading the table. So the push has to run before any of their handlers, and Qt
         # calls slots in connection order: this connect must stay above them.
-        self.dlg.processingsTable.itemSelectionChanged.connect(self.push_processings_selection)
+        guarded_connect(self.dlg.processingsTable.itemSelectionChanged,
+                        self.push_processings_selection,
+                        "pushing the processings selection", self.app_context)
         # Same reason for the search table: the start-button gate reads the selected images through
         # the service, which is told them rather than reading the metadata table. Pushed before the
         # controllers whose handlers read them back.
-        self.dlg.metadataTable.itemSelectionChanged.connect(self.push_search_selection)
+        guarded_connect(self.dlg.metadataTable.itemSelectionChanged, self.push_search_selection,
+                        "pushing the search selection", self.app_context)
         self.processing_controller = ProcessingController(
             iface=self.iface,
             aoi_service=self.aoi_service,
@@ -438,10 +446,14 @@ class Mapflow(QObject):
         # Layer actions
         iface.addCustomActionForLayerType(self.add_layer_action, None, QgsMapLayerType.VectorLayer, True)
         iface.addCustomActionForLayerType(self.remove_layer_action, None, QgsMapLayerType.VectorLayer, False)
-        self.add_layer_action.triggered.connect(self.processing_controller.use_current_layer_as_aoi)
-        self.remove_layer_action.triggered.connect(
-            self.processing_controller.stop_using_current_layer_as_aoi)
-        self.dlg.useAllVectorLayers.stateChanged.connect(self.toggle_all_layers)
+        guarded_connect(self.add_layer_action.triggered,
+                        self.processing_controller.use_current_layer_as_aoi,
+                        "using the current layer as the AOI", self.app_context)
+        guarded_connect(self.remove_layer_action.triggered,
+                        self.processing_controller.stop_using_current_layer_as_aoi,
+                        "removing the current layer as the AOI", self.app_context)
+        guarded_connect(self.dlg.useAllVectorLayers.stateChanged, self.toggle_all_layers,
+                        "toggling all vector layers", self.app_context)
         self.processing_controller.refresh_excepted_layers()
 
         # ========== 10. INITIALIZE AREA CALCULATOR SERVICE ==========
@@ -478,29 +490,46 @@ class Mapflow(QObject):
         # ========== 12. SET UP SIGNALS & SLOTS ==========
         # The model combo and its option checkboxes are wired by ProcessingController.
         # Memorize dialog element sizes & positioning
-        self.dlg.finished.connect(self.save_dialog_state)
+        guarded_connect(self.dlg.finished, self.save_dialog_state,
+                        "saving the dialog state", self.app_context)
         # Connect buttons
-        self.dlg.logoutButton.clicked.connect(self.session_service.logout)
-        self.dlg.selectOutputDirectory.clicked.connect(self.select_output_directory)
-        self.dlg.downloadResultsButton.clicked.connect(
-            self.project_processing_controller.load_results)
+        guarded_connect(self.dlg.logoutButton.clicked, self.session_service.logout,
+                        "logging out", self.app_context)
+        guarded_connect(self.dlg.selectOutputDirectory.clicked, self.select_output_directory,
+                        "choosing the output directory", self.app_context)
+        guarded_connect(self.dlg.downloadResultsButton.clicked,
+                        self.project_processing_controller.load_results,
+                        "loading the results", self.app_context)
         # Calculate AOI size
-        self.dlg.polygonCombo.layerChanged.connect(self.area_calculator_service.calculate_aoi_area_polygon_layer)
+        guarded_connect(self.dlg.polygonCombo.layerChanged,
+                        self.area_calculator_service.calculate_aoi_area_polygon_layer,
+                        "calculating the AOI area", self.app_context)
         # Push the chosen AOI layer so ProviderService can rebuild a duplicated search over it
         # without reading the combo. Seed it with the current layer, then follow every change.
         self.app_context.aoi_layer = self.dlg.polygonCombo.currentLayer()
-        self.dlg.polygonCombo.layerChanged.connect(self.push_aoi_layer)
-        self.dlg.mosaicTable.itemSelectionChanged.connect(self.area_calculator_service.calculate_aoi_area_catalog)
-        self.dlg.imageTable.itemSelectionChanged.connect(self.area_calculator_service.calculate_aoi_area_catalog)
+        guarded_connect(self.dlg.polygonCombo.layerChanged, self.push_aoi_layer,
+                        "changing the AOI layer", self.app_context)
+        guarded_connect(self.dlg.mosaicTable.itemSelectionChanged,
+                        self.area_calculator_service.calculate_aoi_area_catalog,
+                        "calculating the catalog AOI area", self.app_context)
+        guarded_connect(self.dlg.imageTable.itemSelectionChanged,
+                        self.area_calculator_service.calculate_aoi_area_catalog,
+                        "calculating the catalog AOI area", self.app_context)
         self.monitor_polygon_layer_feature_selection([
             self.app_context.project.mapLayer(layer_id) for layer_id in self.app_context.project.mapLayers(validOnly=True)
         ])
-        self.app_context.project.layersAdded.connect(self.setup_layers_context_menu)
-        self.app_context.project.layersAdded.connect(self.monitor_polygon_layer_feature_selection)
+        guarded_connect(self.app_context.project.layersAdded, self.setup_layers_context_menu,
+                        "setting up the layer context menu", self.app_context)
+        guarded_connect(self.app_context.project.layersAdded,
+                        self.monitor_polygon_layer_feature_selection,
+                        "monitoring an added polygon layer", self.app_context)
         # Processings
-        self.dlg.processingsTable.cellDoubleClicked.connect(
-            self.project_processing_controller.load_results)
-        self.dlg.deleteProcessings.clicked.connect(self.processing_service.confirm_delete_processings)
+        guarded_connect(self.dlg.processingsTable.cellDoubleClicked,
+                        self.project_processing_controller.load_results,
+                        "loading the results", self.app_context)
+        guarded_connect(self.dlg.deleteProcessings.clicked,
+                        self.processing_service.confirm_delete_processings,
+                        "deleting processings", self.app_context)
         # Entering and leaving a template is TemplateController's entirely — it owns the layers,
         # the search results and the view state they drive. What the processings-table selection
         # enables is split between the two controllers that own those widgets: the Start button is
@@ -542,11 +571,17 @@ class Mapflow(QObject):
 
         self.search_controller.connect_table_selection()
         self.app_context.meta_layer_table_connection = None
-        self.dlg.getMetadata.clicked.connect(self.handle_metadata_button_click)
-        self.dlg.metadataTable.cellClicked.connect(self.on_metadata_table_cell_clicked)
-        self.dlg.metadataTable.horizontalHeader().sectionClicked.connect(self.on_metadata_header_clicked)
-        self.dlg.rasterSourceChanged.connect(self.on_provider_change)
-        self.dlg.metadataTableFilled.connect(self.search_controller.apply_local_filter)
+        guarded_connect(self.dlg.getMetadata.clicked, self.handle_metadata_button_click,
+                        "searching for imagery", self.app_context)
+        guarded_connect(self.dlg.metadataTable.cellClicked, self.on_metadata_table_cell_clicked,
+                        "clicking a search result", self.app_context)
+        guarded_connect(self.dlg.metadataTable.horizontalHeader().sectionClicked,
+                        self.on_metadata_header_clicked,
+                        "sorting the search results", self.app_context)
+        guarded_connect(self.dlg.rasterSourceChanged, self.on_provider_change,
+                        "changing the imagery source", self.app_context)
+        guarded_connect(self.dlg.metadataTableFilled, self.search_controller.apply_local_filter,
+                        "applying the local filter", self.app_context)
         # Instant local filtering: changing a filter widget re-filters the already-fetched
         # results in place (no server request), for both regular search and templates.
         # The handler and the Reset/(!) buttons are SearchController's; only these
@@ -562,9 +597,15 @@ class Mapflow(QObject):
                        self.dlg.hideUnavailableResults.toggled,
                        self.dlg.searchMosaicCheckBox.toggled,
                        self.dlg.searchImageCheckBox.toggled):
-            signal.connect(self.search_controller.apply_local_filter)
-        self.dlg.searchRightButton.clicked.connect(self.show_search_next_page)
-        self.dlg.searchLeftButton.clicked.connect(self.show_search_previous_page)
+            # Guarded like every other Qt-source connection. The AST enforcement cannot see these —
+            # the receiver is a loop variable, not an attribute access — so they are easy to leave
+            # behind; they are Qt widget signals all the same.
+            guarded_connect(signal, self.search_controller.apply_local_filter,
+                            "applying the local filter", self.app_context)
+        guarded_connect(self.dlg.searchRightButton.clicked, self.show_search_next_page,
+                        "the next search page", self.app_context)
+        guarded_connect(self.dlg.searchLeftButton.clicked, self.show_search_previous_page,
+                        "the previous search page", self.app_context)
         self.search_view.searchModeChanged.connect(self.template_controller.on_search_mode_changed)
         self.search_view.setup_search_mode_dropdown()
         self.search_view.setup_seen_dropdown(
@@ -669,30 +710,47 @@ class Mapflow(QObject):
         self.add_layer_menu.addAction(self.use_imagery_extent)
         self.add_layer_menu.addAction(self.create_aoi_from_map_action)
         
-        self.draw_aoi.triggered.connect(self.processing_controller.draw_aoi)
-        self.use_imagery_extent.triggered.connect(self.processing_controller.create_aoi_from_imagery)
-        self.create_aoi_from_map_action.triggered.connect(
-            self.processing_controller.create_aoi_from_map_extent)
+        guarded_connect(self.draw_aoi.triggered, self.processing_controller.draw_aoi,
+                        "drawing an AOI", self.app_context)
+        guarded_connect(self.use_imagery_extent.triggered,
+                        self.processing_controller.create_aoi_from_imagery,
+                        "creating an AOI from the imagery extent", self.app_context)
+        guarded_connect(self.create_aoi_from_map_action.triggered,
+                        self.processing_controller.create_aoi_from_map_extent,
+                        "creating an AOI from the map extent", self.app_context)
         self.dlg.addAoiButton.setMenu(self.add_layer_menu)
 
     def setup_options_menu_connections(self):
-        self.dlg.save_result_action.triggered.connect(
-            self.project_processing_controller.download_results_file)
-        self.dlg.download_aoi_action.triggered.connect(
-            self.project_processing_controller.download_aoi_file)
+        guarded_connect(self.dlg.save_result_action.triggered,
+                        self.project_processing_controller.download_results_file,
+                        "saving the results to a file", self.app_context)
+        guarded_connect(self.dlg.download_aoi_action.triggered,
+                        self.project_processing_controller.download_aoi_file,
+                        "downloading the AOI", self.app_context)
         # 'See details' and the menu's own aboutToShow are wired by ProjectProcessingController,
         # which owns what the processings table offers for the current selection.
-        self.dlg.processing_update_action.triggered.connect(self.processing_service.update_processing)
-        self.dlg.processing_restart_action.triggered.connect(self.processing_service.restart_processing)
-        self.dlg.processing_duplicate_action.triggered.connect(self.check_dir_and_duplicate_processing)
+        guarded_connect(self.dlg.processing_update_action.triggered,
+                        self.processing_service.update_processing,
+                        "renaming a processing", self.app_context)
+        guarded_connect(self.dlg.processing_restart_action.triggered,
+                        self.processing_service.restart_processing,
+                        "restarting a processing", self.app_context)
+        guarded_connect(self.dlg.processing_duplicate_action.triggered,
+                        self.check_dir_and_duplicate_processing,
+                        "duplicating a processing", self.app_context)
         # The template run-state actions are wired by TemplateController, which owns their handlers.
         # AOI actions (in-template view)
-        self.dlg.aoi_rename_action.triggered.connect(self.template_service.rename_aoi)
-        self.dlg.aoi_delete_action.triggered.connect(self.template_service.delete_aoi)
-        self.dlg.aoi_add_action.triggered.connect(self.add_aoi_from_layer_dialog)
-        self.dlg.aoi_update_geometry_action.triggered.connect(
-            self.aoi_service.start_update_session)
-        self.dlg.aoi_draw_action.triggered.connect(self.aoi_service.start_draw_session)
+        guarded_connect(self.dlg.aoi_rename_action.triggered, self.template_service.rename_aoi,
+                        "renaming an AOI", self.app_context)
+        guarded_connect(self.dlg.aoi_delete_action.triggered, self.template_service.delete_aoi,
+                        "deleting an AOI", self.app_context)
+        guarded_connect(self.dlg.aoi_add_action.triggered, self.add_aoi_from_layer_dialog,
+                        "adding an AOI from a layer", self.app_context)
+        guarded_connect(self.dlg.aoi_update_geometry_action.triggered,
+                        self.aoi_service.start_update_session,
+                        "updating an AOI's geometry", self.app_context)
+        guarded_connect(self.dlg.aoi_draw_action.triggered, self.aoi_service.start_draw_session,
+                        "drawing an AOI", self.app_context)
         self.dlg.saveOptionsButton.setMenu(self.dlg.options_menu)
 
     # ==================== AOI edit/draw/add sessions ==================== #
@@ -718,8 +776,9 @@ class Mapflow(QObject):
         dlg_login.setWindowTitle(helpers.generate_plugin_header(self.tr("Log in ") + self.plugin_name,
                                                                      self.config.MAPFLOW_ENV,
                                                                      None, None, None))
-        dlg_login.logIn.clicked.connect(self.log_in)
-        dlg_login.useOauth.toggled.connect(self.session_service.set_auth_type)
+        guarded_connect(dlg_login.logIn.clicked, self.log_in, "logging in", self.app_context)
+        guarded_connect(dlg_login.useOauth.toggled, self.session_service.set_auth_type,
+                        "switching the authentication type", self.app_context)
         return dlg_login
 
     def log_in(self) -> None:
@@ -790,10 +849,18 @@ class Mapflow(QObject):
             # processing cost a second time on every image click — skip it.
             if self.search_service.is_search_metadata_layer(layer):
                 continue
-            layer.selectionChanged.connect(self.area_calculator_service.calculate_aoi_area_selection)
-            layer.geometryChanged.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
-            layer.featureAdded.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
-            layer.featuresDeleted.connect(self.area_calculator_service.calculate_aoi_area_layer_edited)
+            guarded_connect(layer.selectionChanged,
+                            self.area_calculator_service.calculate_aoi_area_selection,
+                            "calculating the selected AOI area", self.app_context)
+            guarded_connect(layer.geometryChanged,
+                            self.area_calculator_service.calculate_aoi_area_layer_edited,
+                            "recalculating the AOI area after an edit", self.app_context)
+            guarded_connect(layer.featureAdded,
+                            self.area_calculator_service.calculate_aoi_area_layer_edited,
+                            "recalculating the AOI area after an edit", self.app_context)
+            guarded_connect(layer.featuresDeleted,
+                            self.area_calculator_service.calculate_aoi_area_layer_edited,
+                            "recalculating the AOI area after an edit", self.app_context)
 
     def toggle_imagery_search(self,
                               provider):
@@ -1009,9 +1076,11 @@ class Mapflow(QObject):
                                                                project_owner=None))
         # Display plugin icon in own toolbar
         plugin_button = QAction(self.plugin_icon, self.plugin_name, self.main_window)
-        plugin_button.triggered.connect(self.main)
+        guarded_connect(plugin_button.triggered, self.main,
+                        "opening the plugin", self.app_context)
         self.toolbar.addAction(plugin_button)
-        self.app_context.project.readProject.connect(self.set_layer_group)
+        guarded_connect(self.app_context.project.readProject, self.set_layer_group,
+                        "restoring the layer group for the opened project", self.app_context)
         self.dlg.processingsTable.sortByColumn(self.config.PROCESSING_TABLE_SORT_COLUMN_INDEX, Qt.DescendingOrder)
 
     def set_layer_group(self) -> None:
@@ -1308,8 +1377,13 @@ class Mapflow(QObject):
             # with any auth method
             self.dlg.show()
             self.dlg.raise_()
-            self.account_service.request_status()
+            # Start the periodic refresh BEFORE the one-off request. Starting a timer cannot fail,
+            # while dispatching the request can raise — and with the order reversed a failed
+            # immediate refresh also cost the session its periodic one, so the balance and the
+            # remaining limit would never update again. This entry point is guarded now, which
+            # would make that silent (spec/006 § a guarded callback is interrupted).
             self.account_service.start_refreshing()
+            self.account_service.request_status()
             return
 
         token = self.session_service.saved_token

--- a/tests/functional/test_entry_points_guarded.py
+++ b/tests/functional/test_entry_points_guarded.py
@@ -74,28 +74,6 @@ ALLOWED_UNGUARDED = {
     # `send_request` wires the finished signal to `response_dispatcher`, which IS the guard (it wraps
     # every callback in `call_guarded`). It is the one `.connect` that need not go through the helper.
     ('mapflow/http.py', 'send_request', 'finished'),
-    ('mapflow/mapflow.py', '__init__', 'cellClicked'),
-    ('mapflow/mapflow.py', '__init__', 'cellDoubleClicked'),
-    ('mapflow/mapflow.py', '__init__', 'clicked'),
-    ('mapflow/mapflow.py', '__init__', 'finished'),
-    ('mapflow/mapflow.py', '__init__', 'itemSelectionChanged'),
-    ('mapflow/mapflow.py', '__init__', 'layerChanged'),
-    ('mapflow/mapflow.py', '__init__', 'layersAdded'),
-    ('mapflow/mapflow.py', '__init__', 'metadataTableFilled'),
-    ('mapflow/mapflow.py', '__init__', 'rasterSourceChanged'),
-    ('mapflow/mapflow.py', '__init__', 'sectionClicked'),
-    ('mapflow/mapflow.py', '__init__', 'stateChanged'),
-    ('mapflow/mapflow.py', '__init__', 'triggered'),
-    ('mapflow/mapflow.py', 'initGui', 'readProject'),
-    ('mapflow/mapflow.py', 'initGui', 'triggered'),
-    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'featureAdded'),
-    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'featuresDeleted'),
-    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'geometryChanged'),
-    ('mapflow/mapflow.py', 'monitor_polygon_layer_feature_selection', 'selectionChanged'),
-    ('mapflow/mapflow.py', 'set_up_login_dialog', 'clicked'),
-    ('mapflow/mapflow.py', 'set_up_login_dialog', 'toggled'),
-    ('mapflow/mapflow.py', 'setup_add_layer_menu', 'triggered'),
-    ('mapflow/mapflow.py', 'setup_options_menu_connections', 'triggered'),
 }
 
 

--- a/tests/qgis/test_startup_status_poll.py
+++ b/tests/qgis/test_startup_status_poll.py
@@ -60,6 +60,25 @@ def test_the_next_tick_retries_once_the_previous_request_failed(service):
     assert service.startup_timer.isActive(), "a single failure is not fatal"
 
 
+def test_main_starts_the_periodic_refresh_even_if_the_immediate_one_fails():
+    """The timer is the durable mechanism and cannot fail; the immediate request can. Starting the
+    timer second meant one failed refresh cost the session every later one — silently, now that the
+    entry point is guarded."""
+    plugin = Mapflow.__new__(Mapflow)
+    plugin.http = MagicMock()
+    plugin.server = "https://example.invalid/api"
+    plugin.version_ok = True
+    plugin.dlg = MagicMock()
+    plugin.app_context = SimpleNamespace(logged_in=True)
+    plugin.account_service = MagicMock()
+    plugin.account_service.request_status.side_effect = RuntimeError("could not send")
+
+    with pytest.raises(RuntimeError):
+        plugin.main()
+
+    plugin.account_service.start_refreshing.assert_called_once()
+
+
 def test_a_request_that_fails_to_dispatch_does_not_stall_the_poll(service):
     """If sending the request raises, neither callback runs, so nothing clears the in-flight flag.
     The tick is reached through the guard, which swallows the raise — so without clearing the flag

--- a/tests/qgis/test_template_search_footprints.py
+++ b/tests/qgis/test_template_search_footprints.py
@@ -199,9 +199,11 @@ def test_monitor_skips_current_search_metadata_layer():
 
     # The footprint (search-metadata) layer is skipped; a real AOI layer is still wired.
     footprint_layer.selectionChanged.connect.assert_not_called()
-    aoi_layer.selectionChanged.connect.assert_called_once_with(
-        plugin.area_calculator_service.calculate_aoi_area_selection
-    )
+    aoi_layer.selectionChanged.connect.assert_called_once()
+    # The connected callable is `guarded_connect`'s wrapper, not the slot itself, so check where it
+    # leads rather than its identity: firing it must reach the area calculation.
+    aoi_layer.selectionChanged.connect.call_args.args[0]([])
+    plugin.area_calculator_service.calculate_aoi_area_selection.assert_called_once()
 
 
 def test_template_callback_alerts_and_skips_when_no_images(tmp_path, monkeypatch):


### PR DESCRIPTION
Takes the entry-point rollout (spec/007 § Entry points, invariant 7) through `mapflow.py`: the
dialog's own `finished`, the buttons and tables wired here rather than in a controller, the AOI and
options menus, the login dialog, the QgsProject subscriptions, the per-layer AOI-area monitoring,
`initGui`'s plugin button and `readProject`. 22 rows leave `ALLOWED_UNGUARDED`, which now holds only
the views, the dialogs, and the `response_dispatcher` wiring that IS the guard.

Connection ORDER is load-bearing in two places here — the selection pushes must run before the
handlers that read the pushed state back, and Qt calls slots in connection order. `guarded_connect`
still calls `signal.connect()` at the same point, so that ordering is unchanged.

Also guarded the local-filter block, which connects nine Qt widget signals through a loop variable.
The AST enforcement cannot see those: it classifies a connection by the attribute the `.connect`
hangs off, and there the receiver is a bare name. They were found by reading the code, not by the
test — so a WAL entry now tracks closing that gap, because a guard rollout that depends on someone
remembering is the thing the enforcement test exists to replace.

The audit that accompanies each conversion (spec/006 § "A guarded callback is interrupted, not
completed") found one live bug. `main` called `account_service.request_status()` and only then
`start_refreshing()`. Dispatching that request can raise — the same failure the previous change
found in the startup poll — and the timer start sat after it, so one failed immediate refresh cost
the session its periodic refresh entirely: the balance and the remaining limit would never update
again. Starting a timer cannot fail, so it now goes first and the request follows. Guarding this
entry point is what would have made the loss silent.

`save_dialog_state` was checked with the same suspicion, since it is the `finished` handler that
persists geometry the way `unload` persists the metadata filter — it is a single write with nothing
after it, so it is fine as it stands.

## Manual test
The whole plugin is the regression surface here, because this is where most of the UI is wired:
open the plugin from the toolbar, log in (both auth types), switch imagery source, search, page
through results, use the AOI menu (draw, from map extent, from imagery), the options menu (save
results, download AOI, rename/restart/duplicate a processing, the AOI actions), toggle "use all
vector layers", select features in a polygon layer and watch the AOI area update, and open a QGIS
project to see the layer group restored. Anything that stops responding to a click is the
regression. For the timer fix: with a working connection the balance keeps updating as before.
