### PR TITLE
fix: guard the view and dialog entry points, and stop the guard crashing on its own report

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -329,22 +329,27 @@ request fails it.
 into PRs; mechanism + two spec deltas approved by the user (guarded-connect helper at connect sites,
 decorator for non-connect entries; new invariant 7 enforced by an AST test).
 
-[ready-for-review] 4-PR5 The composition root: every Qt-source connection in `mapflow.py`
-    (`__init__`, `initGui`, `main`, the menus, the login dialog, the per-layer AOI monitoring) —
-    22 allowlist rows removed, plus the local-filter loop the AST test cannot see. The audit found
-    one live bug: `main` started the periodic status refresh *after* the one-off request, so a
-    failed immediate refresh cost the session every later one.
-[ ] 4-PR6 Views and dialogs — the last regions. When they land, `ALLOWED_UNGUARDED` holds only
-    the `response_dispatcher` wiring, which IS the guard, and Phase 4 is complete.
+[ready-for-review] 4-PR6 Views and dialogs — the last regions. `ALLOWED_UNGUARDED` now holds only
+    the `response_dispatcher` wiring, which IS the guard, so **step 4 is complete**. Three bugs
+    found: `_resolve_plugin_version` could raise while building a report and escape the guard
+    entirely (a slot's failure then reached the event loop unguarded); the source/provider combo
+    pair reconnected its sibling at the tail, so one raising handler stopped the combos syncing for
+    the session; and `aoi_view`'s save/cancel were Qt -> plugin-signal passthroughs, leaving nothing
+    between the button and `aoi_service` guarded at all.
 [ ] Close the entry-point enforcement gap the rollout exposed
     `test_entry_points_guarded` classifies a connection by the attribute the `.connect` hangs off,
     so `for signal in (...): signal.connect(...)` is invisible to it — the receiver is a bare name.
     `mapflow.py`'s local-filter block was exactly that shape (nine Qt widget signals) and was
     guarded only because the rollout read the code. Either resolve simple loop variables in the
     visitor, or fail on a `.connect` whose receiver cannot be classified.
-The expensive half is `spec/006` § "A guarded callback is interrupted, not completed": every slot
-converted is checked for cleanup placed after code that can raise — the bug that polled
-`/user/status` twice a second for a whole session.
+[ ] Give dialog-originated reports a plugin version
+    `guarded_connect`'s `version_source` resolves `plugin_version` off the passed object; dialogs and
+    views carry neither it nor `app_context`, so a report raised from one says "unknown". The version
+    is parsed once in `Mapflow.__init__` from metadata.txt — a one-time module-level fallback in
+    `error_guard` would fix every such site at once.
+The expensive half was `spec/006` § "A guarded callback is interrupted, not completed": every slot
+converted was checked for cleanup placed after code that can raise. That audit is what found the
+stalled startup poll, the stranded submission flag, the lost periodic refresh and the combo pair.
 
 [fixed] A refused price (and any disable) is undone by the next selection
 `update_start_processing_button_state` re-enabled Start whenever there was no *planned-processing*
@@ -371,11 +376,14 @@ No evidence of a plugin defect here — the vector-tile assertions (source and e
 the only stall came from a deliberately unroutable host.
 
 [ ] Detach the plugin from QgsProject on unload
-`unload()` closes the dialogs but never disconnects the `QgsProject` subscriptions made in
-`mapflow.py:349-350` and `:4028` (`layersAdded` ×2, `readProject`). After a QGIS plugin reload
-the previous instance is still subscribed, so adding a layer runs its handlers against a
-closed dialog — and against whatever state that instance was left in, which can take a branch
-the live instance never would.
+`unload()` closes the dialogs but never disconnects the `QgsProject` subscriptions
+(`layersAdded` ×2, `readProject`). After a QGIS plugin reload the previous instance is still
+subscribed, so adding a layer runs its handlers against a closed dialog — and against whatever
+state that instance was left in, which can take a branch the live instance never would.
+The entry-point rollout makes this **more certain, not less**: `guarded_connect` connects a
+closure rather than a bound method, so PyQt's auto-disconnect-when-the-receiver-dies no longer
+applies. `QgsProject` outlives the plugin, so these subscriptions now survive until something
+disconnects them explicitly — which is exactly what this step must add.
 Found because the behavioral suite builds a plugin per test: opening a mosaic in one journey
 made a *later, unrelated* journey fail, with the traceback running through the previous
 plugin's dialog. `tests/qgis/behavioral/conftest.py` disconnects those signals at teardown to

--- a/mapflow/dialogs/image_dialog.py
+++ b/mapflow/dialogs/image_dialog.py
@@ -1,6 +1,7 @@
 from PyQt5 import uic
 from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 
+from ..error_guard import guarded_connect
 from ..schema.data_catalog import ImageReturnSchema
 from .processing_dialog import ui_path, plugin_icon
 
@@ -11,7 +12,8 @@ class RenameImageDialog(*uic.loadUiType(ui_path/'image_dialog.ui')):
         self.setupUi(self)
         self.setWindowIcon(plugin_icon)
         self.ok = self.buttonBox.button(QDialogButtonBox.Ok)
-        self.imageName.textChanged.connect(self.on_name_change)
+        guarded_connect(self.imageName.textChanged, self.on_name_change,
+                        "editing the image name", self)
 
     def setup(self, image: ImageReturnSchema):
         if not image:

--- a/mapflow/dialogs/main_dialog.py
+++ b/mapflow/dialogs/main_dialog.py
@@ -12,6 +12,7 @@ from qgis.gui import QgsRangeSlider
 
 from . import icons
 from ..config import config, ConfigColumns
+from ..error_guard import guarded_connect
 from ..schema import BillingType, UserRole
 from ..model.provider import ProviderInterface
 from ..functional import helpers
@@ -69,9 +70,15 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         coin_pixmap = icons.coins_icon.pixmap(16, 16)
         self.labelCoins_1.setPixmap(coin_pixmap)
 
-        self.modelInfo.clicked.connect(lambda: helpers.open_model_info(model_name=self.modelCombo.currentText()))
-        self.topUpBalanceButton.clicked.connect(lambda: helpers.open_url(config.TOP_UP_URL))
-        self.billingHistoryButton.clicked.connect(lambda: helpers.open_url(config.BILLING_HISTORY_URL))
+        guarded_connect(self.modelInfo.clicked,
+                        lambda: helpers.open_model_info(model_name=self.modelCombo.currentText()),
+                        "opening the model info", self)
+        guarded_connect(self.topUpBalanceButton.clicked,
+                        lambda: helpers.open_url(config.TOP_UP_URL),
+                        "opening the top-up page", self)
+        guarded_connect(self.billingHistoryButton.clicked,
+                        lambda: helpers.open_url(config.BILLING_HISTORY_URL),
+                        "opening the billing history", self)
 
         self.alert_palette = QPalette()
         self.default_palette = QPalette()
@@ -92,12 +99,20 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         # current state to compare with on change
         self.current_raster_source = self.sourceCombo.currentText()
         # connect raster/provider combos
-        self.raster_provider_connection = self.sourceCombo.currentTextChanged.connect(self.switch_provider_combo)
-        self.provider_raster_connection = self.providerCombo.currentTextChanged.connect(self.switch_raster_combo)
+        # These two keep their connection tokens: each combo's handler takes the other's connection
+        # down while it drives, so they do not ping-pong. `guarded_connect` returns whatever
+        # `signal.connect()` returns, so the stored tokens still disconnect.
+        self.raster_provider_connection = guarded_connect(
+            self.sourceCombo.currentTextChanged, self.switch_provider_combo,
+            "switching the imagery source", self)
+        self.provider_raster_connection = guarded_connect(
+            self.providerCombo.currentTextChanged, self.switch_raster_combo,
+            "switching the provider", self)
 
         self.modelOptions = []
         # Save on toggle
-        self.buttonGroup.buttonClicked.connect(self.save_view_results_mode)
+        guarded_connect(self.buttonGroup.buttonClicked, self.save_view_results_mode,
+                        "choosing how results are viewed", self)
 
         # Restored saved state
         self.set_state_from_settings()
@@ -186,12 +201,16 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
             self.viewAsLocal.setChecked(True)
         self.useAllVectorLayers.setChecked(str(self.settings.value('useAllVectorLayers', "true")).lower() == "true")
         self.cornfirmProcessingStart.setChecked(str(self.settings.value('confirmProcessingStart', "true")).lower() == "true")
-        self.cornfirmProcessingStart.toggled.connect(lambda: self.settings.setValue("confirmProcessingStart",
-                                                                                    self.cornfirmProcessingStart.isChecked()))
+        guarded_connect(self.cornfirmProcessingStart.toggled,
+                        lambda: self.settings.setValue(
+                            "confirmProcessingStart", self.cornfirmProcessingStart.isChecked()),
+                        "toggling the start confirmation", self)
         # The "Providers" filter is only relevant when the search is limited to available
         # providers, so show it only while that checkbox is set.
         self._search_providers_available = False
-        self.hideUnavailableResults.toggled.connect(self.update_search_providers_filter_visibility)
+        guarded_connect(self.hideUnavailableResults.toggled,
+                        self.update_search_providers_filter_visibility,
+                        "toggling unavailable search results", self)
         self.update_search_providers_filter_visibility()
 
     # connect raster/provider combos funcs
@@ -203,9 +222,17 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.current_raster_source = text
 
         self.providerCombo.currentTextChanged.disconnect(self.provider_raster_connection)
-        self.providerCombo.setCurrentText(text)
-        self.rasterSourceChanged.emit()
-        self.provider_raster_connection = self.providerCombo.currentTextChanged.connect(self.switch_raster_combo)
+        try:
+            self.providerCombo.setCurrentText(text)
+            self.rasterSourceChanged.emit()
+        finally:
+            # Reconnect even when a `rasterSourceChanged` handler raises. Left at the tail, one
+            # failure stopped the two combos driving each other for the rest of the session — and
+            # this slot is guarded, so that loss would be silent (spec/006 § a guarded callback is
+            # interrupted).
+            self.provider_raster_connection = guarded_connect(
+                self.providerCombo.currentTextChanged, self.switch_raster_combo,
+                "switching the provider", self)
 
     def switch_raster_combo(self, text):
         # We want to skip the signal emission if the actual text did not change
@@ -213,9 +240,15 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
             return
         self.current_raster_source = text
         self.sourceCombo.currentTextChanged.disconnect(self.raster_provider_connection)
-        self.sourceCombo.setCurrentText(text)
-        self.rasterSourceChanged.emit()
-        self.raster_provider_connection = self.sourceCombo.currentTextChanged.connect(self.switch_provider_combo)
+        try:
+            self.sourceCombo.setCurrentText(text)
+            self.rasterSourceChanged.emit()
+        finally:
+            # Same reason as switch_provider_combo above: the reconnect must survive a raising
+            # handler, or the combos stop syncing for the session.
+            self.raster_provider_connection = guarded_connect(
+                self.sourceCombo.currentTextChanged, self.switch_provider_combo,
+                "switching the imagery source", self)
 
     def set_raster_sources(self,
                            provider_names: Dict[str, str],
@@ -230,22 +263,29 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.providerCombo.currentTextChanged.disconnect(self.provider_raster_connection)
         self.sourceCombo.currentTextChanged.disconnect(self.raster_provider_connection)
 
-        self.sourceCombo.clear()
-        for name, api_name in provider_names.items():
-            self.sourceCombo.addItem(name, api_name)
-        self.providerCombo.clear()
-        for name, api_name in provider_names.items():
-            self.providerCombo.addItem(name, api_name)
+        try:
+            self.sourceCombo.clear()
+            for name, api_name in provider_names.items():
+                self.sourceCombo.addItem(name, api_name)
+            self.providerCombo.clear()
+            for name, api_name in provider_names.items():
+                self.providerCombo.addItem(name, api_name)
 
-        for name in default_provider_names:
-            if name in provider_names:
-                self.sourceCombo.setCurrentText(name)
-                self.providerCombo.setCurrentText(name)
-        self.current_raster_source = self.sourceCombo.currentText()
-
-        # Now, after all is set, we can unblock the signals and emit a new one
-        self.provider_raster_connection = self.providerCombo.currentTextChanged.connect(self.switch_raster_combo)
-        self.raster_provider_connection = self.sourceCombo.currentTextChanged.connect(self.switch_provider_combo)
+            for name in default_provider_names:
+                if name in provider_names:
+                    self.sourceCombo.setCurrentText(name)
+                    self.providerCombo.setCurrentText(name)
+            self.current_raster_source = self.sourceCombo.currentText()
+        finally:
+            # Both combos are deliberately deaf for the block above, so restoring them belongs in
+            # `finally`: a raise while repopulating would otherwise leave them disconnected for the
+            # rest of the session, with no visible sign that the pair stopped syncing.
+            self.provider_raster_connection = guarded_connect(
+                self.providerCombo.currentTextChanged, self.switch_raster_combo,
+                "switching the provider", self)
+            self.raster_provider_connection = guarded_connect(
+                self.sourceCombo.currentTextChanged, self.switch_provider_combo,
+                "switching the imagery source", self)
         self.rasterSourceChanged.emit()
 
     def set_processing_visible_columns(self):
@@ -263,7 +303,8 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
 
     def connect_processing_column_checkboxes(self):
         for checkbox in self.processing_columns:
-            checkbox.toggled.connect(self.set_processing_column_visibility)
+            guarded_connect(checkbox.toggled, self.set_processing_column_visibility,
+                            "showing or hiding a processings column", self)
 
     def set_processing_column_visibility(self):
         """
@@ -443,7 +484,8 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.modelOptionsLayout.addWidget(checkbox)
         self.modelOptions.append(checkbox)
         checkbox.setChecked(checked)
-        checkbox.toggled.connect(lambda: self.modelOptionsChanged.emit())
+        guarded_connect(checkbox.toggled, lambda: self.modelOptionsChanged.emit(),
+                        "toggling a model option", self)
 
     def enabled_blocks(self):
         """
@@ -649,7 +691,8 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
     
     def connect_search_column_checkboxes(self):
         for checkbox in self.search_columns:
-            checkbox.toggled.connect(self.set_search_column_visibility)
+            guarded_connect(checkbox.toggled, self.set_search_column_visibility,
+                            "showing or hiding a search column", self)
 
     OFF_NADIR_MIN = 0
     OFF_NADIR_MAX = 30
@@ -691,9 +734,12 @@ class MainDialog(*uic.loadUiType(ui_path/'main_dialog.ui')):
         self.layoutMetadataFilters.addWidget(self.labelOffNadir, row, 0)
         self.layoutMetadataFilters.addWidget(self.offNadirSlider, row, 1)
         self.layoutMetadataFilters.addLayout(spin_row, row, 2)
-        self.offNadirSlider.rangeChanged.connect(self._sync_off_nadir_spinboxes)
-        self.minOffNadirSpinBox.valueChanged.connect(self._sync_off_nadir_slider)
-        self.maxOffNadirSpinBox.valueChanged.connect(self._sync_off_nadir_slider)
+        guarded_connect(self.offNadirSlider.rangeChanged, self._sync_off_nadir_spinboxes,
+                        "dragging the off-nadir slider", self)
+        guarded_connect(self.minOffNadirSpinBox.valueChanged, self._sync_off_nadir_slider,
+                        "editing the minimum off-nadir angle", self)
+        guarded_connect(self.maxOffNadirSpinBox.valueChanged, self._sync_off_nadir_slider,
+                        "editing the maximum off-nadir angle", self)
 
     def _off_nadir_spinbox(self, value: int) -> QSpinBox:
         box = QSpinBox()

--- a/mapflow/dialogs/mosaic_dialog.py
+++ b/mapflow/dialogs/mosaic_dialog.py
@@ -1,6 +1,7 @@
 from PyQt5 import uic
 from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 
+from ..error_guard import guarded_connect
 from ..schema.data_catalog import MosaicUpdateSchema, MosaicReturnSchema
 from .processing_dialog import ui_path
 
@@ -11,7 +12,8 @@ class MosaicDialog(*uic.loadUiType(ui_path/'mosaic_dialog.ui')):
         self.setupUi(self)
         self.ok = self.buttonBox.button(QDialogButtonBox.Ok)
 
-        self.mosaicName.textChanged.connect(self.on_name_change)
+        guarded_connect(self.mosaicName.textChanged, self.on_name_change,
+                        "editing the mosaic name", self)
 
     def on_name_change(self):
         if not self.mosaicName.text():

--- a/mapflow/dialogs/processing_dialog.py
+++ b/mapflow/dialogs/processing_dialog.py
@@ -7,6 +7,7 @@ from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 # `from .processing_dialog import plugin_icon`. The redundant alias marks it as an
 # intentional re-export so ruff won't strip it as unused.
 from .icons import plugin_icon as plugin_icon
+from ..error_guard import guarded_connect
 from ..schema.processing import UpdateProcessingSchema, ProcessingDTO
 
 ui_path = Path(__file__).parent/'static'/'ui'
@@ -18,7 +19,8 @@ class UpdateProcessingDialog(*uic.loadUiType(ui_path/'processing_dialog.ui')):
         self.setupUi(self)
         self.ok = self.buttonBox.button(QDialogButtonBox.Ok)
 
-        self.processingName.textChanged.connect(self.on_name_change)
+        guarded_connect(self.processingName.textChanged, self.on_name_change,
+                        "editing the processing name", self)
 
     def on_name_change(self):
         if not self.processingName.text():

--- a/mapflow/dialogs/project_dialog.py
+++ b/mapflow/dialogs/project_dialog.py
@@ -3,6 +3,7 @@ from PyQt5.QtCore import QCoreApplication
 from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 
 from .processing_dialog import ui_path
+from ..error_guard import guarded_connect
 from ..schema.project import MapflowProject, CreateProjectSchema, UpdateProjectSchema
 
 
@@ -17,7 +18,8 @@ class ProjectDialog(*uic.loadUiType(ui_path/'project_dialog.ui')):
         self.current_project = None
         self.result = None
 
-        self.projectName.textChanged.connect(self.on_name_change)
+        guarded_connect(self.projectName.textChanged, self.on_name_change,
+                        "editing the project name", self)
 
     def on_name_change(self):
         if not self.projectName.text():

--- a/mapflow/dialogs/provider_dialog.py
+++ b/mapflow/dialogs/provider_dialog.py
@@ -4,6 +4,7 @@ from PyQt5 import uic
 from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 
 from .processing_dialog import ui_path
+from ..error_guard import guarded_connect
 from ..model.provider import (CRS,
                                BasicAuth,
                                UsersProvider,
@@ -21,13 +22,17 @@ class ProviderDialog(*uic.loadUiType(ui_path/'provider_dialog.ui')):
         ok = self.buttonBox.button(QDialogButtonBox.Ok)
         ok.setEnabled(False)
 
-        self.type.currentTextChanged.connect(self.on_type_change)
-        self.name.textChanged.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
-        self.url.textChanged.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
-        self.login.textChanged.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
-        self.password.textChanged.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
-        self.crs.currentTextChanged.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
-        self.save_credentials.toggled.connect(lambda: ok.setEnabled(self.validate_and_create_provider()))
+        guarded_connect(self.type.currentTextChanged, self.on_type_change,
+                        "changing the provider type", self)
+        # Every other field revalidates the whole form, so they share one handler.
+        for signal in (self.name.textChanged,
+                       self.url.textChanged,
+                       self.login.textChanged,
+                       self.password.textChanged,
+                       self.crs.currentTextChanged,
+                       self.save_credentials.toggled):
+            guarded_connect(signal, lambda: ok.setEnabled(self.validate_and_create_provider()),
+                            "validating the provider form", self)
 
         # we store here the provider that we are editing right now
         self.current_provider = None

--- a/mapflow/dialogs/review_dialog.py
+++ b/mapflow/dialogs/review_dialog.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QWidget, QDialogButtonBox
 from qgis.core import QgsMapLayerProxyModel
 
 from .icons import plugin_icon
+from ..error_guard import guarded_connect
 
 ui_path = Path(__file__).parent/'static'/'ui'
 
@@ -27,8 +28,12 @@ class ReviewDialog(*uic.loadUiType(ui_path/'review_dialog.ui')):
         ok = self.buttonBox.button(QDialogButtonBox.Ok)
         ok.setEnabled(self.review_submit_allowed())
         # Enabled only if the text is entered
-        self.reviewComment.textChanged.connect(lambda: ok.setEnabled(self.review_submit_allowed()))
-        self.reviewLayerCombo.layerChanged.connect(lambda: ok.setEnabled(self.review_submit_allowed()))
+        guarded_connect(self.reviewComment.textChanged,
+                        lambda: ok.setEnabled(self.review_submit_allowed()),
+                        "validating the review form", self)
+        guarded_connect(self.reviewLayerCombo.layerChanged,
+                        lambda: ok.setEnabled(self.review_submit_allowed()),
+                        "validating the review form", self)
 
     def review_submit_allowed(self):
         text_ok = self.reviewComment.toPlainText() != ""

--- a/mapflow/error_guard.py
+++ b/mapflow/error_guard.py
@@ -31,6 +31,26 @@ from .infra.reporter import report_unexpected_error
 logger = logging.getLogger(__name__)
 
 
+def _attribute_or_none(obj: object, attribute: str):
+    """`getattr` that cannot raise.
+
+    `getattr(x, name, default)` only swallows AttributeError, and the default is no help against
+    anything else: a sip-wrapped Qt object whose C++ base was never constructed raises RuntimeError
+    on any attribute access, and a property can raise whatever it likes. This is reached while a
+    failure is already being reported, so an exception escaping here would both replace that failure
+    with its own and escape the guard to the event loop — turning one bug into exactly the unguarded
+    crash the guard exists to prevent.
+    """
+    try:
+        return getattr(obj, attribute, None)
+    except Exception as error:
+        # Debug, not error: the report this feeds is already being built for a real failure, and a
+        # missing version degrades it rather than breaking it. The trace still says which attribute
+        # refused and why.
+        logger.debug("Could not read %r for the error report: %s", attribute, error)
+        return None
+
+
 def _resolve_plugin_version(obj: object) -> str:
     """Best-effort plugin version from a bound instance.
 
@@ -40,7 +60,7 @@ def _resolve_plugin_version(obj: object) -> str:
     for path in (('plugin_version',), ('app_context', 'plugin_version')):
         target = obj
         for attribute in path:
-            target = getattr(target, attribute, None)
+            target = _attribute_or_none(target, attribute)
             if target is None:
                 break
         if isinstance(target, str) and target:

--- a/mapflow/functional/view/aoi_view.py
+++ b/mapflow/functional/view/aoi_view.py
@@ -6,6 +6,7 @@ from qgis.core import Qgis, QgsMapLayer, QgsVectorLayer
 
 from ...dialogs.main_dialog import MainDialog
 from ...dialogs.select_aoi_layers_dialog import SelectAoiLayersDialog
+from ...error_guard import guarded_connect
 
 
 class AoiView(QObject):
@@ -67,8 +68,15 @@ class AoiView(QObject):
         layout.addStretch(1)
         save_button = QPushButton(self.tr("Save AOI"))
         cancel_button = QPushButton(self.tr("Cancel"))
-        save_button.clicked.connect(self.saveRequested)
-        cancel_button.clicked.connect(self.cancelRequested)
+        # Qt -> plugin-signal passthroughs, and the Qt boundary for the whole save/cancel chain:
+        # `saveRequested` is connected to `aoi_service.save_session` as a plugin signal, and plugin
+        # signals are left raw because they emit inside an already-guarded stack. That only holds if
+        # the stack starts guarded, so it starts here. The lambdas take no arguments, so the guard
+        # trims `clicked`'s `checked` bool away — these signals carry none.
+        guarded_connect(save_button.clicked, lambda: self.saveRequested.emit(),
+                        "saving the AOI edit session", self)
+        guarded_connect(cancel_button.clicked, lambda: self.cancelRequested.emit(),
+                        "cancelling the AOI edit session", self)
         layout.addWidget(save_button)
         layout.addWidget(cancel_button)
         self._edit_bar_item = self.iface.messageBar().pushWidget(widget, Qgis.Info)

--- a/mapflow/functional/view/processing_view.py
+++ b/mapflow/functional/view/processing_view.py
@@ -11,6 +11,7 @@ from ...schema.template import (ProcessingTemplateDTO, TemplateAoiDTO,
                                 AoiProcessingLink, TemplateProcessingSchema,
                                 NoAoiProcessingsRow)
 from ...config import config
+from ...error_guard import guarded_connect
 from ...infra.alert_service import alert
 
 class ProcessingView:
@@ -59,9 +60,9 @@ class ProcessingView:
 
     def connect_header_sort(self, on_sort_changed):
         """Connect column header clicks to a templates-first re-sort."""
-        self.dlg.processingsTable.horizontalHeader().sectionClicked.connect(
-            lambda col: self._on_header_clicked(col, on_sort_changed)
-        )
+        guarded_connect(self.dlg.processingsTable.horizontalHeader().sectionClicked,
+                        lambda col: self._on_header_clicked(col, on_sort_changed),
+                        "sorting the processings by a column header", self)
 
     def clear_header_sort(self) -> None:
         """Drop the column-click override so `sort_processings` reads the combo again."""
@@ -161,8 +162,9 @@ class ProcessingView:
             if self.dlg.cornfirmProcessingStart.isChecked() != (not dont_ask):
                 self.dlg.cornfirmProcessingStart.setChecked(not dont_ask)
 
-        dialog.checkBox.toggled.connect(sync_dont_ask_again)
-        dialog.accepted.connect(on_accept)
+        guarded_connect(dialog.checkBox.toggled, sync_dont_ask_again,
+                        "toggling 'don't ask again'", self)
+        guarded_connect(dialog.accepted, on_accept, "confirming the processing start", self)
         ui_start_params = self.read_processing_start_params()
         dialog.setup(
             name=name,

--- a/mapflow/functional/view/search_view.py
+++ b/mapflow/functional/view/search_view.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import QAbstractItemView, QMenu, QPushButton, QTableWidgetI
 
 from ..helpers import utc_date_from_iso
 from ...dialogs.main_dialog import MainDialog
+from ...error_guard import guarded_connect
 from ...schema.catalog import ProductType
 from ...schema.template import SearchParams
 
@@ -48,8 +49,10 @@ class SearchView(QObject):
         self._search_menu = QMenu(self.dlg.getMetadata)
         search_action = self._search_menu.addAction(self.tr("Search"))
         plan_action = self._search_menu.addAction(self.tr("Plan search"))
-        search_action.triggered.connect(lambda: self.set_search_mode("search"))
-        plan_action.triggered.connect(lambda: self.set_search_mode("plan"))
+        guarded_connect(search_action.triggered, lambda: self.set_search_mode("search"),
+                        "choosing the search mode", self)
+        guarded_connect(plan_action.triggered, lambda: self.set_search_mode("plan"),
+                        "choosing the plan-search mode", self)
         self.dlg.getMetadata.setPopupMode(QToolButton.MenuButtonPopup)
         self.dlg.getMetadata.setMenu(self._search_menu)
         self.set_search_mode("search")
@@ -68,8 +71,8 @@ class SearchView(QObject):
         self._seen_menu = QMenu(self.dlg.markSeenButton)
         seen_action = self._seen_menu.addAction(self.tr("Seen"))
         seen_all_action = self._seen_menu.addAction(self.tr("Seen all"))
-        seen_action.triggered.connect(on_seen)
-        seen_all_action.triggered.connect(on_seen_all)
+        guarded_connect(seen_action.triggered, on_seen, "marking images seen", self)
+        guarded_connect(seen_all_action.triggered, on_seen_all, "marking all images seen", self)
         self.dlg.markSeenButton.setPopupMode(QToolButton.MenuButtonPopup)
         self.dlg.markSeenButton.setMenu(self._seen_menu)
         self.dlg.markSeenButton.setDefaultAction(seen_action)
@@ -244,7 +247,8 @@ class SearchView(QObject):
         several preview layers (feedback 4.2). The prior connection is dropped first.
         """
         self.disconnect_cell_preview()
-        self._cell_preview_connection = self.dlg.metadataTable.cellClicked.connect(handler)
+        self._cell_preview_connection = guarded_connect(
+            self.dlg.metadataTable.cellClicked, handler, "previewing a search result", self)
 
     def disconnect_cell_preview(self) -> None:
         try:
@@ -364,7 +368,8 @@ class SearchView(QObject):
         return bool(self.dlg.metadataTable.findItems(text, Qt.MatchExactly))
 
     def connect_table_selection(self, handler):
-        return self.dlg.metadataTable.itemSelectionChanged.connect(handler)
+        return guarded_connect(self.dlg.metadataTable.itemSelectionChanged, handler,
+                               "syncing the table selection to the map", self)
 
     def disconnect_table_selection(self, connection) -> None:
         """Drop the table->layer handler while the layer is driving the table.

--- a/tests/functional/test_entry_points_guarded.py
+++ b/tests/functional/test_entry_points_guarded.py
@@ -40,39 +40,16 @@ QT_SIGNALS = {
 }
 
 #: (path relative to repo root, enclosing function, signal name) for each Qt-source connection still
-#: made with a raw `.connect`. Only shrinks — see the module docstring. Seeded with the set that
-#: existed when the guard rollout began (PR-1), minus `provider_controller`, converted as the worked
-#: example. Each later entry-point PR routes its region through `guarded_connect` and deletes its rows.
+#: made with a raw `.connect`. Only shrinks — see the module docstring. It began as every Qt-source
+#: connection in the plugin and is now down to one, which is not a gap:
+#:
+#: `send_request` wires the finished signal to `response_dispatcher`, which IS the guard (it wraps
+#: every callback in `call_guarded`). It is the one `.connect` that need not go through the helper —
+#: routing the guard through itself would be circular.
+#:
+#: So a new row here is a regression, not a step: every other Qt entry point in the plugin reaches
+#: plugin code through `guarded_connect`.
 ALLOWED_UNGUARDED = {
-    ('mapflow/dialogs/image_dialog.py', '__init__', 'textChanged'),
-    ('mapflow/dialogs/main_dialog.py', '__init__', 'clicked'),
-    ('mapflow/dialogs/main_dialog.py', '__init__', 'currentTextChanged'),
-    ('mapflow/dialogs/main_dialog.py', '_setup_off_nadir_filter', 'valueChanged'),
-    ('mapflow/dialogs/main_dialog.py', 'add_model_option', 'toggled'),
-    ('mapflow/dialogs/main_dialog.py', 'connect_processing_column_checkboxes', 'toggled'),
-    ('mapflow/dialogs/main_dialog.py', 'connect_search_column_checkboxes', 'toggled'),
-    ('mapflow/dialogs/main_dialog.py', 'set_raster_sources', 'currentTextChanged'),
-    ('mapflow/dialogs/main_dialog.py', 'set_state_from_settings', 'toggled'),
-    ('mapflow/dialogs/main_dialog.py', 'switch_provider_combo', 'currentTextChanged'),
-    ('mapflow/dialogs/main_dialog.py', 'switch_raster_combo', 'currentTextChanged'),
-    ('mapflow/dialogs/mosaic_dialog.py', '__init__', 'textChanged'),
-    ('mapflow/dialogs/processing_dialog.py', '__init__', 'textChanged'),
-    ('mapflow/dialogs/project_dialog.py', '__init__', 'textChanged'),
-    ('mapflow/dialogs/provider_dialog.py', '__init__', 'currentTextChanged'),
-    ('mapflow/dialogs/provider_dialog.py', '__init__', 'textChanged'),
-    ('mapflow/dialogs/provider_dialog.py', '__init__', 'toggled'),
-    ('mapflow/dialogs/review_dialog.py', 'setup', 'layerChanged'),
-    ('mapflow/dialogs/review_dialog.py', 'setup', 'textChanged'),
-    ('mapflow/functional/view/aoi_view.py', 'enter_edit_session', 'clicked'),
-    ('mapflow/functional/view/processing_view.py', 'confirm_processing_start', 'accepted'),
-    ('mapflow/functional/view/processing_view.py', 'confirm_processing_start', 'toggled'),
-    ('mapflow/functional/view/processing_view.py', 'connect_header_sort', 'sectionClicked'),
-    ('mapflow/functional/view/search_view.py', 'connect_cell_preview', 'cellClicked'),
-    ('mapflow/functional/view/search_view.py', 'connect_table_selection', 'itemSelectionChanged'),
-    ('mapflow/functional/view/search_view.py', 'setup_search_mode_dropdown', 'triggered'),
-    ('mapflow/functional/view/search_view.py', 'setup_seen_dropdown', 'triggered'),
-    # `send_request` wires the finished signal to `response_dispatcher`, which IS the guard (it wraps
-    # every callback in `call_guarded`). It is the one `.connect` that need not go through the helper.
     ('mapflow/http.py', 'send_request', 'finished'),
 }
 

--- a/tests/functional/test_guarded_connect.py
+++ b/tests/functional/test_guarded_connect.py
@@ -129,3 +129,30 @@ def test_the_plugin_version_comes_from_the_version_source():
         signal.connected()
 
     assert reported.call_args.args[2] == "9.9.9"
+
+
+def test_a_version_source_that_raises_on_attribute_access_still_reports():
+    """The resolver runs while a failure is already being handled, so it must not add one of its
+    own. `getattr(x, name, default)` only swallows AttributeError — a sip-wrapped Qt object whose
+    C++ base was never constructed raises RuntimeError, and a property can raise anything. Escaping
+    here would take the guard's own report down and reach the event loop unguarded."""
+    signal = _FakeSignal()
+
+    class Hostile:
+        @property
+        def plugin_version(self):
+            raise RuntimeError("super-class __init__() was never called")
+
+        @property
+        def app_context(self):
+            raise RuntimeError("super-class __init__() was never called")
+
+    def slot(*args):
+        raise Boom("x")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        error_guard.guarded_connect(signal, slot, "x", version_source=Hostile())
+        signal.connected()  # must not raise
+
+    reported.assert_called_once()
+    assert reported.call_args.args[2] == "unknown"

--- a/tests/qgis/test_provider_combo_sync.py
+++ b/tests/qgis/test_provider_combo_sync.py
@@ -1,0 +1,67 @@
+"""The source/provider combo pair keeps syncing after a failure (entry-point rollout, 4-PR6).
+
+The two combos mirror each other, so each handler takes the *other* one's connection down while it
+drives and restores it afterwards. That restore used to sit at the tail of the method, after a
+`setCurrentText` and a `rasterSourceChanged.emit()` that runs plugin handlers — so one raising
+handler left the pair permanently disconnected, and the combos silently stopped following each
+other for the rest of the session. Now that these slots are guarded the raise is swallowed too,
+which would have made the loss invisible (spec/006 § a guarded callback is interrupted).
+
+The restore is in a `finally` now. These tests force a failure inside the guarded block and check
+the connection comes back.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from mapflow.dialogs.main_dialog import MainDialog
+
+
+def _dialog():
+    """A partial dialog: only what the combo-sync methods touch. Building the real MainDialog would
+    pull in the whole .ui tree for a two-attribute test."""
+    dlg = MainDialog.__new__(MainDialog)
+    dlg.current_raster_source = "old source"
+    dlg.provider_raster_connection = object()
+    dlg.raster_provider_connection = object()
+    dlg.providerCombo = MagicMock()
+    dlg.sourceCombo = MagicMock()
+    # Bound slots the reconnect passes to guarded_connect.
+    dlg.switch_raster_combo = MagicMock()
+    dlg.switch_provider_combo = MagicMock()
+    return dlg
+
+
+def test_switch_provider_combo_reconnects_the_sibling_when_the_body_raises():
+    dlg = _dialog()
+    dlg.providerCombo.setCurrentText.side_effect = RuntimeError("a handler failed")
+
+    with pytest.raises(RuntimeError):
+        MainDialog.switch_provider_combo(dlg, "new source")
+
+    dlg.providerCombo.currentTextChanged.disconnect.assert_called_once()
+    # Restored despite the raise — without this the provider combo stops driving the source combo.
+    dlg.providerCombo.currentTextChanged.connect.assert_called_once()
+
+
+def test_switch_raster_combo_reconnects_the_sibling_when_the_body_raises():
+    dlg = _dialog()
+    dlg.sourceCombo.setCurrentText.side_effect = RuntimeError("a handler failed")
+
+    with pytest.raises(RuntimeError):
+        MainDialog.switch_raster_combo(dlg, "new source")
+
+    dlg.sourceCombo.currentTextChanged.disconnect.assert_called_once()
+    dlg.sourceCombo.currentTextChanged.connect.assert_called_once()
+
+
+def test_set_raster_sources_reconnects_both_combos_when_repopulating_raises():
+    dlg = _dialog()
+    dlg.sourceCombo.addItem.side_effect = RuntimeError("bad provider list")
+
+    with pytest.raises(RuntimeError):
+        MainDialog.set_raster_sources(dlg, {"Mapflow": "mapflow"}, ["Mapflow"])
+
+    # Both were deliberately deaf for the repopulate; both must come back.
+    dlg.providerCombo.currentTextChanged.connect.assert_called_once()
+    dlg.sourceCombo.currentTextChanged.connect.assert_called_once()

--- a/tests/qgis/test_search_selection_sync.py
+++ b/tests/qgis/test_search_selection_sync.py
@@ -34,6 +34,23 @@ def _table(rows):
     return table
 
 
+def _select_row(plugin, row: int) -> None:
+    """Arrange a table selection without firing the table->layer handler.
+
+    The fixture wires that handler for real, so an unblocked `selectRow` runs the very method most
+    of these tests then call explicitly, and the assertions would count both. Blocking the signal
+    keeps arranging the selection separate from the action under test. (This only started mattering
+    once the connection went through `guarded_connect`: connecting a bound method of the fixture's
+    half-built QObject left it inert, so the setup used to be silent by accident.)
+    """
+    table = plugin.dlg.metadataTable
+    table.blockSignals(True)
+    try:
+        table.selectRow(row)
+    finally:
+        table.blockSignals(False)
+
+
 @pytest.fixture
 def plugin():
     """A `SearchController` with a real results table and real `SearchView` widget access.
@@ -72,7 +89,7 @@ def plugin():
 def test_the_layer_handler_is_disconnected_while_the_table_drives(plugin):
     """The selectByExpression below fires the layer's selectionChanged; if the table handler is
     still attached it calls straight back into this method."""
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_table_selection_with_layer()
 
@@ -83,7 +100,7 @@ def test_the_layer_handler_is_disconnected_while_the_table_drives(plugin):
 
 
 def test_the_selected_rows_local_indices_reach_the_layer(plugin):
-    plugin.dlg.metadataTable.selectRow(1)
+    _select_row(plugin, 1)
 
     plugin.sync_table_selection_with_layer()
 
@@ -114,7 +131,7 @@ def test_the_zoom_combo_is_written_with_signals_blocked(plugin):
     """zoomCombo.currentIndexChanged -> on_zoom_change fires a second, duplicate cost request,
     and it would use the stale zoom. The block is the fix; this pins it."""
     plugin.dlg.zoomCombo.findText.return_value = 2
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_table_selection_with_layer()
 
@@ -125,7 +142,7 @@ def test_the_zoom_combo_is_written_with_signals_blocked(plugin):
 
 def test_an_unknown_zoom_falls_back_to_the_first_entry(plugin):
     plugin.dlg.zoomCombo.findText.return_value = -1
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_table_selection_with_layer()
 
@@ -133,7 +150,7 @@ def test_an_unknown_zoom_falls_back_to_the_first_entry(plugin):
 
 
 def test_the_cost_is_recomputed_after_the_zoom_is_set(plugin):
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_table_selection_with_layer()
 
@@ -161,7 +178,7 @@ def test_the_table_handler_is_disconnected_while_the_layer_drives(plugin):
 
 
 def test_no_selected_features_clears_the_table(plugin):
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_layer_selection_with_table([])
 
@@ -188,7 +205,7 @@ def test_several_footprints_select_several_rows(plugin):
 # ---------- image id -> table ----------
 
 def test_an_empty_image_id_clears_the_selection(plugin):
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_image_id_with_table("")
 
@@ -196,7 +213,7 @@ def test_an_empty_image_id_clears_the_selection(plugin):
 
 
 def test_an_unknown_image_id_clears_the_selection(plugin):
-    plugin.dlg.metadataTable.selectRow(0)
+    _select_row(plugin, 0)
 
     plugin.sync_image_id_with_table("no-such-image")
 

--- a/tests/qgis/test_template_group_and_preview.py
+++ b/tests/qgis/test_template_group_and_preview.py
@@ -102,12 +102,16 @@ def _search_view():
 def test_reconnect_cell_preview_disconnects_previous_first():
     view = _search_view()
     view._cell_preview_connection = object()  # a prior connection exists
-    handler = object()
+    handler = MagicMock()
 
     view.connect_cell_preview(handler)
 
     view.dlg.metadataTable.disconnect.assert_called_once()
-    view.dlg.metadataTable.cellClicked.connect.assert_called_once_with(handler)
+    view.dlg.metadataTable.cellClicked.connect.assert_called_once()
+    # The connected callable is `guarded_connect`'s wrapper, not the handler itself, so check where
+    # it leads rather than its identity: firing the cell click must reach the handler.
+    view.dlg.metadataTable.cellClicked.connect.call_args.args[0](0, 0)
+    handler.assert_called_once()
 
 
 def test_reconnect_cell_preview_first_time_no_disconnect_error():


### PR DESCRIPTION
Finishes the entry-point rollout (spec/007 § Entry points, invariant 7) through the last two
regions: the views' tables, split-buttons and confirmation dialog, and the dialogs' own form wiring.
26 rows leave `ALLOWED_UNGUARDED`, and what remains is a single row that is not a gap —
`send_request` wiring `finished` to `response_dispatcher`, which IS the guard. Every other Qt entry
point in the plugin now reaches plugin code through `guarded_connect`.

Three bugs came out of it, the first in the guard itself.

**The guard could turn one failure into an unguarded crash.** `_resolve_plugin_version` runs inside
`_guarded`, on the way to building a report, and its docstring promises it is "deliberately
forgiving: this runs while already handling a failure, so a missing attribute must not raise a
second exception on top of the first". It was not. `getattr(x, name, default)` only swallows
AttributeError, and a sip-wrapped Qt object whose C++ base was never constructed raises RuntimeError
instead — as does any property that fails. That exception escaped `_guarded` entirely, so a slot
that raised would produce no report and reach Qt's event loop anyway: the exact outcome the guard
exists to prevent, and worst on the objects most likely to be half-built when something is already
wrong. Now genuinely forgiving, and pinned by a test with a version source that raises on every
attribute.

**The source/provider combo pair could stop syncing for the session.** The two combos mirror each
other, so each handler disconnects the *other* one while it drives. `switch_provider_combo` and
`switch_raster_combo` restored that connection on the last line, after a `setCurrentText` and a
`rasterSourceChanged.emit()` that runs plugin handlers; `set_raster_sources` restored both after
repopulating. One raising handler therefore left the pair disconnected permanently — the imagery
source and provider combos silently stopped following each other, with no error and no way back
short of a restart. All three restores move into `finally`.

**The AOI save/cancel chain was unguarded end to end.** `aoi_view` connected the edit-bar buttons
straight to its own `saveRequested`/`cancelRequested` signals, and the controller connects those to
`aoi_service`. Plugin-signal connections are deliberately left raw because they emit inside a stack
that is already guarded — but that only holds if the stack *starts* guarded, and here the Qt
boundary was this passthrough. So nothing between the button and the service was guarded at all.
Guarding the passthrough closes the chain; the lambdas take no arguments, so the guard trims
`clicked`'s `checked` bool, which these signals do not carry.

Known gap, tracked in the WAL rather than fixed here: `guarded_connect` resolves the plugin version
off the object passed as `version_source`, and dialogs and views carry neither `plugin_version` nor
`app_context`, so a report raised from one of these sites says "unknown". The version is parsed once
in `Mapflow.__init__`, so a module-level fallback in `error_guard` would fix every such site at once
— a separate change, since it touches the report tier rather than the wiring.

## Manual test
Imagery source and provider: switch the source combo and confirm the provider combo follows, and
vice versa — that pair is the regression surface for the `finally` change, and the symptom to watch
for is the two combos drifting apart after any error. AOI editing: start a draw/update session from
the template AOI actions and use both Save AOI and Cancel on the message bar. Dialogs: create and
edit a mosaic, rename an image and a processing, create and rename a project, add and edit an
imagery provider, submit a review — each form's OK button must still enable and disable as you type.
Also the search split-buttons (Search / Plan search, Seen / Seen all), the results table's preview
cell click and row selection, the processings column-header sort, the "don't ask again" checkbox on
the start-confirmation dialog, the model option checkboxes, the off-nadir slider and its spinboxes,
and the processing/search column visibility checkboxes.
