### PR TITLE
fix: fail closed on connections the guard rule cannot see, and name the version in every report

### DIFF
--- a/WAL.md
+++ b/WAL.md
@@ -215,17 +215,11 @@ message; the durable rules are in `spec/006` and `spec/007`.
 
 Two follow-ups it left behind:
 
-[ ] Close the entry-point enforcement gap the rollout exposed
-    `test_entry_points_guarded` classifies a connection by the attribute the `.connect` hangs off,
-    so `for signal in (...): signal.connect(...)` is invisible to it — the receiver is a bare name.
-    `mapflow.py`'s local-filter block was exactly that shape (nine Qt widget signals) and was
-    guarded only because the rollout read the code. Either resolve simple loop variables in the
-    visitor, or fail on a `.connect` whose receiver cannot be classified.
-[ ] Give dialog-originated reports a plugin version
-    `guarded_connect`'s `version_source` resolves `plugin_version` off the passed object; dialogs and
-    views carry neither it nor `app_context`, so a report raised from one says "unknown". The version
-    is parsed once in `Mapflow.__init__` from metadata.txt — a one-time module-level fallback in
-    `error_guard` would fix every such site at once.
+[ready-for-review] Close the entry-point enforcement gap, and give reports a plugin version.
+    The classifier now fails closed on a `.connect` whose receiver it cannot name, instead of
+    skipping it; that immediately found an injected plugin signal nobody had noticed. And
+    `error_guard` records the version once at startup, so reports raised from dialogs and views no
+    longer say "unknown".
 
 [ ] Check whether the behavioral tier reaches the real backend
 The fake network replaces `QgsNetworkAccessManager` for everything the plugin requests through

--- a/mapflow/error_guard.py
+++ b/mapflow/error_guard.py
@@ -30,6 +30,25 @@ from .infra.reporter import report_unexpected_error
 
 logger = logging.getLogger(__name__)
 
+#: The running plugin version, recorded once at startup by `Mapflow.__init__` (it parses
+#: metadata.txt). `_resolve_plugin_version` falls back to this when the object a guard was given
+#: carries no version of its own: dialogs and views hold neither `plugin_version` nor `app_context`,
+#: so every report raised from a widget slot used to arrive saying "unknown" — the one field that
+#: makes a report actionable, missing on a whole tier of them.
+_plugin_version: Optional[str] = None
+
+
+def set_plugin_version(version: str) -> None:
+    """Record the running plugin version for reports raised where no version source is at hand.
+
+    Module state rather than an argument threaded through every `guarded_connect` call: the version
+    is a property of the running plugin, identical for every report, and the alternative is handing
+    it to widgets that otherwise have no reason to know it.
+    """
+    global _plugin_version
+    if isinstance(version, str) and version:
+        _plugin_version = version
+
 
 def _attribute_or_none(obj: object, attribute: str):
     """`getattr` that cannot raise.
@@ -65,7 +84,7 @@ def _resolve_plugin_version(obj: object) -> str:
                 break
         if isinstance(target, str) and target:
             return target
-    return 'unknown'
+    return _plugin_version or 'unknown'
 
 
 def guard_entry_point(context: str, reraise: bool = False) -> Callable:

--- a/mapflow/mapflow.py
+++ b/mapflow/mapflow.py
@@ -17,7 +17,7 @@ from qgis.core import (
 )
 
 from .config import Config, ConfigColumns
-from .error_guard import guarded_connect
+from .error_guard import guarded_connect, set_plugin_version
 # Functional
 from .functional import helpers, layer_utils
 from .functional.app_context import AppContext
@@ -136,6 +136,9 @@ class Mapflow(QObject):
         metadata_parser = ConfigParser()
         metadata_parser.read(os.path.join(self.plugin_dir, 'metadata.txt'))
         self.app_context.plugin_version = metadata_parser.get('general', 'version')
+        # Give the guard a version for reports raised where no version source is at hand — a widget
+        # slot has no `app_context` to resolve one from (spec/006: the report must be actionable).
+        set_plugin_version(self.app_context.plugin_version)
         self.dlg.help.setText(
             self.dlg.help.text().replace('Mapflow', f'{self.plugin_name} {self.app_context.plugin_version}', 1)
         )

--- a/tests/functional/test_entry_points_guarded.py
+++ b/tests/functional/test_entry_points_guarded.py
@@ -54,13 +54,36 @@ ALLOWED_UNGUARDED = {
 }
 
 
+#: `.connect(...)` sites whose receiver is a bare name, so no signal can be named for them. One
+#: entry, and it is the helper itself: `guarded_connect` connects its wrapper to whatever signal it
+#: was handed, which is the entire point of it. Anything else appearing here is a connection the
+#: rule above cannot see — make the receiver an attribute access, or route it through
+#: `guarded_connect`. Do not add rows to silence it.
+ALLOWED_UNCLASSIFIED = {
+    # The helper itself: `guarded_connect` connects its wrapper to whatever signal it was handed,
+    # which is the entire point of it.
+    ('mapflow/error_guard.py', 'guarded_connect'),
+    # `model_options_changed` is `MainDialog.modelOptionsChanged` — a plugin pyqtSignal injected as
+    # a constructor argument, so the receiver is a parameter name and nothing can be read off it.
+    # Plugin-signal connections stay raw because they emit inside an already-guarded stack, and this
+    # one's Qt boundary is the model-option checkbox's `toggled`, guarded in `main_dialog`.
+    ('mapflow/functional/controller/processing_controller.py', '__init__'),
+}
+
+
+def _is_connect_call(call: ast.Call) -> bool:
+    return isinstance(call.func, ast.Attribute) and call.func.attr == "connect"
+
+
 def _signal_name(call: ast.Call):
     """The signal a `.connect(...)` call attaches to, e.g. 'clicked' for `btn.clicked.connect(x)`.
 
-    Returns None when the receiver of `.connect` is not an attribute access (e.g. a bare `signal`
-    parameter inside the helper itself), which cannot be a Qt-source connection to classify.
+    Returns None when the receiver of `.connect` is not an attribute access — a bare name, as in
+    `for signal in (...): signal.connect(...)`. Such a call is NOT thereby safe: it is invisible to
+    the classification, which is why `test_no_connection_is_invisible_to_the_classifier` fails on it
+    separately rather than letting it pass as "not a Qt signal".
     """
-    if not (isinstance(call.func, ast.Attribute) and call.func.attr == "connect"):
+    if not _is_connect_call(call):
         return None
     receiver = call.func.value
     return receiver.attr if isinstance(receiver, ast.Attribute) else None
@@ -71,6 +94,7 @@ class _ConnectVisitor(ast.NodeVisitor):
         self.rel_path = rel_path
         self.func_stack = []
         self.sites = set()
+        self.unclassified = set()
 
     def visit_FunctionDef(self, node):
         self.func_stack.append(node.name)
@@ -80,15 +104,18 @@ class _ConnectVisitor(ast.NodeVisitor):
     visit_AsyncFunctionDef = visit_FunctionDef
 
     def visit_Call(self, node):
-        name = _signal_name(node)
-        if name in QT_SIGNALS:
+        if _is_connect_call(node):
             func = self.func_stack[-1] if self.func_stack else "<module>"
-            self.sites.add((self.rel_path, func, name))
+            name = _signal_name(node)
+            if name is None:
+                self.unclassified.add((self.rel_path, func))
+            elif name in QT_SIGNALS:
+                self.sites.add((self.rel_path, func, name))
         self.generic_visit(node)
 
 
-def _qt_source_connects():
-    sites = set()
+def _visit_plugin():
+    sites, unclassified = set(), set()
     for path in sorted(PLUGIN.rglob("*.py")):
         if "__pycache__" in path.parts:
             continue
@@ -96,7 +123,12 @@ def _qt_source_connects():
         visitor = _ConnectVisitor(path.relative_to(PLUGIN.parent).as_posix())
         visitor.visit(tree)
         sites |= visitor.sites
-    return sites
+        unclassified |= visitor.unclassified
+    return sites, unclassified
+
+
+def _qt_source_connects():
+    return _visit_plugin()[0]
 
 
 def test_every_qt_source_connection_is_guarded_or_allowlisted():
@@ -114,3 +146,30 @@ def test_the_allowlist_has_no_stale_entries():
     assert not stale, (
         f"these are allowlisted but no longer raw Qt-source connects — drop them from "
         f"ALLOWED_UNGUARDED:\n{chr(10).join(repr(s) for s in sorted(stale))}")
+
+
+def test_no_connection_is_invisible_to_the_classifier():
+    """Fail closed: a `.connect` the classifier cannot name is a hole, not an absence.
+
+    The rule above reads the signal off an attribute access, so `for signal in (...):
+    signal.connect(...)` names nothing and simply never appears — it is neither guarded nor
+    allowlisted nor reported. `mapflow.py` held exactly that shape (nine Qt widget signals wired in
+    a loop) through the whole rollout, and they were guarded only because a human happened to read
+    the block. An enforcement test that depends on someone reading the code is not enforcing
+    anything, so an unnameable receiver now has to be justified like any other exemption.
+    """
+    _sites, unclassified = _visit_plugin()
+    invisible = unclassified - ALLOWED_UNCLASSIFIED
+    assert not invisible, (
+        "these `.connect(...)` calls have a receiver the classifier cannot name, so the guard rule "
+        "cannot see them. Give the receiver an attribute access (`widget.signal.connect(...)`) or "
+        "route it through `guarded_connect`:\n"
+        + "\n".join(repr(s) for s in sorted(invisible)))
+
+
+def test_the_unclassified_allowlist_has_no_stale_entries():
+    _sites, unclassified = _visit_plugin()
+    stale = ALLOWED_UNCLASSIFIED - unclassified
+    assert not stale, (
+        f"these are allowlisted as unclassifiable but no longer are — drop them from "
+        f"ALLOWED_UNCLASSIFIED:\n{chr(10).join(repr(s) for s in sorted(stale))}")

--- a/tests/functional/test_guarded_connect.py
+++ b/tests/functional/test_guarded_connect.py
@@ -131,11 +131,48 @@ def test_the_plugin_version_comes_from_the_version_source():
     assert reported.call_args.args[2] == "9.9.9"
 
 
-def test_a_version_source_that_raises_on_attribute_access_still_reports():
+def test_a_report_with_no_version_source_falls_back_to_the_recorded_version(monkeypatch):
+    """Dialogs and views hold neither `plugin_version` nor `app_context`, so every report raised
+    from a widget slot said "unknown" — the field that makes a report actionable, missing on a whole
+    tier of them. `Mapflow.__init__` records the version once and the guard falls back to it."""
+    monkeypatch.setattr(error_guard, "_plugin_version", None)
+    error_guard.set_plugin_version("3.7.0")
+    signal = _FakeSignal()
+
+    def slot(*args):
+        raise Boom("x")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        # No version_source at all — the shape every dialog and view conversion uses.
+        error_guard.guarded_connect(signal, slot, "editing a name")
+        signal.connected()
+
+    assert reported.call_args.args[2] == "3.7.0"
+
+
+def test_an_explicit_version_source_still_wins_over_the_recorded_one(monkeypatch):
+    monkeypatch.setattr(error_guard, "_plugin_version", "3.7.0")
+    signal = _FakeSignal()
+
+    class Owner:
+        plugin_version = "9.9.9"
+
+    def slot(*args):
+        raise Boom("x")
+
+    with patch.object(error_guard, "report_unexpected_error") as reported:
+        error_guard.guarded_connect(signal, slot, "x", version_source=Owner())
+        signal.connected()
+
+    assert reported.call_args.args[2] == "9.9.9"
+
+
+def test_a_version_source_that_raises_on_attribute_access_still_reports(monkeypatch):
     """The resolver runs while a failure is already being handled, so it must not add one of its
     own. `getattr(x, name, default)` only swallows AttributeError — a sip-wrapped Qt object whose
     C++ base was never constructed raises RuntimeError, and a property can raise anything. Escaping
     here would take the guard's own report down and reach the event loop unguarded."""
+    monkeypatch.setattr(error_guard, "_plugin_version", None)  # no fallback: isolate the resolver
     signal = _FakeSignal()
 
     class Hostile:


### PR DESCRIPTION
The two loose ends the entry-point rollout left behind (spec/007 § Entry points, invariant 7;
spec/006 § the report must be actionable).

**The enforcement had a hole the size of the rule.** `test_entry_points_guarded` reads the signal
off the attribute the `.connect` hangs from, so a receiver that is a bare name — `for signal in
(...): signal.connect(...)` — named nothing and simply never appeared: not guarded, not allowlisted,
not reported. `mapflow.py`'s local-filter block was exactly that shape, nine Qt widget signals, and
survived the entire six-PR rollout unnoticed; they are guarded today only because the rollout
happened to read that block. An enforcement test that holds when someone reads the code is not
enforcing anything.

It now fails closed: a `.connect` whose receiver cannot be named is a violation to justify, not an
absence to skip. Of the two options the WAL recorded, this beats teaching the visitor to resolve
loop variables — that would fix the one shape that had already been found while leaving every other
way of holding a signal in a local invisible, which is the same bug with a smaller blast radius.

It earned its keep immediately, finding a connection nobody had looked at: `ProcessingController`
takes `model_options_changed` as a constructor argument, so `MainDialog.modelOptionsChanged` is
connected through a parameter name. That one is legitimate — plugin signals stay raw because they
emit inside an already-guarded stack, and its Qt boundary is the model-option checkbox's `toggled`
— so it is allowlisted with that reasoning rather than converted. The point is that it is now
*visible*: the exemption is written down, and the next injected signal has to be argued for.

**Reports from widgets could not name their version.** `_resolve_plugin_version` reads the version
off the object handed to the guard, and dialogs and views hold neither `plugin_version` nor
`app_context` — so after the last change, which guarded every dialog and view, an entire tier of
reports arrived saying "unknown". That is the single field that makes a report actionable.
`Mapflow.__init__` already parses it once from metadata.txt and now records it in `error_guard`,
which falls back to it when the version source yields nothing. An explicit source still wins, so
nothing that already reported a version changes.

Module state rather than an argument threaded through every call site: the version is a property of
the running plugin, identical in every report, and the alternative is handing it to widgets that
have no other reason to know it.

## Manual test
none directly — both are visible only in a report's contents or a failing test. Regression surface:
the plugin must still start (the version is recorded during `__init__`), and the model option
checkboxes must still re-quote the cost when toggled, since that is the connection the new rule
flagged and the allowlist now covers.
